### PR TITLE
Redirect user to home page after saving settings

### DIFF
--- a/src/Pmi/Controller/DefaultController.php
+++ b/src/Pmi/Controller/DefaultController.php
@@ -278,10 +278,11 @@ class DefaultController extends AbstractController
             $app['em']->getRepository('users')->update($app->getUserId(), [
                 'timezone' => $settingsForm['timezone']->getData()
             ]);
+            $app->addFlashSuccess('Your settings have been updated');
             if ($request->query->has('return')) {
                 return $app->redirect($request->query->get('return'));
             } else {
-                return $app->redirectToRoute('settings');
+                return $app->redirectToRoute('home');
             }
         }
 


### PR DESCRIPTION
Previously, if a return URL wasn't specified, it would leave the user on the settings page.  Now, it adds a success flash message and sends the user back to the home page.