### PR TITLE
[HPRO-411] Improve error messages when auth fails

### DIFF
--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -6,6 +6,7 @@ use Memcache;
 use Pmi\Audit\Log;
 use Pmi\Datastore\DatastoreSessionHandler;
 use Pmi\Twig\Provider\TwigServiceProvider;
+use Pmi\Util;
 use Silex\Application;
 use Silex\Provider\CsrfServiceProvider;
 use Silex\Provider\FormServiceProvider;
@@ -334,8 +335,7 @@ abstract class AbstractApplication extends Application
 
             // syslog 500 errors
             if ($code >= 500) {
-                syslog(LOG_CRIT, $e->getMessage());
-                syslog(LOG_INFO, substr($e->getTraceAsString(), 0, 5120)); // log the first 5KB of the stack trace
+                Util::logException($e);
             }
 
             // If not in debug mode or error is < 500, render the error template

--- a/src/Pmi/Security/GoogleGroupsAuthenticator.php
+++ b/src/Pmi/Security/GoogleGroupsAuthenticator.php
@@ -4,6 +4,7 @@ namespace Pmi\Security;
 use Pmi\Application\AbstractApplication;
 use Pmi\Audit\Log;
 use Pmi\HttpClient;
+use Pmi\Util;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
  */
 class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
 {
+    const OAUTH_FAILURE_MESSAGE = 'OAuth Failure';
+
     private $app;
     
     public function __construct(AbstractApplication $app)
@@ -70,15 +73,20 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
                 return $this->buildCredentials(null);
             }
         } elseif ($request->query->get('state') && $request->query->get('state') === $this->app['session']->get('auth_state')) {
-            // process a return from Google authentication
-            $client = $this->getAuthLoginClient();
-            $token = $client->fetchAccessTokenWithAuthCode($request->query->get('code'));
-            $client->setAccessToken($token);
-            $idToken = $client->verifyIdToken();
-            if ($idToken) {
-                $this->app['session']->set('googleUser', new \Pmi\Drc\GoogleUser($idToken['sub'], $idToken['email']));
+            try {
+                // process a return from Google authentication
+                $client = $this->getAuthLoginClient();
+                $token = $client->fetchAccessTokenWithAuthCode($request->query->get('code'));
+                $client->setAccessToken($token);
+                $idToken = $client->verifyIdToken();
+                if ($idToken) {
+                    $this->app['session']->set('googleUser', new \Pmi\Drc\GoogleUser($idToken['sub'], $idToken['email']));
+                }
+                return $this->buildCredentials($this->app->getGoogleUser());
+            } catch (\Exception $e) {
+                Util::logException($e);
+                throw new AuthenticationException(self::OAUTH_FAILURE_MESSAGE);
             }
-            return $this->buildCredentials($this->app->getGoogleUser());
         } elseif ($this->app->getConfig('gae_auth') && $this->app->getGoogleUser()) {
             return $this->buildCredentials($this->app->getGoogleUser());
         } else {
@@ -130,7 +138,9 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
             } else {
                 $template = 'error-auth.html.twig';
             }
-            
+        } elseif ($exception->getMessage() === self::OAUTH_FAILURE_MESSAGE) {
+            $template = 'error-oauth.html.twig';
+            $params = [];
         } elseif ($this->app->getConfig('gae_auth')) {
             $template = 'error-gae-auth.html.twig';
             $params = ['loginUrl' => $this->app->getGoogleLoginUrl()];

--- a/src/Pmi/Security/UserProvider.php
+++ b/src/Pmi/Security/UserProvider.php
@@ -5,6 +5,7 @@ use Symfony\Component\Security\Core\User\UserProviderInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
+use Pmi\Util;
 
 class UserProvider implements UserProviderInterface
 {
@@ -28,8 +29,7 @@ class UserProvider implements UserProviderInterface
                 $groups = $this->app['pmi.drc.appsclient'] ? $this->app['pmi.drc.appsclient']->getGroups($googleUser->getEmail()) : [];
                 $this->app['session']->set('googlegroups', $groups);
             } catch (\Exception $e) {
-                syslog(LOG_CRIT, $e->getMessage());
-                syslog(LOG_INFO, substr($e->getTraceAsString(), 0, 5120)); // log the first 5KB of the stack trace
+                Util::logException($e);
                 throw new AuthenticationException('Failed to retrieve group permissions');
             }
         }

--- a/src/Pmi/Util.php
+++ b/src/Pmi/Util.php
@@ -46,4 +46,10 @@ class Util
         }
         return true;
     }
+
+    public static function logException($exception)
+    {
+        syslog(LOG_CRIT, $exception->getMessage());
+        syslog(LOG_INFO, substr($exception->getTraceAsString(), 0, 5120)); // log the first 5KB of the stack trace
+    }
 }

--- a/views/error-auth.html.twig
+++ b/views/error-auth.html.twig
@@ -2,7 +2,12 @@
 {% block title %}Error - {% endblock %}
 {% block body %}
     <div class="alert alert-danger">
-        <span class="glyphicon glyphicon-thumbs-down"></span>
-        <strong>Access denied!</strong> You are currently logged into Google as <strong>{{ email }}</strong>, but this account does not have access to HealthPro. You may <a href="{{ logoutUrl }}">log out of your current Google account</a> and select a different one.
+        <p>
+            <span class="glyphicon glyphicon-thumbs-down"></span>
+            <strong>Access denied!</strong> You are currently logged into Google as <strong>{{ email }}</strong>, but this account does not have access to HealthPro. It is also possible that the authorization service is down.
+        </p>
+        <p>
+            You may <a href="{{ logoutUrl }}">log out of your current Google account</a> to try again or log in with a different account.
+        </p>
     </div>
 {% endblock %}

--- a/views/error-oauth.html.twig
+++ b/views/error-oauth.html.twig
@@ -1,0 +1,10 @@
+{% extends 'base.html.twig' %}
+{% block title %}Error - {% endblock %}
+{% block body %}
+    <div class="alert alert-danger">
+        <p>
+            <span class="glyphicon glyphicon-thumbs-down"></span>
+            <strong>An error occurred.</strong> Sorry, there was a problem logging you in to HealthPro.  Please <a href="{{ logoutUrl }}">try again</a>.
+        </p>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Previously, if the OAuth workflow or the retrieval of Google Group membership fails for some reason, a generic 500 was thrown.

This PR catches errors for both of these failures and displays a more helpful error message.

Also, by throwing the proper `Symfony\Component\Security\Core\Exception\AuthenticationException` exception, this allows the user to refresh the page to restart the auth process again, instead of just recreating the error (in the case of a failed OAuth handoff).