### PR TITLE
[DASH1-50] Add close button to new 'Display Metrics' help modal

### DIFF
--- a/views/dashboard/dashboard_help.html.twig
+++ b/views/dashboard/dashboard_help.html.twig
@@ -110,6 +110,9 @@
                     <li><strong>Total Registered Participants</strong></li>
                 </ul>
             </div>
+            <div class="modal-footer">
+                <button class="close" data-dismiss="modal">×</button>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This update adds a close button to the new 'Display Metrics' help modal.