### PR TITLE
[HPRO-410] Update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -532,24 +532,26 @@
             }
         },
         "browser-sync": {
-            "version": "2.24.7",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.7.tgz",
-            "integrity": "sha512-NqXek0cPNEayQm77VGnD+qrwcVBTKMIQ9bdP6IWDRUTU1Bk7tZeq5QR3OG5Rr36Rao1t+Vx1QnfolHvvr5qsTA==",
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.26.0.tgz",
+            "integrity": "sha512-/2f2/jPmFEdPw7wcARid/oGO237RMfZ8SyAYVtF4Zq5R/E+78zx/rH6aFc/UFY+VDHcsCqmDsfIEi/q1fA3l4Q==",
             "requires": {
-                "browser-sync-ui": "v1.0.1",
+                "browser-sync-client": "^2.26.0",
+                "browser-sync-ui": "^2.26.0",
                 "bs-recipes": "1.3.4",
-                "chokidar": "1.7.0",
+                "bs-snippet-injector": "^2.0.1",
+                "chokidar": "^2.0.4",
                 "connect": "3.6.6",
-                "connect-history-api-fallback": "^1.5.0",
+                "connect-history-api-fallback": "^1",
                 "dev-ip": "^1.0.1",
                 "easy-extender": "^2.3.4",
-                "eazy-logger": "3.0.2",
+                "eazy-logger": "^3",
                 "etag": "^1.8.1",
                 "fresh": "^0.5.2",
                 "fs-extra": "3.0.1",
                 "http-proxy": "1.15.2",
-                "immutable": "3.8.2",
-                "localtunnel": "1.9.0",
+                "immutable": "^3",
+                "localtunnel": "1.9.1",
                 "micromatch": "2.3.11",
                 "opn": "5.3.0",
                 "portscanner": "2.1.1",
@@ -565,15 +567,6 @@
                 "yargs": "6.4.0"
             },
             "dependencies": {
-                "anymatch": {
-                    "version": "1.3.2",
-                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-                    "requires": {
-                        "micromatch": "^2.1.5",
-                        "normalize-path": "^2.0.0"
-                    }
-                },
                 "arr-diff": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -602,22 +595,6 @@
                     "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
                     "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
                 },
-                "chokidar": {
-                    "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-                    "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-                    "requires": {
-                        "anymatch": "^1.3.0",
-                        "async-each": "^1.0.0",
-                        "fsevents": "^1.0.0",
-                        "glob-parent": "^2.0.0",
-                        "inherits": "^2.0.1",
-                        "is-binary-path": "^1.0.0",
-                        "is-glob": "^2.0.0",
-                        "path-is-absolute": "^1.0.0",
-                        "readdirp": "^2.0.0"
-                    }
-                },
                 "cliui": {
                     "version": "3.2.0",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
@@ -642,14 +619,6 @@
                     "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
                     "requires": {
                         "is-extglob": "^1.0.0"
-                    }
-                },
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "requires": {
-                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -718,7 +687,7 @@
                 },
                 "yargs-parser": {
                     "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "requires": {
                         "camelcase": "^3.0.0"
@@ -726,16 +695,25 @@
                 }
             }
         },
+        "browser-sync-client": {
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.26.0.tgz",
+            "integrity": "sha512-XRVN6xNFCQYb5mjrDoVzdV2rBK6PMLtTeYkKcs5UPp+/cuviB8z8odaHx0Oe/cAs3Vl45csRdpa7T+q1Zf+6qQ==",
+            "requires": {
+                "mitt": "^1.1.3",
+                "rxjs": "^5.5.6"
+            }
+        },
         "browser-sync-ui": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
-            "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.26.0.tgz",
+            "integrity": "sha512-7bXPmkQ9GuSPUgji3Nb4y0IL8wS2LfdrKSG28bQwvys5bs4kWyXDec2RkYBiupTTModM5lbwXgtmoh7GWQuLGg==",
             "requires": {
                 "async-each-series": "0.1.1",
-                "connect-history-api-fallback": "^1.1.0",
-                "immutable": "^3.7.6",
+                "connect-history-api-fallback": "^1",
+                "immutable": "^3",
                 "server-destroy": "1.0.1",
-                "socket.io-client": "2.0.4",
+                "socket.io-client": "^2.0.4",
                 "stream-throttle": "^0.1.3"
             }
         },
@@ -752,6 +730,11 @@
             "version": "1.3.4",
             "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
             "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
+        },
+        "bs-snippet-injector": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/bs-snippet-injector/-/bs-snippet-injector-2.0.1.tgz",
+            "integrity": "sha1-YbU5PxH1JVntEgaTEANDtu2wTdU="
         },
         "buffer-equal": {
             "version": "1.0.0",
@@ -1278,21 +1261,21 @@
             }
         },
         "datatables.net-buttons": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-1.5.3.tgz",
-            "integrity": "sha512-qGdYiquuIvoZSH0jkRTcVnS1LlCuJFOSlIX5wNmK+3267Ryq6r9llKFtgrIORkSlyy+M1TJMViFJxRSX5W62GA==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/datatables.net-buttons/-/datatables.net-buttons-1.5.4.tgz",
+            "integrity": "sha512-xfo/23sGVXQW0kj2jLH6PzkhnXv+yGPrUXh7/ZT7xvCL1sNt8MLLf0tPLyrWynyeaew+Qvx5NBZer4MLxmisyw==",
             "requires": {
                 "datatables.net": "^1.10.15",
                 "jquery": ">=1.7"
             }
         },
         "datatables.net-buttons-bs": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/datatables.net-buttons-bs/-/datatables.net-buttons-bs-1.5.3.tgz",
