### PR TITLE
Add config option to use GAE auth instead of OAuth

### DIFF
--- a/dev_config/config.yml.dist
+++ b/dev_config/config.yml.dist
@@ -36,5 +36,8 @@ gaApplicationName: PMI DRC HPO
 gaDomain: staging.pmi-ops.org
 gaAdminEmail: hpo-api@staging.pmi-ops.org
 
+# use Google App Engine auth via UserService instead of Google OAuth
+gae_auth: 1
+
 # IP whitelist (CSV)
 ip_whitelist:

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -117,20 +117,6 @@ class HpoApplication extends AbstractApplication
             $this->configuration[$key] = $val;
         }
     }
-
-    public function getConfig($key)
-    {
-        if (isset($this->configuration[$key])) {
-            return $this->configuration[$key];
-        } else {
-            return null;
-        }
-    }
-
-    public function setConfig($key, $val)
-    {
-        $this->configuration[$key] = $val;
-    }
     
     protected function registerDb()
     {

--- a/tests/Pmi/AbstractWebTestCase.php
+++ b/tests/Pmi/AbstractWebTestCase.php
@@ -36,7 +36,8 @@ abstract class AbstractWebTestCase extends WebTestCase
         $app->setup([
             // don't bypass groups auth because we handle this with fixtures
             'gaBypass' => false,
-            'ip_whitelist' => $this->getIpWhitelist()
+            'ip_whitelist' => $this->getIpWhitelist(),
+            'gae_auth' => true
         ]);
         $app->mount('/', new Controller\DefaultController());
         $app->mount('/dashboard', new Controller\DashboardController());

--- a/tests/Pmi/Application/HpoApplicationTest.php
+++ b/tests/Pmi/Application/HpoApplicationTest.php
@@ -20,7 +20,7 @@ class HpoApplicationTest extends AbstractWebTestCase
     {
         $client = $this->createClient();
         $crawler = $client->request('GET', '/');
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertEquals(403, $client->getResponse()->getStatusCode());
     }
 
     /*public function testLogin()

--- a/tests/Pmi/GoogleUserService.php
+++ b/tests/Pmi/GoogleUserService.php
@@ -20,4 +20,14 @@ class GoogleUserService
     {
         self::$googleUser = null;
     }
+    
+    public static function createLoginURL($destination_url = null, $federated_identity = null)
+    {
+        return null;
+    }
+    
+    public static function createLogoutURL($destination_url)
+    {
+        return null;
+    }
 }

--- a/views/error-gae-auth.html.twig
+++ b/views/error-gae-auth.html.twig
@@ -1,0 +1,8 @@
+{% extends 'base.html.twig' %}
+{% block title %}Error - {% endblock %}
+{% block body %}
+    <div class="alert alert-danger">
+        <span class="glyphicon glyphicon-thumbs-down"></span>
+        <strong>Access denied!</strong> You are not logged into Google, please <a href="{{ loginUrl }}">try again</a>.
+    </div>
+{% endblock %}


### PR DESCRIPTION
@jt2k Local Dev Auth... now 50% less annoying! Use config`gae_auth` to make the app use the old GAE auth (doesn't make use of `login: required`)
