### PR TITLE
[HPRO-347] Update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
     "requires": true,
     "dependencies": {
         "ajv": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.2.3.tgz",
-            "integrity": "sha1-wG9Zh3jETGsWGrr+NGa4GtGBTtI=",
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
             "requires": {
                 "co": "4.6.0",
-                "fast-deep-equal": "1.0.0",
-                "json-schema-traverse": "0.3.1",
-                "json-stable-stringify": "1.0.1"
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
             }
         },
         "align-text": {
@@ -35,6 +35,14 @@
             "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
             "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
+        "ansi-colors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-1.1.0.tgz",
+            "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
+            "requires": {
+                "ansi-wrap": "0.1.0"
+            }
+        },
         "ansi-regex": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -45,15 +53,20 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
             "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
+        "ansi-wrap": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+            "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768="
+        },
         "archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
             "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "argparse": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "requires": {
                 "sprintf-js": "1.0.3"
             }
@@ -70,6 +83,11 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
             "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+        },
+        "arr-union": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-differ": {
             "version": "1.0.0",
@@ -119,6 +137,11 @@
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
             "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
+        "assign-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
+        },
         "async": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -140,7 +163,7 @@
             "integrity": "sha1-Hb0cg1ZY41zj+ZhAmdsAWFx4IBQ=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000743",
+                "caniuse-db": "1.0.30000830",
                 "normalize-range": "0.1.2",
                 "num2fraction": "1.2.2",
                 "postcss": "5.2.18",
@@ -153,16 +176,16 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-            "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
         },
         "backbone": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.3.3.tgz",
             "integrity": "sha1-TMgOp8sWMaxHSInOQPL4vGg7KZk=",
             "requires": {
-                "underscore": "1.8.3"
+                "underscore": "1.9.0"
             }
         },
         "balanced-match": {
@@ -189,7 +212,7 @@
             "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
             "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "bootstrap": {
@@ -221,9 +244,14 @@
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
             "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
             "requires": {
-                "caniuse-db": "1.0.30000743",
-                "electron-to-chromium": "1.3.24"
+                "caniuse-db": "1.0.30000830",
+                "electron-to-chromium": "1.3.44"
             }
+        },
+        "buffer-from": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
         },
         "builtin-modules": {
             "version": "1.1.1",
@@ -241,15 +269,15 @@
             "integrity": "sha1-tTTnxzTE+B7F++isoq0kNUuWLGw=",
             "requires": {
                 "browserslist": "1.7.7",
-                "caniuse-db": "1.0.30000743",
+                "caniuse-db": "1.0.30000830",
                 "lodash.memoize": "4.1.2",
                 "lodash.uniq": "4.5.0"
             }
         },
         "caniuse-db": {
-            "version": "1.0.30000743",
-            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000743.tgz",
-            "integrity": "sha1-vI3yolfPkboCQyImYpWvPe2FIwY="
+            "version": "1.0.30000830",
+            "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000830.tgz",
+            "integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM="
         },
         "caseless": {
             "version": "0.12.0",
@@ -330,7 +358,7 @@
             "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
             "integrity": "sha1-qe8VNmDWqGqL3sAomlxoTSF0Mv0=",
             "requires": {
-                "q": "1.5.0"
+                "q": "1.5.1"
             }
         },
         "color": {
@@ -339,14 +367,14 @@
             "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
             "requires": {
                 "clone": "1.0.2",
-                "color-convert": "1.9.0",
+                "color-convert": "1.9.1",
                 "color-string": "0.3.0"
             }
         },
         "color-convert": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-            "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
                 "color-name": "1.1.3"
             }
@@ -380,9 +408,9 @@
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
         },
         "combined-stream": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-            "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "requires": {
                 "delayed-stream": "1.0.0"
             }
@@ -428,7 +456,7 @@
                     "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
                     "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.2.1"
                     }
                 }
             }
