### PR TITLE
[HPRO-196] Update firewall rules to allow paths without trailing slashes

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -86,17 +86,17 @@ class HpoApplication extends AbstractApplication
                 [['path' => $anonRegex, 'ips' => $ips], 'IS_AUTHENTICATED_ANONYMOUSLY'],
                 [['path' => $anonRegex], 'ROLE_NO_ACCESS'],
                 
-                [['path' => '^/_dev/.*$', 'ips' => $ips], 'IS_AUTHENTICATED_FULLY'],
-                [['path' => '^/_dev/.*$'], 'ROLE_NO_ACCESS'],
+                [['path' => '^/_dev($|\/)$', 'ips' => $ips], 'IS_AUTHENTICATED_FULLY'],
+                [['path' => '^/_dev($|\/)$'], 'ROLE_NO_ACCESS'],
                 
                 [['path' => $commonRegex, 'ips' => $ips], 'IS_AUTHENTICATED_FULLY'],
                 [['path' => $commonRegex], 'ROLE_NO_ACCESS'],
                 
-                [['path' => '^/dashboard/.*$', 'ips' => $ips], 'ROLE_DASHBOARD'],
-                [['path' => '^/dashboard/.*$'], 'ROLE_NO_ACCESS'],
+                [['path' => '^/dashboard($|\/)', 'ips' => $ips], 'ROLE_DASHBOARD'],
+                [['path' => '^/dashboard($|\/)'], 'ROLE_NO_ACCESS'],
 
-                [['path' => '^/admin/.*$', 'ips' => $ips], 'ROLE_ADMIN'],
-                [['path' => '^/admin/.*$'], 'ROLE_NO_ACCESS'],
+                [['path' => '^/admin($|\/)', 'ips' => $ips], 'ROLE_ADMIN'],
+                [['path' => '^/admin($|\/)'], 'ROLE_NO_ACCESS'],
 
                 [['path' => '^/.*$', 'ips' => $ips], 'ROLE_USER'],
                 [['path' => '^/.*$'], 'ROLE_NO_ACCESS']

--- a/tests/Pmi/Application/HpoApplicationTest.php
+++ b/tests/Pmi/Application/HpoApplicationTest.php
@@ -63,6 +63,8 @@ class HpoApplicationTest extends AbstractWebTestCase
         $this->assertSame(null, $this->app['session']->get('isLogin'));
         $client = $this->createClient();
         $client->followRedirects();
+        $crawler = $client->request('GET', '/dashboard');
+        $this->assertEquals(403, $client->getResponse()->getStatusCode());
         $crawler = $client->request('GET', '/dashboard/');
         $this->assertEquals(403, $client->getResponse()->getStatusCode());
     }
@@ -75,6 +77,8 @@ class HpoApplicationTest extends AbstractWebTestCase
         $this->assertSame(null, $this->app['session']->get('isLogin'));
         $client = $this->createClient();
         $client->followRedirects();
+        $crawler = $client->request('GET', '/dashboard');
+        $this->assertEquals(200, $client->getResponse()->getStatusCode());
         $crawler = $client->request('GET', '/dashboard/');
         $this->assertEquals(200, $client->getResponse()->getStatusCode());
     }


### PR DESCRIPTION
Routing component automatically redirects to the canonical URL with trailing slash, but the firewall rules happen first, which was causing `/dashboard` to be denied to a `ROLE_DASHBOARD` user if not also granted the `ROLE_USER` role.