### PR TITLE
[HPRO-160] Add configuration option to disable RDR cache

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -29,6 +29,9 @@ class HpoApplication extends AbstractApplication
         if ($this->getConfig('rdr_auth_json')) {
             $rdrOptions['key_contents'] = $this->getConfig('rdr_auth_json');
         }
+        if ($this->getConfig('rdr_disable_cache')) {
+            $rdrOptions['disable_cache'] = true;
+        }
 
         $this['pmi.drc.rdrhelper'] = new \Pmi\Drc\RdrHelper($rdrOptions);
         if ($this->participantSource == 'mock') {

--- a/src/Pmi/Drc/RdrHelper.php
+++ b/src/Pmi/Drc/RdrHelper.php
@@ -6,12 +6,16 @@ class RdrHelper
     protected $client;
     protected $endpoint = 'https://pmi-drc-api-test.appspot.com/';
     protected $options = [];
+    protected $cacheEnabled = true;
 
     public function __construct(array $options)
     {
         if (!empty($options)) {
             if (!empty($options['endpoint'])) {
                 $this->endpoint = $options['endpoint'];
+            }
+            if (!empty($options['disable_cache']) && $options['disable_cache']) {
+                $this->cacheEnabled = false;
             }
             $this->options = $options;
         }
@@ -40,5 +44,10 @@ class RdrHelper
         return $googleClient->authorize(new \GuzzleHttp\Client([
             'base_uri' => $endpoint
         ]));
+    }
+
+    public function isCacheEnabled()
+    {
+        return $this->cacheEnabled;
     }
 }


### PR DESCRIPTION
Hotfix to support dress rehearsals.  We may still want to provide a user-initiated mechanism to refresh data when caching is enabled, but for now this gives us a global mechanism to disable caching RDR responses.

@shyamnaru this can be used in your selenium tests locally by adding `rdr_disable_cache: 1` to your `config.yml` file.