@@ -677,9 +705,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.24",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.24.tgz",
-            "integrity": "sha1-m3uIuwXOufoBahd4M8wt3jiPIbY="
+            "version": "1.3.44",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.44.tgz",
+            "integrity": "sha1-72sVCmDVIwgjiMra2ICF7NL9RoQ="
         },
         "end-of-stream": {
             "version": "0.1.5",
@@ -739,6 +767,25 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
             "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
+        "extend-shallow": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+            "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+            "requires": {
+                "assign-symbols": "1.0.0",
+                "is-extendable": "1.0.1"
+            },
+            "dependencies": {
+                "is-extendable": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+                    "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+                    "requires": {
+                        "is-plain-object": "2.0.4"
+                    }
+                }
+            }
+        },
         "extglob": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
@@ -762,9 +809,14 @@
             }
         },
         "fast-deep-equal": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-            "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "filename-regex": {
             "version": "2.0.1",
@@ -860,13 +912,13 @@
             "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
-            "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "requires": {
                 "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "combined-stream": "1.0.6",
+                "mime-types": "2.1.18"
             }
         },
         "fs-exists-sync": {
@@ -1176,13 +1228,14 @@
             }
         },
         "gulp-cssnano": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.2.tgz",
-            "integrity": "sha1-4IoJdx7FRUpUnxoAW90lbLjl4KM=",
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/gulp-cssnano/-/gulp-cssnano-2.1.3.tgz",
+            "integrity": "sha512-r8qdX5pTXsBb/IRm9loE8Ijz8UiPW/URMC/bKJe4FPNHRaz4aEx8Bev03L0FYHd/7BSGu/ebmfumAkpGuTdenA==",
             "requires": {
+                "buffer-from": "1.0.0",
                 "cssnano": "3.10.0",
-                "gulp-util": "3.0.8",
                 "object-assign": "4.1.1",
+                "plugin-error": "1.0.1",
                 "vinyl-sourcemaps-apply": "0.2.1"
             },
             "dependencies": {
@@ -1298,7 +1351,7 @@
             "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "requires": {
-                "ajv": "5.2.3",
+                "ajv": "5.5.2",
                 "har-schema": "2.0.0"
             }
         },
@@ -1338,14 +1391,14 @@
             "requires": {
                 "boom": "4.3.1",
                 "cryptiles": "3.1.2",
-                "hoek": "4.2.0",
-                "sntp": "2.0.2"
+                "hoek": "4.2.1",
+                "sntp": "2.1.0"
             }
         },
         "hoek": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
-            "integrity": "sha512-v0XCLxICi9nPfYrS9RL8HbYnXi9obYAeLbSP00BmnZwCK9+Ih9WOjoZ8YoHCoav2csqn4FOz4Orldsy2dmDwmQ=="
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+            "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
         },
         "homedir-polyfill": {
             "version": "1.0.1",
@@ -1356,9 +1409,9 @@
             }
         },
         "hosted-git-info": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-            "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+            "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
         },
         "html-comment-regex": {
             "version": "1.1.1",
@@ -1372,7 +1425,7 @@
             "requires": {
                 "assert-plus": "1.0.0",
                 "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "sshpk": "1.14.1"
             }
         },
         "import-regex": {
@@ -1585,23 +1638,23 @@
             "integrity": "sha1-AeHfuikP5z3rp3zurLD5ui/sngw="
         },
         "js-base64": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.3.2.tgz",
-            "integrity": "sha512-Y2/+DnfJJXT1/FCwUebUhLWb3QihxiSC42+ctHLGogmW2jPY6LCapMdFZXRvVP2z6qyKW7s6qncE/9gSqZiArw=="
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
+            "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw=="
         },
         "js-yaml": {
             "version": "3.7.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
             "integrity": "sha1-XJZ93YN6m/3KXy3oQlOr6KHAO4A=",
             "requires": {
-                "argparse": "1.0.9",
+                "argparse": "1.0.10",
                 "esprima": "2.7.3"
             }
         },
         "jsbarcode": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.8.0.tgz",
-            "integrity": "sha1-opA3mnRJ+5J/JtJrMZwkvy3ryPw="
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.9.0.tgz",
+            "integrity": "sha512-FWuQ+XJTvtF8urAjJCYxb14cA1QzItGj8Cw8Wnwii6KluWuPmmRbeP5G5Utbn7gy6yA+4vaaUg7GLii/dzXTBA=="
         },
         "jsbn": {
             "version": "0.1.1",
@@ -1610,9 +1663,9 @@
             "optional": true
         },
         "json-parse-better-errors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
