### PR TITLE
Average all 3 heartrate fields instead of just the last 2

### DIFF
--- a/views/evaluationform/0.3.html.twig
+++ b/views/evaluationform/0.3.html.twig
@@ -66,7 +66,7 @@
                     Heart rate:
                     <span id="mean-heart-rate"></span>
                     {{ schema.fields['heart-rate'].unit }}
-                    <small class="text-muted">(average of 2nd and 3rd measures)</small>
+                    <small class="text-muted">(average of all 3 measures)</small>
 
                     <div id="blood-pressure-systolic-warning"></div>
                     <div id="blood-pressure-diastolic-warning"></div>

--- a/web/assets/js/views/PhysicalEvaluation-0.3.js
+++ b/web/assets/js/views/PhysicalEvaluation-0.3.js
@@ -62,8 +62,7 @@ PMI.views['PhysicalEvaluation-0.3'] = Backbone.View.extend({
         var fieldSelector = '.field-' + field;
         var secondThirdFields = [
             'blood-pressure-systolic',
-            'blood-pressure-diastolic',
-            'heart-rate'
+            'blood-pressure-diastolic'
         ];
         var twoClosestFields = [
             'hip-circumference',


### PR DESCRIPTION
- Displays the average of all 3 heart rate measurements, not just the last two.
- Changes wording indicating all 3 are averaged
- Data is stored the same way as before.