### PR TITLE
[HPRO-310] Remove calling sendToRdr method in collect step

### DIFF
--- a/src/Pmi/Controller/OrderController.php
+++ b/src/Pmi/Controller/OrderController.php
@@ -278,7 +278,6 @@ class OrderController extends AbstractController
                             if ($app['em']->getRepository('orders')->update($orderId, ['mayo_id' => $mayoId])) {
                                 $app->log(Log::ORDER_EDIT, $orderId);
                                 $order = $this->loadOrder($participantId, $orderId, $app);
-                                $order->sendToRdr();
                                 $successMsg = 'Order collection updated and successfully sent';
                                 // Redirect to print requisition
                                 if ($order->get('type') !== 'kit') {


### PR DESCRIPTION
We should not call the `sendToRdr` method in collect step. Since `sendToRdr` method is returning false when `finalized_ts` is not set we didn't noticed any issue.