### PR TITLE
[HPRO-317] Adjust display of Today's Participants table

### DIFF
--- a/views/review/today.html.twig
+++ b/views/review/today.html.twig
@@ -27,19 +27,19 @@
         <li role="presentation"><a href="{{ path('review_measurements') }}">Unfinalized Physical Measurements</a></li>
     </ul>
     <br />
-    <table class="table table-striped table-bordered table-small">
+    <table class="table table-striped table-bordered table-small" id="table-today">
         <thead>
             <tr>
                 <th rowspan="2">Participant ID</th>
                 <th rowspan="2">Name</th>
-                <th colspan="3" class="text-center" style="background-color: #f9f9f9">Physical Measurement</th>
-                <th colspan="7" class="text-center" style="background-color: #f9f9f9">Biobank Order</th>
+                <th colspan="3" class="text-center td-left-border" style="background-color: #f9f9f9">Physical Measurement</th>
+                <th colspan="7" class="text-center td-left-border" style="background-color: #f9f9f9">Biobank Order</th>
             </tr>
             <tr>
-                <th>Status</th>
+                <th class="td-left-border">Status</th>
                 <th>Created</th>
                 <th>Finalized</th>
-                <th>Status</th>
+                <th class="td-left-border">Status</th>
                 <th>Order ID</th>
                 <th>Created</th>
                 <th>Collected</th>
@@ -47,6 +47,7 @@
                 <th>Finalized</th>
                 <th>Finalized Samples</th>
             </tr>
+        </thead>
         <tbody>
             {% for id, participant in participants %}
                 <tr>
@@ -65,7 +66,7 @@
                             <span class="sr-only">Loading...</span>
                         </td>
                     {% endif %}
-                    <td>
+                    <td class="td-left-border">
                         {% if participant.physicalMeasurement %}
                             <nobr>
                                 <a href="{{ path('evaluation', { participantId: id, evalId: participant.physicalMeasurement.id }) }}">{{ participant.physicalMeasurementStatus }}</a>
@@ -82,7 +83,7 @@
                     <td>
                         {{ today.displayDate(participant, 'physicalMeasurement', 'finalized_ts') }}
                     </td>
-                    <td>
+                    <td class="td-left-border">
                         {% if participant.order %}
                             <nobr>
                                 <a href="{{ path('order', { participantId: id, orderId: participant.order.id }) }}">{{ participant.orderStatus }}</a>

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -268,6 +268,14 @@ label.label-normal {
     );
 }
 
+/* Today's participants */
+#table-today>thead>tr>td, #table-today>thead>tr>th {
+    border-bottom-width: 1px;
+}
+#table-today>tbody>tr>td.td-left-border, #table-today>thead>tr>th.td-left-border {
+    border-left-width: 3px;
+}
+
 /* Orders */
 table.table-samples {
     margin-bottom: 5px;


### PR DESCRIPTION
Addresses some late feedback on the Today's Participants table:

* Add a link to the order page on the order ID
* Add wider border between column sections

![screen shot 2018-04-24 at 3 21 49 pm](https://user-images.githubusercontent.com/860499/39212561-b0af286c-47d4-11e8-9af1-179b347cabfd.png)
