### PR TITLE
[HPRO-99] Add MayoLINK site id to RDR order payload

### DIFF
--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -294,11 +294,20 @@ class Order
             'system' => 'https://www.pmi-ops.org',
             'value' => $this->order['order_id']
         ];
-        if ($this->app && !$this->app->getConfig('ml_mock_order') && $this->order['mayo_id'] != 'pmitest') {
-            $identifiers[] =[
-            'system' => 'https://orders.mayomedicallaboratories.com',
-                'value' => $this->order['mayo_id']
-            ];
+        if ($this->app) {
+            if (!$this->app->getConfig('ml_mock_order') && $this->order['mayo_id'] != 'pmitest') {
+                $identifiers[] =[
+                    'system' => 'https://orders.mayomedicallaboratories.com',
+                    'value' => $this->order['mayo_id']
+                ];
+            }
+            $site = $this->app['em']->getRepository('sites')->fetchOneBy(['google_group' => $this->order['site']]);
+            if ($site && $site['mayolink_account']) {
+                $identifiers[] =[
+                    'system' => 'https://www.pmi-ops.org/mayolink-site-id',
+                    'value' => $site['mayolink_account']
+                ];
+            }
         }
         $obj->identifier = $identifiers;
 


### PR DESCRIPTION
Add MayoLINK site id/client id/account number to the array of identifiers sent to the RDR.

(So many names for the same id!)