### PR TITLE
[HPRO-367] Make it more obvious that results are loading when paging through the work queue

### DIFF
--- a/web/assets/js/views/workqueue.js
+++ b/web/assets/js/views/workqueue.js
@@ -266,6 +266,7 @@ $(document).ready(function() {
 
     // Scroll to top when performing pagination
     $('#workqueue').on('page.dt', function() {
+        //Took reference from https://stackoverflow.com/a/21627503
         $('html').animate({
             scrollTop: $('#filters').offset().top
         }, 'slow');


### PR DESCRIPTION
After scrolling to the top the page scrolls down back so we need to focus on table header to fix this.