-            "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema": {
             "version": "0.2.3",
@@ -1624,23 +1677,10 @@
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
             "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
-        "json-stable-stringify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "requires": {
-                "jsonify": "0.0.0"
-            }
-        },
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-        },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
         },
         "jsprim": {
             "version": "1.4.1",
@@ -1941,16 +1981,16 @@
             }
         },
         "mime-db": {
-            "version": "1.30.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-            "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
         },
         "mime-types": {
-            "version": "2.1.17",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+            "version": "2.1.18",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "1.33.0"
             }
         },
         "minimatch": {
@@ -2012,10 +2052,10 @@
             "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "requires": {
-                "hosted-git-info": "2.5.0",
+                "hosted-git-info": "2.6.0",
                 "is-builtin-module": "1.0.0",
                 "semver": "4.3.6",
-                "validate-npm-package-license": "3.0.1"
+                "validate-npm-package-license": "3.0.3"
             }
         },
         "normalize-path": {
@@ -2212,13 +2252,31 @@
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
+        "plugin-error": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-1.0.1.tgz",
+            "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
+            "requires": {
+                "ansi-colors": "1.1.0",
+                "arr-diff": "4.0.0",
+                "arr-union": "3.1.0",
+                "extend-shallow": "3.0.2"
+            },
+            "dependencies": {
+                "arr-diff": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
+                }
+            }
+        },
         "postcss": {
             "version": "5.2.18",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
             "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "requires": {
                 "chalk": "1.1.3",
-                "js-base64": "2.3.2",
+                "js-base64": "2.4.3",
                 "source-map": "0.5.7",
                 "supports-color": "3.2.3"
             },
@@ -2339,7 +2397,7 @@
                 "caniuse-api": "1.6.1",
                 "postcss": "5.2.18",
                 "postcss-selector-parser": "2.2.3",
-                "vendors": "1.0.1"
+                "vendors": "1.0.2"
             }
         },
         "postcss-message-helpers": {
@@ -2522,9 +2580,9 @@
             "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "q": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/q/-/q-1.5.0.tgz",
-            "integrity": "sha1-3QG6ydBtMObyGa7LglPunr3DCPE="
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+            "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
         },
         "qs": {
             "version": "6.5.1",
@@ -2591,7 +2649,7 @@
             "requires": {
                 "debuglog": "1.0.1",
                 "graceful-fs": "4.1.11",
-                "read-package-json": "2.0.12",
+                "read-package-json": "2.0.13",
                 "readdir-scoped-modules": "1.0.2",
                 "semver": "4.3.6",
                 "slide": "1.1.6",
@@ -2607,13 +2665,13 @@
             }
         },
         "read-package-json": {
-            "version": "2.0.12",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
-            "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
+            "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
             "requires": {
                 "glob": "7.1.2",
                 "graceful-fs": "4.1.11",
-                "json-parse-better-errors": "1.0.1",
+                "json-parse-better-errors": "1.0.2",
                 "normalize-package-data": "2.4.0",
                 "slash": "1.0.0"
             },
@@ -2745,32 +2803,32 @@
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
         "request": {
-            "version": "2.83.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
-            "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+            "version": "2.85.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
+            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
             "requires": {
                 "aws-sign2": "0.7.0",
-                "aws4": "1.6.0",
+                "aws4": "1.7.0",
                 "caseless": "0.12.0",
-                "combined-stream": "1.0.5",
+                "combined-stream": "1.0.6",
                 "extend": "3.0.1",
                 "forever-agent": "0.6.1",
-                "form-data": "2.3.1",
+                "form-data": "2.3.2",
                 "har-validator": "5.0.3",
                 "hawk": "6.0.2",
                 "http-signature": "1.2.0",
                 "is-typedarray": "1.0.0",
                 "isstream": "0.1.2",
                 "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.17",
+                "mime-types": "2.1.18",
                 "oauth-sign": "0.8.2",
                 "performance-now": "2.1.0",
                 "qs": "6.5.1",
                 "safe-buffer": "5.1.1",
                 "stringstream": "0.0.5",
-                "tough-cookie": "2.3.3",
+                "tough-cookie": "2.3.4",
                 "tunnel-agent": "0.6.0",
-                "uuid": "3.1.0"
+                "uuid": "3.2.1"
             }
         },
         "resolve": {
@@ -2796,13 +2854,13 @@
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "retire": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/retire/-/retire-1.4.0.tgz",
-            "integrity": "sha1-sYMfEvysx09U38ZP5edT7c6/xR4=",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/retire/-/retire-1.6.0.tgz",
+            "integrity": "sha1-hkzZTfu8H/Vn1ftACr7v6Kt8GsE=",
             "requires": {
                 "commander": "2.5.1",
                 "read-installed": "4.0.3",
-                "request": "2.83.0",
+                "request": "2.85.0",
                 "walkdir": "0.0.7"
             }
         },
@@ -2891,11 +2949,11 @@
             "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "sntp": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.0.2.tgz",
-            "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+            "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
             "requires": {
-                "hoek": "4.2.0"
+                "hoek": "4.2.1"
             }
         },
         "sort-keys": {
@@ -2933,22 +2991,32 @@
             "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM="
         },
         "spdx-correct": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "requires": {
-                "spdx-license-ids": "1.2.2"
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
             }
         },
