### PR TITLE
[HPRO-409] Add invalid EHR consent filter option to work queue

### DIFF
--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -103,7 +103,8 @@ class WorkQueue
             'options' => [
                 'Consented' => 'SUBMITTED',
                 'Refused consent' => 'SUBMITTED_NO_CONSENT',
-                'Consent not completed' => 'UNSET'
+                'Consent not completed' => 'UNSET',
+                'Invalid' => 'SUBMITTED_INVALID'
             ]
         ],
         'ageRange' => [

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -277,6 +277,9 @@ label.label-normal {
         #f4e7e7 20px
     );
 }
+#filters .form-inline select.form-control {
+    margin-bottom: 4px;
+}
 
 /* Today's participants */
 #table-today>thead>tr>td, #table-today>thead>tr>th {


### PR DESCRIPTION
This adds a new EHR Consent Status filter option of "Invalid" which maps to the `SUBMITTED_INVALID` value for `consentForElectronicHealthRecords` in the participant summary object.

In addition to adding the new filter option, I also made a small CSS change to add some bottom margin to the filter selects so that there is a little vertical spacing when they don't all fit on the same row:

![screen shot 2018-09-26 at 2 45 22 pm](https://user-images.githubusercontent.com/860499/46105112-d22ba480-c19a-11e8-9aca-8d548244c918.png)

![screen shot 2018-09-26 at 2 45 00 pm](https://user-images.githubusercontent.com/860499/46105113-d3f56800-c19a-11e8-9e83-73bdd007caeb.png)
