### PR TITLE
[DASH1-71] Dashboards > Replace date picker with component from HealthPro

### DIFF
--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -303,7 +303,7 @@
                   $('#real-time-end-date').on("dp.change", function (e) {
                     $('#real-time-start-date').data("DateTimePicker").maxDate(e.date);
                   });
-                })
+                });
 
                 if ( new Date(tpStartDate) > new Date(tpEndDate)) {
                   alert('Your date selection is invalid: The selected cutoff date of ' + tpEndDate + ' is before ' + tpStartDate + '. Please select a valid date range.');


### PR DESCRIPTION

![screen shot 2018-08-21 at 4 18 43 pm](https://user-images.githubusercontent.com/80459/44429692-eb1eb580-a55d-11e8-9a91-a91b85d7a5e7.png)


The ticket called for fixing missing display arrows in the jQuery UI implementation of the date picker, but that is not the one we are using elsewhere in HealthPro. In the interest of standardizing on a single implementation, this PR uses the convention from HealthPro. It adds some additional controls around visually restricting "linked" date fields from picking a date out of range from the set start/end window.

More generally speaking, the JavaScript needs some :heart:, but this resolves the pressing matter.

[[DASH1-71](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-71)]