### PR TITLE
[HPRO-366] Fix session issues

### DIFF
--- a/src/Pmi/Datastore/DatastoreSessionHandler.php
+++ b/src/Pmi/Datastore/DatastoreSessionHandler.php
@@ -25,6 +25,12 @@ class DatastoreSessionHandler extends AbstractSessionHandler
         return true;
     }
 
+    /**
+     * @SuppressWarnings("PHPMD.UnusedFormalParameter")
+     *
+     * This noop method is required since the AbstractSessionHandler
+     * class implements SessionUpdateTimestampHandlerInterface
+     */
     public function updateTimestamp($id, $data)
     {
         return true;


### PR DESCRIPTION
[[HPRO-366](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-366)]

There are two session-related issues addressed here.  First, if you manipulate the PHPSESSID cookie to add certain invalid characters, the Datastore php-gds library throws an exception.  Second, under certain circumstances where a session id is invalid, the Google Auth workflow was getting stuck in a redirect loop.

The first issue is solved by catching the Datastore exceptions.  The second issue is addressed by destroying the session after failing to read a session due to a Datastore exception.  In order to implement the session destroying, I updated our `DatastoreSessionHandler` to extend Symfony's `AbstractSessionHandler`.

### Steps to reproduce and verify the fix

1. Reproduce the problem in `develop` by editing the PHPSESSID cookie and adding `%83` to the end of the session id.  You should see the 500 error.
2. Switch to this branch. Perform the same procedure above and verify that you get a new, valid session id and are logged out.
3. Test using Google Auth (disable the GAE auth by commenting out the `gae_auth: 1` line in your `dev_config/config.yml` file and verify that everything works as expected here (i.e. no infinite redirects)