### PR TITLE
Change datatables.net version from 2.1.1 to 1.10.15 in bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "bootstrap": "3.*",
     "eonasdan-bootstrap-datetimepicker": "^4.17.42",
     "parsleyjs": "^2.5.0",
-    "datatables.net": "~2.1.1",
+    "datatables.net": "~1.10.15",
     "datatables.net-bs": "~2.1.1",
     "datatables.net-responsive": "^2.1.1",
     "datatables.net-responsive-bs": "^2.1.1",


### PR DESCRIPTION
It seems like the package "datatables.net" no longer has "2.1.1" version hence the bower install fails. I updated to the latest available version which is "1.10.15".
https://github.com/DataTables/Dist-DataTables/releases