-            "integrity": "sha512-kxhcdy6tUFyQt0MV6p1kFqJ+nhZjYxSkftKIAEMuLWVDhYZ5bQJkDUBOpiWAjqHz5KqXorRqxYP0TzPLuGld5A==",
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/datatables.net-buttons-bs/-/datatables.net-buttons-bs-1.5.4.tgz",
+            "integrity": "sha512-NUKPMmc/5RPeQP3aq+ey7DYNmy516OjAPo6Mv3qQis5ZNItms/y8d+nIYQ16QKv+fRO1NVgsjOxB7OpYSbH2ug==",
             "requires": {
                 "datatables.net-bs": "^1.10.15",
-                "datatables.net-buttons": "1.5.3",
+                "datatables.net-buttons": "1.5.4",
                 "jquery": ">=1.7"
             },
             "dependencies": {
@@ -1629,9 +1612,9 @@
             }
         },
         "engine.io-client": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
-            "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+            "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
@@ -3098,9 +3081,9 @@
             }
         },
         "gulp-rename": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.3.tgz",
-            "integrity": "sha512-CmdPM0BjJ105QCX1fk+j7NGhiN/1rCl9HLGss+KllBS/tdYadpjTxqdKyh/5fNV+M3yjT1MFz5z93bXdrTyzAw=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.4.0.tgz",
+            "integrity": "sha512-swzbIGb/arEoFK89tPY58vg3Ok1bw+d35PfUNwWqdo7KM4jkmuGA78JiDNqR+JeZFaeeHnRg9N7aihX3YPmsyg=="
         },
         "gulp-sourcemaps": {
             "version": "1.6.0",
@@ -3675,9 +3658,9 @@
             }
         },
         "jsbarcode": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.9.0.tgz",
-            "integrity": "sha512-FWuQ+XJTvtF8urAjJCYxb14cA1QzItGj8Cw8Wnwii6KluWuPmmRbeP5G5Utbn7gy6yA+4vaaUg7GLii/dzXTBA=="
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.11.0.tgz",
+            "integrity": "sha512-/ozCd7wsa+VIHo9sUc03HneVEQrH7cVWfJolUT/WOW1m8mJ2e3iYZje6C9X3LFHdczlesqFHRpxLtbVsNtjyow=="
         },
         "jsbn": {
             "version": "0.1.1",
@@ -3855,12 +3838,12 @@
             }
         },
         "localtunnel": {
-            "version": "1.9.0",
-            "resolved": "http://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
-            "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/localtunnel/-/localtunnel-1.9.1.tgz",
+            "integrity": "sha512-HWrhOslklDvxgOGFLxi6fQVnvpl6XdX4sPscfqMZkzi3gtt9V7LKBWYvNUcpHSVvjwCQ6xzXacVvICNbNcyPnQ==",
             "requires": {
                 "axios": "0.17.1",
-                "debug": "2.6.8",
+                "debug": "2.6.9",
                 "openurl": "1.1.1",
                 "yargs": "6.6.0"
             },
@@ -3878,14 +3861,6 @@
                         "string-width": "^1.0.1",
                         "strip-ansi": "^3.0.1",
                         "wrap-ansi": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "2.6.8",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-                    "requires": {
-                        "ms": "2.0.0"
                     }
                 },
                 "yargs": {
@@ -3910,7 +3885,7 @@
                 },
                 "yargs-parser": {
                     "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
                     "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
                     "requires": {
                         "camelcase": "^3.0.0"
@@ -4242,6 +4217,11 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
             "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "mitt": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/mitt/-/mitt-1.1.3.tgz",
+            "integrity": "sha512-mUDCnVNsAi+eD6qA0HkRkwYczbLHJ49z17BGe2PYRhZL4wpZUFZGJHU7/5tmvohoma+Hdn0Vh/oJTiPEmgSruA=="
         },
         "mixin-deep": {
             "version": "1.3.1",
@@ -5634,6 +5614,14 @@
             "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
             "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
         },
+        "rxjs": {
+            "version": "5.5.12",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+            "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
+            "requires": {
+                "symbol-observable": "1.0.1"
+            }
+        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -5890,60 +5878,6 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
-                },
-                "engine.io-client": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
-                    "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
-                    "requires": {
-                        "component-emitter": "1.2.1",
-                        "component-inherit": "0.0.3",
-                        "debug": "~3.1.0",
-                        "engine.io-parser": "~2.1.1",
-                        "has-cors": "1.1.0",
-                        "indexof": "0.0.1",
-                        "parseqs": "0.0.5",
-                        "parseuri": "0.0.5",
-                        "ws": "~3.3.1",
-                        "xmlhttprequest-ssl": "~1.5.4",
-                        "yeast": "0.1.2"
-                    }
-                },
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-                },
-                "socket.io-client": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
-                    "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
-                    "requires": {
-                        "backo2": "1.0.2",
-                        "base64-arraybuffer": "0.1.5",
-                        "component-bind": "1.0.0",
-                        "component-emitter": "1.2.1",
-                        "debug": "~3.1.0",
-                        "engine.io-client": "~3.2.0",
-                        "has-binary2": "~1.0.2",
-                        "has-cors": "1.1.0",
-                        "indexof": "0.0.1",
-                        "object-component": "0.0.3",
-                        "parseqs": "0.0.5",
-                        "parseuri": "0.0.5",
-                        "socket.io-parser": "~3.2.0",
-                        "to-array": "0.1.4"
-                    }
-                },
-                "socket.io-parser": {
-                    "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
-                    "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
-                    "requires": {
-                        "component-emitter": "1.2.1",
-                        "debug": "~3.1.0",
-                        "isarray": "2.0.1"
-                    }
                 }
             }
         },
