### PR TITLE
[HPRO-320] Add Twig method for displaying an in-app message

### DIFF
--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -390,6 +390,26 @@ abstract class AbstractApplication extends Application
             return !is_null($this['routes']->get($name));
         }));
 
+        // Register custom Twig function for in-app messaging
+        $this['twig']->addFunction(new Twig_SimpleFunction('display_message', function($name, $type = false, $options = []) {
+            $configPrefix = 'messaging_';
+            $message = $this->getConfig($configPrefix . $name);
+            if (empty($message)) {
+                return;
+            }
+            switch ($type) {
+                case 'alert':
+                    return '<div class="alert alert-info">' . $message . '</div>';
+                    break;
+                case 'tooltip':
+                    $tooltipText = htmlspecialchars($message, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+                    return '<span title="' . $tooltipText . '" data-toggle="tooltip"><i class="fa fa-info-circle" aria-hidden="true"></i></span>';
+                    break;
+                default:
+                    return $message;
+            }
+        }, ['is_safe' => ['html']]));        
+
         // Register custom Twig cache
         if (isset($this['twigCacheHandler'])) {
             switch ($this['twigCacheHandler']) {


### PR DESCRIPTION
Example usage:
1. Add a configuration item using the key `messaging_example`
2. Add in your twig template `display_message('example')|raw`

For an info alert, use `display_message('example', 'alert')`  
For an info tooltip, use `display_message('example', 'tooltip')`

For some reason, the `is_safe` option isn't working and you still need to pipe the results of the Twig function to `|raw`.

If we do want a message to go out with the 0.9.2 release, we can add the workqueue messaging in to this PR and merge into master.  Otherwise, this can just be merged to develop for future use.