### PR TITLE
[HPRO-401] Update CircleCI badge image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HealthPro Portal and Admin Dashboard
 
-![Build Status of master](https://circleci.com/gh/vanderbilt/pmi-drc-hpo.png?circle-token=17ce7a55825cb047e685c2376d7e33441a07c590)
+![Build Status of develop](https://circleci.com/gh/all-of-us/healthpro.png)
 
 ## Contributions
 


### PR DESCRIPTION
[[HPRO-401](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-401)]

After moving the repository to the All of Us organization, we need to update the URL for the CircleCI badge image in the README file.