@@ -5953,33 +5887,43 @@
             "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
         },
         "socket.io-client": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
-            "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+            "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
             "requires": {
                 "backo2": "1.0.2",
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "~2.6.4",
-                "engine.io-client": "~3.1.0",
+                "debug": "~3.1.0",
+                "engine.io-client": "~3.2.0",
+                "has-binary2": "~1.0.2",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "~3.1.1",
+                "socket.io-parser": "~3.2.0",
                 "to-array": "0.1.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
             }
         },
         "socket.io-parser": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
-            "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+            "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
             "requires": {
                 "component-emitter": "1.2.1",
                 "debug": "~3.1.0",
-                "has-binary2": "~1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -6201,6 +6145,11 @@
                 "sax": "~1.2.1",
                 "whet.extend": "~0.9.9"
             }
+        },
+        "symbol-observable": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+            "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
         },
         "tfunk": {
             "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,20 @@
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "accepts": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "requires": {
+                "mime-types": "~2.1.18",
+                "negotiator": "0.6.1"
+            }
+        },
+        "after": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
+        },
         "ajv": {
             "version": "5.5.2",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -224,6 +238,11 @@
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
+        "arraybuffer.slice": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
+            "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
+        },
         "asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -264,6 +283,16 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
             "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0="
+        },
+        "async-each-series": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
+            "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI="
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
         },
         "async-settle": {
             "version": "1.0.0",
@@ -306,6 +335,15 @@
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
             "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
         },
+        "axios": {
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
+            "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+            "requires": {
+                "follow-redirects": "^1.2.5",
+                "is-buffer": "^1.1.5"
+            }
+        },
         "bach": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/bach/-/bach-1.2.0.tgz",
@@ -329,6 +367,11 @@
             "requires": {
                 "underscore": ">=1.8.3"
             }
+        },
+        "backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc="
         },
         "balanced-match": {
             "version": "1.0.0",
@@ -395,6 +438,21 @@
                 }
             }
         },
+        "base64-arraybuffer": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+        },
+        "base64id": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+            "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+        },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
+        },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -409,10 +467,23 @@
             "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
             "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak="
         },
+        "better-assert": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+            "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+            "requires": {
+                "callsite": "1.0.0"
+            }
+        },
         "binary-extensions": {
             "version": "1.11.0",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
             "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
+        },
+        "blob": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+            "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
         },
         "bootstrap": {
             "version": "3.3.7",
@@ -460,6 +531,214 @@
                 }
             }
         },
+        "browser-sync": {
+            "version": "2.24.7",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.24.7.tgz",
+            "integrity": "sha512-NqXek0cPNEayQm77VGnD+qrwcVBTKMIQ9bdP6IWDRUTU1Bk7tZeq5QR3OG5Rr36Rao1t+Vx1QnfolHvvr5qsTA==",
+            "requires": {
+                "browser-sync-ui": "v1.0.1",
+                "bs-recipes": "1.3.4",
+                "chokidar": "1.7.0",
+                "connect": "3.6.6",
+                "connect-history-api-fallback": "^1.5.0",
+                "dev-ip": "^1.0.1",
+                "easy-extender": "^2.3.4",
+                "eazy-logger": "3.0.2",
+                "etag": "^1.8.1",
+                "fresh": "^0.5.2",
+                "fs-extra": "3.0.1",
+                "http-proxy": "1.15.2",
+                "immutable": "3.8.2",
+                "localtunnel": "1.9.0",
+                "micromatch": "2.3.11",
+                "opn": "5.3.0",
+                "portscanner": "2.1.1",
+                "qs": "6.2.3",
+                "raw-body": "^2.3.2",
+                "resp-modifier": "6.0.2",
+                "rx": "4.1.0",
+                "serve-index": "1.9.1",
+                "serve-static": "1.13.2",
+                "server-destroy": "1.0.1",
+                "socket.io": "2.1.1",
+                "ua-parser-js": "0.7.17",
+                "yargs": "6.4.0"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+                    "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+                    "requires": {
+                        "micromatch": "^2.1.5",
+                        "normalize-path": "^2.0.0"
+                    }
+                },
+                "arr-diff": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+                    "requires": {
+                        "arr-flatten": "^1.0.1"
+                    }
+                },
+                "array-unique": {
+                    "version": "0.2.1",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+                    "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM="
+                },
+                "braces": {
+                    "version": "1.8.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                    "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+                    "requires": {
+                        "expand-range": "^1.8.1",
+                        "preserve": "^0.2.0",
+                        "repeat-element": "^1.1.2"
+                    }
+                },
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                },
+                "chokidar": {
+                    "version": "1.7.0",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+                    "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+                    "requires": {
+                        "anymatch": "^1.3.0",
+                        "async-each": "^1.0.0",
+                        "fsevents": "^1.0.0",
+                        "glob-parent": "^2.0.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^2.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0"
+                    }
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "expand-brackets": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                    "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+                    "requires": {
+                        "is-posix-bracket": "^0.1.0"
+                    }
+                },
+                "extglob": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+                    "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                },
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                },
+                "micromatch": {
+                    "version": "2.3.11",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                    "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+                    "requires": {
+                        "arr-diff": "^2.0.0",
+                        "array-unique": "^0.2.1",
+                        "braces": "^1.8.2",
+                        "expand-brackets": "^0.1.4",
+                        "extglob": "^0.3.1",
+                        "filename-regex": "^2.0.0",
+                        "is-extglob": "^1.0.0",
+                        "is-glob": "^2.0.1",
+                        "kind-of": "^3.0.2",
+                        "normalize-path": "^2.0.1",
+                        "object.omit": "^2.0.0",
+                        "parse-glob": "^3.0.4",
+                        "regex-cache": "^0.4.2"
+                    }
+                },
+                "qs": {
+                    "version": "6.2.3",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.2.3.tgz",
+                    "integrity": "sha1-HPyyXBCpsrSDBT/zn138kjOQjP4="
+                },
+                "window-size": {
+                    "version": "0.2.0",
+                    "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+                    "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
+                },
+                "yargs": {
+                    "version": "6.4.0",
+                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.4.0.tgz",
+                    "integrity": "sha1-gW4ahm1VmMzzTlWW3c4i2S2kkNQ=",
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "window-size": "^0.2.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.1.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "browser-sync-ui": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-1.0.1.tgz",
+            "integrity": "sha512-RIxmwVVcUFhRd1zxp7m2FfLnXHf59x4Gtj8HFwTA//3VgYI3AKkaQAuDL8KDJnE59XqCshxZa13JYuIWtZlKQg==",
+            "requires": {
+                "async-each-series": "0.1.1",
+                "connect-history-api-fallback": "^1.1.0",
+                "immutable": "^3.7.6",
+                "server-destroy": "1.0.1",
+                "socket.io-client": "2.0.4",
+                "stream-throttle": "^0.1.3"
+            }
+        },
         "browserslist": {
             "version": "1.7.7",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
@@ -468,6 +747,11 @@
                 "caniuse-db": "^1.0.30000639",
                 "electron-to-chromium": "^1.2.7"
             }
