### PR TITLE
[HPRO-300] Fix pre-commit script for moved/deleted files

### DIFF
--- a/bin/git-hooks/pre-commit
+++ b/bin/git-hooks/pre-commit
@@ -5,11 +5,16 @@
 
 # Checks file for presense of given pattern
 function check_file() {
-    $(git grep -ql --cached "$1" $2)
-    if [ $? == 0 ]
+    # File must exist
+    if [ -f $2 ]
     then
-      echo "[ERROR] Pattern \"$1\" found in $2"
-      exit 1
+      # Search for pattern in file
+      $(git grep -ql --cached "$1" $2)
+      if [ $? == 0 ]
+      then
+        echo "[ERROR] Pattern \"$1\" found in $2"
+        exit 1
+      fi
     fi
 }
 


### PR DESCRIPTION
The previous version of this script did not account for moved or deleted files, so the `git grep` command would be run against non-existent paths. This PR adds a guard against that so that the file is ignored for the purpose of this check.

[[HPRO-300](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-300)]

---

To pick up the new version:

```bash
$ cd /path/to/healthpro/

# Remove existing hook
$ rm -rf .git/hooks/pre-commit

# Installs the new one
$ composer install
```