### PR TITLE
[DASH1-43] Update display value for COLUMBIA to NYC Consortium

### DIFF
--- a/sql/dashboards/recruitment_center_codes.sql
+++ b/sql/dashboards/recruitment_center_codes.sql
@@ -20,7 +20,7 @@ VALUES
 	('JACKSON','Jackson-Hinds Comprehensive Health Center, Jackson, Mississippi','32.329822','-90.194839','FQHC',10000),
 	('SAN_YSIDRO','San Ysidro Health Center, San Ysidro, California','32.558651','-117.047597','FQHC',10000),
 	('CAL_PMC','California Precision Medicine Consortium','32.880060','-117.234014','RMC',10000),
-	('COLUMBIA','Columbia University Medical Center, New York City','40.840845','-73.941582','RMC',10000),
+	('COLUMBIA','NYC Consortium, New York City','40.840845','-73.941582','RMC',10000),
 	('ILLINOIS','Illinois Precision Medicine Consortium','42.056459','-87.675267','RMC',10000),
 	('NE_PMC','New England Precision Medicine Consortium','42.363176','-71.068830','RMC',10000),
 	('TRANS_AM','Trans-American Consortium (TAC)','42.367411','-83.085083','RMC',10000),

--- a/sql/migrations/011-update-dashboard-columbia-entry.sql
+++ b/sql/migrations/011-update-dashboard-columbia-entry.sql
@@ -1,0 +1,1 @@
+UPDATE recruitment_center_codes SET label='NYC Consortium, New York City' WHERE code='COLUMBIA';


### PR DESCRIPTION
Request from Karthik to change the display name of Columbia to 'NYC Consortium', re: https://precisionmedicineinitiative.atlassian.net/browse/DASH1-43