+        },
+        "bs-recipes": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/bs-recipes/-/bs-recipes-1.3.4.tgz",
+            "integrity": "sha1-DS1NSKcYyMBEdp/cT4lZLci2lYU="
         },
         "buffer-equal": {
             "version": "1.0.0",
@@ -483,6 +767,11 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+        },
+        "bytes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "cache-base": {
             "version": "1.0.1",
@@ -506,6 +795,11 @@
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
+        },
+        "callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA="
         },
         "camelcase": {
             "version": "1.2.1",
@@ -744,10 +1038,20 @@
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.5.1.tgz",
             "integrity": "sha1-I8Yfbke+FDzALnrUuxxH9c1aKIM="
         },
+        "component-bind": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
+        },
         "component-emitter": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
             "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
+        },
+        "component-inherit": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -814,10 +1118,31 @@
                 }
             }
         },
+        "connect": {
+            "version": "3.6.6",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.6.tgz",
+            "integrity": "sha1-Ce/2xVr3I24TcTWnJXSFi2eG9SQ=",
+            "requires": {
+                "debug": "2.6.9",
+                "finalhandler": "1.1.0",
+                "parseurl": "~1.3.2",
+                "utils-merge": "1.0.1"
+            }
+        },
+        "connect-history-api-fallback": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.5.0.tgz",
+            "integrity": "sha1-sGhzk0vF40T+9hGhlqb6rgruAVo="
+        },
         "convert-source-map": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz",
             "integrity": "sha1-8dgClQr33SYxof6+BZZVDIarMZA="
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "copy-descriptor": {
             "version": "0.1.1",
@@ -1131,10 +1456,25 @@
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
+        "depd": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
         "detect-file": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
             "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
+        },
+        "dev-ip": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
+            "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
         },
         "dezalgo": {
             "version": "1.0.3",
@@ -1207,6 +1547,22 @@
                 "object.defaults": "^1.1.0"
             }
         },
+        "easy-extender": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/easy-extender/-/easy-extender-2.3.4.tgz",
+            "integrity": "sha512-8cAwm6md1YTiPpOvDULYJL4ZS6WfM5/cTeVVh4JsvyYZAoqlRVUpHL9Gr5Fy7HA6xcSZicUia3DeAgO3Us8E+Q==",
+            "requires": {
+                "lodash": "^4.17.10"
+            }
+        },
+        "eazy-logger": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/eazy-logger/-/eazy-logger-3.0.2.tgz",
+            "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
+            "requires": {
+                "tfunk": "^3.0.1"
+            }
+        },
         "ecc-jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
@@ -1216,10 +1572,20 @@
                 "jsbn": "~0.1.0"
             }
         },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
+        },
         "electron-to-chromium": {
             "version": "1.3.44",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.44.tgz",
             "integrity": "sha1-72sVCmDVIwgjiMra2ICF7NL9RoQ="
+        },
+        "encodeurl": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
         },
         "end-of-stream": {
             "version": "1.4.1",
@@ -1237,6 +1603,69 @@
                         "wrappy": "1"
                     }
                 }
