### PR TITLE
[HPRO-372] Improve order id generator

### DIFF
--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -820,12 +820,23 @@ class Order
         return false;
     }
 
+    private function getNumericId()
+    {
+        $length = 10;
+        // Avoid leading 0s
+        $id = (string)rand(1,9);
+        for ($i = 0; $i < $length - 1; $i++) {
+            $id .= (string)rand(0,9);
+        }
+        return $id;
+    }
+
     public function generateId()
     {
         $attempts = 0;
         $ordersRepository = $this->app['em']->getRepository('orders');
         while (++$attempts <= 20) {
-            $id = (string)rand(1000000000, 9999999999);
+            $id = $this->getNumericId();
             if ($ordersRepository->fetchOneBy(['order_id' => $id])) {
                 $id = null;
             } else {


### PR DESCRIPTION
[[HPRO-372](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-372)]

When deployed to GAE, the previous order id generator was only generating ids between 1000000000 and 2147483647 (largest signed 32 bit integer).  That makes sense given that `getrandmax()` returns that value.  But rand(1000000000, 9999999999) still works locally using the GAE SDK version of App Engine.  My guess is that there is some platform-dependent difference in `rand` implementation.

This PR changes the id generator to generate one digit at a time.