### PR TITLE
[HPRO-345] Switch to use physicalMeasurementsFinalizedTime

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -356,7 +356,7 @@ class WorkQueueController extends AbstractController
                         ];                   
                     }
                     $row[] = $participant->physicalMeasurementsStatus == 'COMPLETED' ? '1' : '0';
-                    $row[] = WorkQueue::dateFromString($participant->physicalMeasurementsTime, $app->getUserTimezone());
+                    $row[] = WorkQueue::dateFromString($participant->physicalMeasurementsFinalizedTime, $app->getUserTimezone());
                     $row[] = $participant->siteSuffix;
                     $row[] = $participant->organization;
                     $row[] = $participant->evaluationFinalizedSite;

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -46,7 +46,7 @@ class WorkQueue
         'questionnaireOnHealthcareAccessTime',
         'site',
         'organization',
-        'physicalMeasurementsTime',
+        'physicalMeasurementsFinalizedTime',
         'physicalMeasurementsFinalizedSite',
         'samplesToIsolateDNA',
         'numBaselineSamplesArrived',
@@ -288,7 +288,7 @@ class WorkQueue
             //In-Person Enrollment
             $row['pairedSite'] = $this->app->getSiteDisplayName($e($participant->siteSuffix));
             $row['pairedOrganization'] = $this->app->getOrganizationDisplayName($e($participant->organization));
-            $row['physicalMeasurementsStatus'] = $this->displayStatus($participant->physicalMeasurementsStatus, 'COMPLETED', $participant->physicalMeasurementsTime);
+            $row['physicalMeasurementsStatus'] = $this->displayStatus($participant->physicalMeasurementsStatus, 'COMPLETED', $participant->physicalMeasurementsFinalizedTime);
             $row['evaluationFinalizedSite'] = $this->app->getSiteDisplayName($e($participant->evaluationFinalizedSite));
             $row['biobankDnaStatus'] = $this->displayStatus($participant->samplesToIsolateDNA, 'RECEIVED');
             if ($participant->numBaselineSamplesArrived >= 7) {

--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -375,8 +375,8 @@
                                             <strong>Physical Measurements</strong>
                                             {% if participant.physicalMeasurementsStatus == 'COMPLETED' %}
                                                 <i class="fa fa-check text-success" aria-hidden="true"></i>
-                                                {% if participant.physicalMeasurementsTime %}
-                                                    <small>{{ participant.physicalMeasurementsTime|date('m/d/Y', app.userTimezone) }}</small>
+                                                {% if participant.physicalMeasurementsFinalizedTime %}
+                                                    <small>{{ participant.physicalMeasurementsFinalizedTime|date('m/d/Y', app.userTimezone) }}</small>
                                                 {% endif %}
                                             {% else %}
                                                 <i class="fa fa-times text-danger" aria-hidden="true"></i>


### PR DESCRIPTION
[[HPRO-345](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-345)]

In the work queue and participant details page, we had previously been using the `physicalMeasurementsTime` from the ParticipantSummary API. 
 The problem is that this time is when the RDR received the physical measurements payload, and not when the physical measurements actually happened.  So in the case where we resend data (e.g. to update to a new format or if an RDR request had failed), the time displayed in HealthPro is updated incorrectly.  The `physicalMeasurementsFinalizedTime` field in the ParticipantSummary API represents the timestamp sent in the FHIR bundle, so we are switching to use this field instead.