+            }
+        },
+        "engine.io": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-3.2.0.tgz",
+            "integrity": "sha512-mRbgmAtQ4GAlKwuPnnAvXXwdPhEx+jkc0OBCLrXuD/CRvwNK3AxRSnqK4FSqmAMRRHryVJP8TopOvmEaA64fKw==",
+            "requires": {
+                "accepts": "~1.3.4",
+                "base64id": "1.0.0",
+                "cookie": "0.3.1",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.0",
+                "ws": "~3.3.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "engine.io-client": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.1.6.tgz",
+            "integrity": "sha512-hnuHsFluXnsKOndS4Hv6SvUrgdYx1pk2NqfaDMW+GWdgfU3+/V25Cj7I8a0x92idSpa5PIhJRKxPvp9mnoLsfg==",
+            "requires": {
+                "component-emitter": "1.2.1",
+                "component-inherit": "0.0.3",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.1",
+                "has-cors": "1.1.0",
+                "indexof": "0.0.1",
+                "parseqs": "0.0.5",
+                "parseuri": "0.0.5",
+                "ws": "~3.3.1",
+                "xmlhttprequest-ssl": "~1.5.4",
+                "yeast": "0.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "engine.io-parser": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.1.2.tgz",
+            "integrity": "sha512-dInLFzr80RijZ1rGpx1+56/uFoH7/7InhH3kZt+Ms6hT8tNx3NGW/WNSA/f8As1WkOfkuyb3tnRyuXGxusclMw==",
+            "requires": {
+                "after": "0.8.2",
+                "arraybuffer.slice": "~0.0.7",
+                "base64-arraybuffer": "0.1.5",
+                "blob": "0.0.4",
+                "has-binary2": "~1.0.2"
             }
         },
         "eonasdan-bootstrap-datetimepicker": {
@@ -1298,6 +1727,11 @@
                 "es6-symbol": "^3.1.1"
             }
         },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+        },
         "escape-string-regexp": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
@@ -1307,6 +1741,16 @@
             "version": "2.7.3",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
             "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+        },
+        "etag": {
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+        },
+        "eventemitter3": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+            "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
         },
         "expand-brackets": {
             "version": "2.1.4",
@@ -1336,6 +1780,36 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "requires": {
                         "is-extendable": "^0.1.0"
+                    }
+                }
+            }
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "requires": {
+                "fill-range": "^2.1.0"
+            },
+            "dependencies": {
+                "fill-range": {
+                    "version": "2.2.4",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+                    "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+                    "requires": {
+                        "is-number": "^2.1.0",
+                        "isobject": "^2.0.0",
+                        "randomatic": "^3.0.0",
+                        "repeat-element": "^1.1.2",
+                        "repeat-string": "^1.5.2"
+                    }
+                },
+                "is-number": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+                    "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -1460,6 +1934,11 @@
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
             "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+        },
         "fill-range": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -1479,6 +1958,20 @@
                         "is-extendable": "^0.1.0"
                     }
                 }
+            }
+        },
+        "finalhandler": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+            "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+            "requires": {
+                "debug": "2.6.9",
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.3.1",
+                "unpipe": "~1.0.0"
             }
         },
         "find-up": {
@@ -1576,6 +2069,24 @@
                 }
             }
         },
+        "follow-redirects": {
+            "version": "1.5.8",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
+            "integrity": "sha512-sy1mXPmv7kLAMKW/8XofG7o9T+6gAjzdZK4AJF6ryqQYUa/hnzgiypoeUecZ53x7XiqKNEpNqLtS97MshW2nxg==",
+            "requires": {
+                "debug": "=3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
         "font-awesome": {
             "version": "4.7.0",
             "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
@@ -1620,6 +2131,21 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "requires": {
                 "map-cache": "^0.2.2"
+            }
+        },
+        "fresh": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+        },
+        "fs-extra": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+            "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^3.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -2153,6 +2679,38 @@
                 }
             }
         },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "requires": {
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+                    "requires": {
+                        "is-glob": "^2.0.0"
+                    }
+                },
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
         "glob-parent": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -2664,6 +3222,26 @@
                 "ansi-regex": "^2.0.0"
             }
         },
+        "has-binary2": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
+            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
+            "requires": {
+                "isarray": "2.0.1"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+                }
+            }
+        },
+        "has-cors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
+        },
         "has-flag": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
@@ -2736,6 +3314,33 @@
             "resolved": "https://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz",
             "integrity": "sha1-ZouTd26q5V696POtRkswekljYl4="
         },
+        "http-errors": {
+            "version": "1.6.3",
+            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "requires": {
+                "depd": "~1.1.2",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.1.0",
+                "statuses": ">= 1.4.0 < 2"
+            },
+            "dependencies": {
+                "statuses": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+                    "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+                }
+            }
+        },
+        "http-proxy": {
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.15.2.tgz",
+            "integrity": "sha1-ZC/cr/5S00SNK9o7AHnpQJBk2jE=",
+            "requires": {
+                "eventemitter3": "1.x.x",
+                "requires-port": "1.x.x"
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -2746,6 +3351,19 @@
                 "sshpk": "^1.7.0"
             }
         },
+        "iconv-lite": {
+            "version": "0.4.23",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+            "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "immutable": {
+            "version": "3.8.2",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+            "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
+        },
         "import-regex": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/import-regex/-/import-regex-1.1.0.tgz",
@@ -2755,6 +3373,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
             "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc="
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "inflight": {
             "version": "1.0.6",
@@ -2863,6 +3486,19 @@
                 }
             }
         },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE="
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "requires": {
+                "is-primitive": "^2.0.0"
+            }
+        },
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -2902,6 +3538,14 @@
                 "kind-of": "^3.0.2"
             }
         },
