### PR TITLE
[HPRO-163] Update display of EHR consent status in work queue

### DIFF
--- a/views/workqueue/index.html.twig
+++ b/views/workqueue/index.html.twig
@@ -100,11 +100,7 @@
                             {{ participant.consentForElectronicHealthRecordsTime ? participant.consentForElectronicHealthRecordsTime|date('m/d/Y') }}
                         {% else %}
                             <i class="fa fa-times text-danger" aria-hidden="true"></i>
-                            {% if participant.consentForElectronicHealthRecordsTime %}
-                                {{ participant.consentForElectronicHealthRecordsTime|date('m/d/Y') }}
-                            {% else %}
-                                (not completed)
-                            {% endif %}
+                            {{ participant.consentForElectronicHealthRecordsTime ? participant.consentForElectronicHealthRecordsTime|date('m/d/Y') : '(not completed)' }}
                         {% endif %}
                     </td>
                     <td class="text-center" data-order="{{ participant.withdrawalStatus == 'NO_USE' ? '1' : '0' }}-{{ participant.withdrawalTime }}">


### PR DESCRIPTION
* If participant is not consented but has submitted the EHR consent form, display date next to red X.
* If participant is not consented and has not submitted the EHR consent form, display "(not completed)" next to red X.  