### PR TITLE
[HPRO-408] Add withdrawal reason to participant page and work queue

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -298,6 +298,7 @@ class WorkQueueController extends AbstractController
                 $headers[] = $label . ' Collection Date';
             }
             $headers[] = 'Biospecimens Site';
+            $headers[] = 'Withdrawal Reason';
             fputcsv($output, $headers);
 
             for ($i = 0; $i < ceil(WorkQueue::LIMIT_EXPORT / WorkQueue::LIMIT_EXPORT_PAGE_SIZE); $i++) {
@@ -363,6 +364,7 @@ class WorkQueueController extends AbstractController
                         $row[] = WorkQueue::dateFromString($participant->{"sampleStatus{$newSample}Time"}, $app->getUserTimezone());
                     }
                     $row[] = $participant->orderCreatedSite;
+                    $row[] = $participant->withdrawalReason;
                     fputcsv($output, $row);
                 }
                 unset($participants);

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -12,6 +12,7 @@ class WorkQueue
 
     protected $app;
 
+    // These are used to map a DataTables column index to an RDR field for sorting
     public static $wQColumns = [
         'lastName',
         'firstName',
@@ -24,6 +25,7 @@ class WorkQueue
         'consentForElectronicHealthRecordsTime',
         'consentForCABoRTime',
         'withdrawalTime',
+        'withdrawalReason',
         'recontactMethod',
         'streetAddress',
         'email',

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -270,8 +270,9 @@ class WorkQueue
             if ($participant->withdrawalStatus == 'NO_USE') {
                 $row['withdrawal'] = self::HTML_DANGER . ' <span class="text-danger">No Use</span> - ' . self::dateFromString($participant->withdrawalTime, $app->getUserTimezone());
             } else {
-                $row['withdrawal'] = ''; 
+                $row['withdrawal'] = '';
             }
+            $row['withdrawalReason'] = $e($participant->withdrawalReason);
 
             //Contact
             $row['contactMethod'] = $e($participant->recontactMethod);

--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -248,7 +248,15 @@
                                     <h3 class="panel-title"><i class="fa fa-times-circle" aria-hidden="true"></i> {{ errorTitle }}</h3>
                                 </div>
                                 <div class="panel-body">
-                                    {{ errorMessage }}
+                                    <p>{{ errorMessage }}</p>
+                                    {% if participant.statusReason == 'withdrawal' and participant.withdrawalReason is not empty %}
+                                        <p>
+                                            <strong>Reason:</strong> {{ participant.withdrawalReason }}
+                                            {% if participant.withdrawalReasonJustification is not empty %}
+                                                <br /><strong>Justification:</strong> {{ participant.withdrawalReasonJustification }}
+                                            {% endif %}
+                                        </p>
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>

--- a/views/workqueue/index.html.twig
+++ b/views/workqueue/index.html.twig
@@ -86,14 +86,14 @@
                 <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Paired Site {{ display_message('pairing_info', 'tooltip')|raw }}</th>
                 <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Paired Organization {{ display_message('pairing_info', 'tooltip')|raw }}</th>
                 <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Phys Measurements</th>
-                <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Phys Meas Site</th>
+                <th class="secondaryheader col-group-inperson multiheader-inperson">Phys Meas Site</th>
                 <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Samples for DNA Received?</th>
                 <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Bio&shy;specimens</th>
                 {% for field, label in samples %}
                     <th class="secondaryheader col-group-inperson multiheader-inperson">{{ label }}</th>
                     <th class="secondaryheader col-group-inperson-time multiheader-inperson">{{ label }} Date</th>
                 {% endfor %}
-                <th class="secondaryheader col-group-inperson col-group-default multiheader-inperson">Bio&shy;specimens Site</th>
+                <th class="secondaryheader col-group-inperson multiheader-inperson">Bio&shy;specimens Site</th>
 
                 <th class="secondaryheader col-group-demographics multiheader-demographics">Age</th>
                 <th class="secondaryheader col-group-demographics multiheader-demographics">Sex</th>

--- a/views/workqueue/index.html.twig
+++ b/views/workqueue/index.html.twig
@@ -60,6 +60,7 @@
                 <th rowspan="2" class="col-group-default col-group-info">EHR Consent</th>
                 <th rowspan="2" class="col-group-info">CABoR Consent <span title="California Research Subjects' Bill of Rights is required for participants only by enrollment sites in California" data-toggle="tooltip" data-container="body"><i class="fa fa-question-circle text-info"></i></span></th>
                 <th rowspan="2" class="col-group-default col-group-info">Withdrawal</th>
+                <th rowspan="2" class="col-group-info">Withdrawal Reason</th>
 
                 <th colspan="4" class="topheader multiheader-contact">Contact</th>
 

--- a/web/assets/js/views/workqueue.js
+++ b/web/assets/js/views/workqueue.js
@@ -47,6 +47,7 @@ $(document).ready(function() {
       { name: 'ehrConsent', data: 'ehrConsent', class: 'text-center' },
       { name: 'caborConsent', visible: false, data: 'caborConsent', class: 'text-center' },
       { name: 'withdrawal', data: 'withdrawal', class: 'text-center' },
+      { name: 'withdrawalReason', visible: false, data: 'withdrawalReason', class: 'text-center' },
       { name: 'contactMethod', visible: false, data: 'contactMethod', orderable: false },
       { name: 'address', visible: false, data: 'address'},
       { name: 'email', visible: false, data: 'email' },


### PR DESCRIPTION
[[HPRO-408](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-408)]

* Adds the withdrawal reason (and justification if it exists) to the message that is displayed when viewing a withdrawn participant (screenshot below)
* Adds the withdrawal reason to the work queue (table and CSV export)
* Fixes a bug where the biospecimen and physical measurements site columns in the work queue were incorrectly associated with the default column group button.

### Example withdrawn participant error message

![screen shot 2018-10-17 at 4 01 52 pm](https://user-images.githubusercontent.com/860499/47116005-fe7c9300-d225-11e8-8df2-5f2397a4961d.png)