+        "is-number-like": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/is-number-like/-/is-number-like-1.0.8.tgz",
+            "integrity": "sha512-6rZi3ezCyFcn5L71ywzz2bS5b2Igl1En3eTlZlvKjpz1n3IZLAYMbKYAIQgFmEu0GENg92ziU/faEOA/aixjbA==",
+            "requires": {
+                "lodash.isfinite": "^3.3.2"
+            }
+        },
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -2921,6 +3565,16 @@
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
                 }
             }
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q="
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU="
         },
         "is-relative": {
             "version": "1.0.0",
@@ -2965,6 +3619,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
             "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         },
         "isarray": {
             "version": "0.0.1",
@@ -3053,6 +3712,14 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+        },
+        "jsonfile": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+            "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+            "requires": {
+                "graceful-fs": "^4.1.6"
+            }
         },
         "jsonify": {
             "version": "0.0.0",
@@ -3170,6 +3837,11 @@
                 "resolve": "^1.1.7"
             }
         },
+        "limiter": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.3.tgz",
+            "integrity": "sha512-zrycnIMsLw/3ZxTbW7HCez56rcFGecWTx5OZNplzcXUUmJLmoYArC6qdJzmAN5BWiNXGcpjhF9RQ1HSv5zebEw=="
+        },
         "load-json-file": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
@@ -3181,6 +3853,75 @@
                 "pinkie-promise": "^2.0.0",
                 "strip-bom": "^2.0.0"
             }
+        },
+        "localtunnel": {
+            "version": "1.9.0",
+            "resolved": "http://registry.npmjs.org/localtunnel/-/localtunnel-1.9.0.tgz",
+            "integrity": "sha512-wCIiIHJ8kKIcWkTQE3m1VRABvsH2ZuOkiOpZUofUCf6Q42v3VIZ+Q0YfX1Z4sYDRj0muiKL1bLvz1FeoxsPO0w==",
+            "requires": {
+                "axios": "0.17.1",
+                "debug": "2.6.8",
+                "openurl": "1.1.1",
+                "yargs": "6.6.0"
+            },
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "requires": {
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "6.6.0",
+                    "resolved": "http://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+                    "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+                    "requires": {
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^4.2.0"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+                    "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+                    "requires": {
+                        "camelcase": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "lodash": {
+            "version": "4.17.11",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
         },
         "lodash._baseassign": {
             "version": "3.2.0",
@@ -3293,6 +4034,11 @@
             "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
             "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U="
         },
+        "lodash.isfinite": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/lodash.isfinite/-/lodash.isfinite-3.3.2.tgz",
+            "integrity": "sha1-+4m2WpqAKBgz8LdHizpRBPiY67M="
+        },
         "lodash.keys": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
@@ -3397,6 +4143,11 @@
             "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
             "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw="
         },
+        "math-random": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w="
+        },
         "merge-stream": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
@@ -3460,6 +4211,11 @@
                     "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 }
             }
+        },
+        "mime": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
         },
         "mime-db": {
             "version": "1.35.0",
@@ -3583,6 +4339,11 @@
                 }
             }
         },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
+        },
         "next-tick": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -3658,6 +4419,11 @@
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
             "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
         },
+        "object-component": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+            "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE="
+        },
         "object-copy": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3682,6 +4448,11 @@
             "version": "1.0.12",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
             "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
+        },
+        "object-path": {
+            "version": "0.9.2",
+            "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.9.2.tgz",
+            "integrity": "sha1-D9mnT8X60a45aLWGvaXGMr1sBaU="
         },
         "object-visit": {
             "version": "1.0.1",
@@ -3736,6 +4507,25 @@
                 "make-iterator": "^1.0.0"
             }
         },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "requires": {
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
+            },
+            "dependencies": {
+                "for-own": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                    "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+                    "requires": {
+                        "for-in": "^1.0.1"
+                    }
+                }
+            }
+        },
         "object.pick": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
@@ -3760,12 +4550,33 @@
                 "make-iterator": "^1.0.0"
             }
         },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "requires": {
+                "ee-first": "1.1.1"
+            }
+        },
         "once": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
             "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
             "requires": {
                 "wrappy": "1"
+            }
+        },
+        "openurl": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/openurl/-/openurl-1.1.1.tgz",
+            "integrity": "sha1-OHW0sO96UsFW8NtB1GCduw+Us4c="
+        },
+        "opn": {
+            "version": "5.3.0",
+            "resolved": "http://registry.npmjs.org/opn/-/opn-5.3.0.tgz",
+            "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
+            "requires": {
+                "is-wsl": "^1.1.0"
             }
         },
         "ordered-read-streams": {
@@ -3828,6 +4639,32 @@
                 "path-root": "^0.1.1"
             }
         },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "requires": {
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
         "parse-import": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/parse-import/-/parse-import-2.0.0.tgz",
@@ -3848,6 +4685,27 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+        },
+        "parseqs": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+            "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+            "requires": {
+                "better-assert": "~1.0.0"
+            }
+        },
+        "parseuri": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+            "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+            "requires": {
+                "better-assert": "~1.0.0"
+            }
+        },
+        "parseurl": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
         },
         "parsleyjs": {
             "version": "2.8.1",
@@ -3947,6 +4805,15 @@
                     "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
                 }
+            }
+        },
+        "portscanner": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
+            "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+            "requires": {
+                "async": "1.5.2",
+                "is-number-like": "^1.0.3"
             }
         },
         "posix-character-classes": {
@@ -4243,6 +5110,11 @@
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
             "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks="
+        },
         "pretty-hrtime": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -4301,6 +5173,44 @@
                     "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
                     "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
                 }
