### PR TITLE
[HPRO-398] Improve return URL check on settings page

### DIFF
--- a/src/Pmi/Controller/DefaultController.php
+++ b/src/Pmi/Controller/DefaultController.php
@@ -412,7 +412,7 @@ class DefaultController extends AbstractController
                 'timezone' => $settingsForm['timezone']->getData()
             ]);
             $app->addFlashSuccess('Your settings have been updated');
-            if ($request->query->has('return') && preg_match('/^\//', $request->query->get('return'))) {
+            if ($request->query->has('return') && preg_match('/^\/\w/', $request->query->get('return'))) {
                 return $app->redirect($request->query->get('return'));
             } else {
                 return $app->redirectToRoute('home');


### PR DESCRIPTION
[[HPRO-398](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-398)]

We pass in a return URL to the settings page to allow users to be redirected back to the page they came from (specifically used when changing timezone directly from a participant order page).

[Previously](https://github.com/vanderbilt/pmi-drc-hpo/pull/378), we addressed an issue where a link could be constructed that would redirect a user to an external site by requiring that the return URL start with a forward slash to guarantee that it is an internal link.  However, Coalfire has [pointed out](https://precisionmedicineinitiative.atlassian.net/browse/PD-1865?focusedCommentId=26080&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-26080) that a URL starting with two forward slashes (`//www.google.com`) would be treated by the browser as a valid external URL (the same mechanism used to allow external assets to be specified without a protocol).

This change fixes the problem by requiring that the return URL start with a single forward slash followed immediately with a word character (`\w`).