+        "spdx-exceptions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
+        },
         "spdx-expression-parse": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+            }
         },
         "spdx-license-ids": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "sprintf-js": {
             "version": "1.0.3",
@@ -2956,9 +3024,9 @@
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-            "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
+            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
             "requires": {
                 "asn1": "0.2.3",
                 "assert-plus": "1.0.0",
@@ -3078,9 +3146,9 @@
             "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM="
         },
         "tough-cookie": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
-            "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
             "requires": {
                 "punycode": "1.4.1"
             }
@@ -3133,9 +3201,9 @@
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
         },
         "underscore": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-            "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.0.tgz",
+            "integrity": "sha512-4IV1DSSxC1QK48j9ONFK1MoIAKKkbE8i7u55w2R6IqBqbT7A/iG7aZBCR2Bi8piF0Uz+i/MG1aeqLwl/5vqF+A=="
         },
         "uniq": {
             "version": "1.0.1",
@@ -3189,9 +3257,9 @@
             "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
         },
         "uuid": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
+            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
         },
         "v8flags": {
             "version": "2.1.1",
@@ -3202,18 +3270,18 @@
             }
         },
         "validate-npm-package-license": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
             "requires": {
-                "spdx-correct": "1.0.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
             }
         },
         "vendors": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz",
-            "integrity": "sha1-N61zyO5Bf7PVgOeFMSMH0nSEfyI="
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
+            "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
         },
         "verror": {
             "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,15 @@
         "gulp": "3.9.x",
         "gulp-concat": "2.6.x",
         "gulp-concat-css": "2.2.x",
-        "gulp-cssnano": "2.1.x",
+        "gulp-cssnano": "^2.1.3",
         "gulp-rename": "1.2.x",
         "gulp-sourcemaps": "1.6.x",
         "gulp-uglify": "1.5.x",
         "jquery": "^1.12.4",
-        "jsbarcode": "^3.8.0",
+        "jsbarcode": "^3.9.0",
         "merge-stream": "^1.0.0",
         "parsleyjs": "^2.8.1",
-        "retire": "^1.2.10",
-        "underscore": "^1.8.3"
+        "retire": "^1.6.0",
+        "underscore": "^1.9.0"
     }
 }


### PR DESCRIPTION
Ran `npm update`. This gets the hoek package to 4.2.1 which should quiet the GitHub vulnerability alert.  Other packages have been updated (I ran update without the `--depth` flag, so this minimizes the impact) to newer minor versions.  I did some testing of most of our JavaScript functionality and everything looks good to me.

Run `npm install` after switching to this branch to test.

[[HPRO-347](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-347)]