+            }
+        },
+        "randomatic": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+            "requires": {
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
+            },
+            "dependencies": {
+                "is-number": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+                    "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+                },
+                "kind-of": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+                    "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+                }
+            }
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
+        },
+        "raw-body": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+            "requires": {
+                "bytes": "3.0.0",
+                "http-errors": "1.6.3",
+                "iconv-lite": "0.4.23",
+                "unpipe": "1.0.0"
             }
         },
         "read-installed": {
@@ -4507,6 +5417,14 @@
                 }
             }
         },
+        "regex-cache": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+            "requires": {
+                "is-equal-shallow": "^0.1.3"
+            }
+        },
         "regex-not": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -4602,6 +5520,11 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
             "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8="
+        },
         "resolve": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
@@ -4631,6 +5554,15 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
             "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+        },
+        "resp-modifier": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/resp-modifier/-/resp-modifier-6.0.2.tgz",
+            "integrity": "sha1-sSTeXE+6/LpUH0j/pzlw9KpFa08=",
+            "requires": {
+                "debug": "^2.2.0",
+                "minimatch": "^3.0.2"
+            }
         },
         "ret": {
             "version": "0.1.15",
@@ -4697,6 +5629,11 @@
                 "align-text": "^0.1.1"
             }
         },
+        "rx": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+            "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+        },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -4733,6 +5670,63 @@
                 "sver-compat": "^1.5.0"
             }
         },
+        "send": {
+            "version": "0.16.2",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "requires": {
+                "debug": "2.6.9",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
+                "fresh": "0.5.2",
+                "http-errors": "~1.6.2",
+                "mime": "1.4.1",
+                "ms": "2.0.0",
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
+            },
+            "dependencies": {
+                "statuses": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+                    "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+                }
+            }
+        },
+        "serve-index": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
+            "requires": {
+                "accepts": "~1.3.4",
+                "batch": "0.6.1",
+                "debug": "2.6.9",
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
+            }
+        },
+        "serve-static": {
+            "version": "1.13.2",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "requires": {
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
+                "send": "0.16.2"
+            }
+        },
+        "server-destroy": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+            "integrity": "sha1-8Tv5KOQrnD55OD5hzDmYtdFObN0="
+        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -4763,6 +5757,11 @@
                     }
                 }
             }
+        },
+        "setprototypeof": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "slash": {
             "version": "1.0.0",
@@ -4869,6 +5868,134 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "requires": {
                 "kind-of": "^3.2.0"
+            }
+        },
+        "socket.io": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-2.1.1.tgz",
+            "integrity": "sha512-rORqq9c+7W0DAK3cleWNSyfv/qKXV99hV4tZe+gGLfBECw3XEhBy7x85F3wypA9688LKjtwO9pX9L33/xQI8yA==",
+            "requires": {
+                "debug": "~3.1.0",
+                "engine.io": "~3.2.0",
+                "has-binary2": "~1.0.2",
+                "socket.io-adapter": "~1.1.0",
+                "socket.io-client": "2.1.1",
+                "socket.io-parser": "~3.2.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "engine.io-client": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.2.1.tgz",
+                    "integrity": "sha512-y5AbkytWeM4jQr7m/koQLc5AxpRKC1hEVUb/s1FUAWEJq5AzJJ4NLvzuKPuxtDi5Mq755WuDvZ6Iv2rXj4PTzw==",
+                    "requires": {
+                        "component-emitter": "1.2.1",
+                        "component-inherit": "0.0.3",
+                        "debug": "~3.1.0",
+                        "engine.io-parser": "~2.1.1",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "ws": "~3.3.1",
+                        "xmlhttprequest-ssl": "~1.5.4",
+                        "yeast": "0.1.2"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+                },
+                "socket.io-client": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.1.1.tgz",
+                    "integrity": "sha512-jxnFyhAuFxYfjqIgduQlhzqTcOEQSn+OHKVfAxWaNWa7ecP7xSNk2Dx/3UEsDcY7NcFafxvNvKPmmO7HTwTxGQ==",
+                    "requires": {
+                        "backo2": "1.0.2",
+                        "base64-arraybuffer": "0.1.5",
+                        "component-bind": "1.0.0",
+                        "component-emitter": "1.2.1",
+                        "debug": "~3.1.0",
+                        "engine.io-client": "~3.2.0",
+                        "has-binary2": "~1.0.2",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "object-component": "0.0.3",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "socket.io-parser": "~3.2.0",
+                        "to-array": "0.1.4"
+                    }
+                },
+                "socket.io-parser": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.2.0.tgz",
+                    "integrity": "sha512-FYiBx7rc/KORMJlgsXysflWx/RIvtqZbyGLlHZvjfmPTPeuD/I8MaW7cfFrj5tRltICJdgwflhfZ3NVVbVLFQA==",
+                    "requires": {
+                        "component-emitter": "1.2.1",
+                        "debug": "~3.1.0",
+                        "isarray": "2.0.1"
+                    }
+                }
+            }
+        },
+        "socket.io-adapter": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.1.tgz",
+            "integrity": "sha1-KoBeihTWNyEk3ZFZrUUC+MsH8Gs="
+        },
+        "socket.io-client": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.0.4.tgz",
+            "integrity": "sha1-CRilUkBtxeVAs4Dc2Xr8SmQzL44=",
+            "requires": {
+                "backo2": "1.0.2",
+                "base64-arraybuffer": "0.1.5",
+                "component-bind": "1.0.0",
+                "component-emitter": "1.2.1",
+                "debug": "~2.6.4",
+                "engine.io-client": "~3.1.0",
+                "has-cors": "1.1.0",
+                "indexof": "0.0.1",
+                "object-component": "0.0.3",
+                "parseqs": "0.0.5",
+                "parseuri": "0.0.5",
+                "socket.io-parser": "~3.1.1",
+                "to-array": "0.1.4"
+            }
+        },
+        "socket.io-parser": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.1.3.tgz",
+            "integrity": "sha512-g0a2HPqLguqAczs3dMECuA1RgoGFPyvDqcbaDEdCWY9g59kdUAz3YRmaJBNKXflrHNwB7Q12Gkf/0CZXfdHR7g==",
+            "requires": {
+                "component-emitter": "1.2.1",
+                "debug": "~3.1.0",
+                "has-binary2": "~1.0.2",
+                "isarray": "2.0.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+                }
             }
         },
         "sort-keys": {
@@ -4987,6 +6114,11 @@
                 }
             }
         },
