### PR TITLE
[HPRO-385] Use https for default mayo link endpoint

### DIFF
--- a/src/Pmi/Order/Mayolink/MayolinkOrder.php
+++ b/src/Pmi/Order/Mayolink/MayolinkOrder.php
@@ -7,7 +7,7 @@ use Pmi\Order\Order;
 
 class MayolinkOrder
 {
-    protected $ordersEndpoint = 'http://test.orders.mayomedicallaboratories.com';
+    protected $ordersEndpoint = 'https://test.orders.mayomedicallaboratories.com';
     protected $nameSpace = 'http://orders.mayomedicallaboratories.com';
     protected $labelPdf = 'orders/labels.xml';
     protected $createOrder = 'orders/create.xml';


### PR DESCRIPTION
**Note:** Didn't change the xml namespace url to `https` because when I change it to `https` mayo is throwing `403 forbidden` error.