### PR TITLE
Integrate UI tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,9 @@
          stopOnFailure="false"
          syntaxCheck="false"
     >
+    <php>
+        <env name="data" value="workqueue"/>
+    </php>
     <testsuites>
         <testsuite name="unit">
             <directory>tests/Pmi</directory>


### PR DESCRIPTION
This is the idea of integrating the two UI tests by using env variable in phpunit.xml file, the default value is `data = "workqueue"`. As the only difference between the two UI tests is the way the participant data is fetched, we can use CLI to tell which data to fetch.

`./vendor/bin/phpunit --testsuite=ui` - This will fetch the participant data from workqueue.
`data=json ./vendor/bin/phpunit --testsuite=ui`- Adding "data=json" will fetch the participant data from json file.

Let me know if this makes sense?