+        "statuses": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+        },
         "stream-exhaust": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/stream-exhaust/-/stream-exhaust-1.0.2.tgz",
@@ -4996,6 +6128,15 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
             "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+        },
+        "stream-throttle": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/stream-throttle/-/stream-throttle-0.1.3.tgz",
+            "integrity": "sha1-rdV8jXzHOoFjDTHNVdOWHPr7qcM=",
+            "requires": {
+                "commander": "^2.2.0",
+                "limiter": "^1.0.5"
+            }
         },
         "strict-uri-encode": {
             "version": "1.1.0",
@@ -5061,6 +6202,15 @@
                 "whet.extend": "~0.9.9"
             }
         },
+        "tfunk": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tfunk/-/tfunk-3.1.0.tgz",
+            "integrity": "sha1-OORBT8ZJd9h6/apy+sttKfgve1s=",
+            "requires": {
+                "chalk": "^1.1.1",
+                "object-path": "^0.9.0"
+            }
+        },
         "through2": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
@@ -5121,6 +6271,11 @@
                 "is-absolute": "^1.0.0",
                 "is-negated-glob": "^1.0.0"
             }
+        },
+        "to-array": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
         },
         "to-object-path": {
             "version": "0.3.0",
@@ -5185,6 +6340,11 @@
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
+        "ua-parser-js": {
+            "version": "0.7.17",
+            "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+            "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+        },
         "uglify-js": {
             "version": "2.6.4",
             "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.6.4.tgz",
@@ -5212,6 +6372,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc="
+        },
+        "ultron": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
         },
         "unc-path-regex": {
             "version": "0.1.2",
@@ -5303,6 +6468,16 @@
                 "through2-filter": "^2.0.0"
             }
         },
+        "universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
+        },
         "unset-value": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
@@ -5381,6 +6556,11 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
             "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
+        },
+        "utils-merge": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
             "version": "3.3.2",
@@ -5624,6 +6804,21 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
+        "ws": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "requires": {
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0",
+                "ultron": "~1.1.0"
+            }
+        },
+        "xmlhttprequest-ssl": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
+            "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
+        },
         "xtend": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
@@ -5659,6 +6854,11 @@
                     "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
                 }
             }
+        },
+        "yeast": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -10,10 +10,11 @@
     "dependencies": {
         "backbone": "^1.3.3",
         "bootstrap": "^3.3.7",
+        "browser-sync": "^2.26.0",
         "datatables.net": "^1.10.19",
         "datatables.net-bs": "^2.1.1",
-        "datatables.net-buttons": "^1.5.3",
-        "datatables.net-buttons-bs": "^1.5.3",
+        "datatables.net-buttons": "^1.5.4",
+        "datatables.net-buttons-bs": "^1.5.4",
         "datatables.net-responsive": "^2.2.3",
         "datatables.net-responsive-bs": "^2.2.3",
         "eonasdan-bootstrap-datetimepicker": "^4.17.47",
@@ -22,15 +23,14 @@
         "gulp-concat": "2.6.x",
         "gulp-concat-css": "^3.1.0",
         "gulp-cssnano": "^2.1.3",
-        "gulp-rename": "^1.2.3",
+        "gulp-rename": "^1.4.0",
         "gulp-sourcemaps": "1.6.x",
         "gulp-uglify": "1.5.x",
         "jquery": "^3.3.1",
-        "jsbarcode": "^3.9.0",
+        "jsbarcode": "^3.11.0",
         "merge-stream": "^1.0.0",
         "parsleyjs": "^2.8.1",
         "retire": "^1.6.2",
-        "underscore": "^1.9.1",
-        "browser-sync": "^2.24.6"
+        "underscore": "^1.9.1"
     }
 }


### PR DESCRIPTION
[[HPRO-410](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-410)]

This PR updates our npm dependencies and the `package-lock.json` file.

The original intent of this PR was to get the `package-lock.json` file up to date, because a previous PR had added dependencies to `package.json` but did not update the lock file.  I took this opportunity to update our npm dependencies:

```
+ gulp-rename@1.4.0
+ datatables.net-buttons@1.5.4
+ browser-sync@2.26.0
+ jsbarcode@3.11.0
+ datatables.net-buttons-bs@1.5.4
```

The browser-sync update includes a fix for a low severity vulnerability in `browser-sync > localtunnel > debug`.