### PR TITLE
Add additional MayoLINK accounts

### DIFF
--- a/src/Pmi/Order/Mayolink/MayolinkOrder.php
+++ b/src/Pmi/Order/Mayolink/MayolinkOrder.php
@@ -69,7 +69,13 @@ class MayolinkOrder
         'montefiorectrc' => '7035772',
         'pelionfp' => '7035779',
         'waverlyfp' => '7035780',
-        'eauclairewi' => '7035781'
+        'eauclairewi' => '7035781',
+        'morristown' => '7035777',
+        'knoxville' => '7035778',
+        'jamesanderson' => '7035782',
+        'copiah' => '7035783',
+        'otay' => '7035784',
+        'chcoceanview' => '7035785'
     ];
 
     private $client;

--- a/tests/Pmi/Order/Mayolink/MayolinkOrderTest.php
+++ b/tests/Pmi/Order/Mayolink/MayolinkOrderTest.php
@@ -3,7 +3,18 @@ use Pmi\Order\Mayolink\MayolinkOrder;
 
 class MayolinkOrderTest extends \PHPUnit_Framework_TestCase
 {
-    public function testLogin()
+    public function testCheckSites()
+    {
+        $siteAccounts = MayolinkOrder::$siteAccounts;
+        $groups = array_keys($siteAccounts);
+        $siteIds = array_values($siteAccounts);
+        // Check that all site groups are unique
+        $this->assertSame(count($siteAccounts), count(array_unique($groups)));
+        // Check that all site ids are unique (except for 1 - sdbb and walgreens share the same id)
+        $this->assertSame(count($siteAccounts), count(array_unique($siteIds)) + 1);
+    }
+
+    public function skipTestLogin()
     {
         $order = new MayolinkOrder();
         // TODO: retrieve test credentials from... datastore?
@@ -15,7 +26,7 @@ class MayolinkOrderTest extends \PHPUnit_Framework_TestCase
     /**
      * @depends testLogin
      */
-    public function testOrder($order)
+    public function skipTestOrder($order)
     {
         $options = [
             'test_code' => 'ACE',


### PR DESCRIPTION
Also added a very simple unit test that would catch some possible errors with the MayoLINK account mapping.