### PR TITLE
Add CI Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PMI Provider Portal and Admin Dashboard
 
+![Build Status of master](https://circleci.com/gh/vanderbilt/pmi-drc-hpo.png?circle-token=17ce7a55825cb047e685c2376d7e33441a07c590)
+
 ## Developer Quick Start
 
 Install the [Google App Engine SDK for PHP](https://cloud.google.com/appengine/downloads).


### PR DESCRIPTION
Note that the key here conveys access _only_ to the "status" API in CircleCI — no further privileges. As demonstrated in the following screenshot from https://circleci.com/gh/vanderbilt/pmi-drc-hpo/edit#api

![image](https://cloud.githubusercontent.com/assets/313089/19537691/f48bbadc-961e-11e6-93e7-f11a8baf8162.png)
