### PR TITLE
[HPRO-375] Add no-store to cache-control header

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -199,6 +199,10 @@ class HpoApplication extends AbstractApplication
         // "low" security finding: enable XSS Protection
         // http://blog.innerht.ml/the-misunderstood-x-xss-protection/
         $response->headers->set('X-XSS-Protection', '1; mode=block');
+
+        // Default cache control header in ResponseHeaderBag::computeCacheControlValue returns "no-cache, private"
+        // Recommendation from security team is to add no-store as well.
+        $response->headers->addCacheControlDirective('no-cache, no-store');
     }
     
     public function switchSite($email)


### PR DESCRIPTION
[[HPRO-375](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-375)]

Adds the `no-store` directive to our `cache-control` header as [recommended by the security team](https://precisionmedicineinitiative.atlassian.net/browse/PD-1969).

Because the `symfony/http-foundation` component (specifically, the `ResponseHeaderBag` class) treats the cache-control header specially, the way to accomplish this was to use the `addCacheControlDirective` method instead of just setting the header directly with `set`.