### PR TITLE
[HPRO-415] Add link to open embedded PDFs

### DIFF
--- a/views/help/faq.html.twig
+++ b/views/help/faq.html.twig
@@ -9,6 +9,7 @@
     <div class="page-header">
         <h2><i class="fa fa-question-circle-o" aria-hidden="true"></i> Technical FAQs</h2>
     </div>
+    <div class="text-right"><a class="pull-right" href="{{ asset('HealthPro Frequently Asked Questions.pdf') }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Open/Download</a></div>
     <iframe class="pdf" name="pdf" src="{{ asset('HealthPro Frequently Asked Questions.pdf') }}#view=FitH"></iframe>
     {% include 'help/footer.html.twig' %}
 {% endblock %}

--- a/views/help/sop-pdf.html.twig
+++ b/views/help/sop-pdf.html.twig
@@ -10,6 +10,7 @@
     <div class="page-header">
         <h2><i class="fa fa-file-text-o" aria-hidden="true"></i> {{ sop }} <small>{{ title }}</small></h2>
     </div>
+    <div class="text-right"><a class="pull-right" href="{{ path('help_sopFile', { id: sop }) }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Open/Download</a></div>
     <iframe class="pdf" name="pdf" src="{{ path('help_sopFile', { id: sop }) }}#view=FitH"></iframe>
     {% include 'help/footer.html.twig' %}
 {% endblock %}

--- a/views/order-print-labels.html.twig
+++ b/views/order-print-labels.html.twig
@@ -7,6 +7,7 @@
             {% if order.printed_ts and errorMessage is empty %}
                 <div class="panel panel-default">
                     <div class="panel-heading">
+                        <a class="pull-right" href="{{ path('orderLabelsPdf', { participantId: participant.id, orderId: order.id }) }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Open/Download</a>
                         <h3 class="panel-title">Labels</h3>
                     </div>
                     <div class="panel-body">

--- a/views/order-print-requisition.html.twig
+++ b/views/order-print-requisition.html.twig
@@ -7,6 +7,7 @@
             {% if order.mayo_id is not empty %}
                 <div class="panel panel-default">
                     <div class="panel-heading">
+                        <a class="pull-right" href="{{ path('orderRequisitionPdf', { participantId: participant.id, orderId: order.id, type: 'requisition' }) }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Open/Download</a>
                         <h3 class="panel-title">Requisition</h3>
                     </div>
                     <div class="panel-body">

--- a/views/order-print-requisition.html.twig
+++ b/views/order-print-requisition.html.twig
@@ -7,7 +7,7 @@
             {% if order.mayo_id is not empty %}
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        <a class="pull-right" href="{{ path('orderRequisitionPdf', { participantId: participant.id, orderId: order.id, type: 'requisition' }) }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Open/Download</a>
+                        <a class="pull-right" href="{{ path('orderRequisitionPdf', { participantId: participant.id, orderId: order.id }) }}" target="_blank"><i class="fa fa-external-link" aria-hidden="true"></i> Open/Download</a>
                         <h3 class="panel-title">Requisition</h3>
                     </div>
                     <div class="panel-body">
@@ -19,7 +19,7 @@
                                 </a>
                             </p>
                         </div>
-                        <iframe name="requisition" class="pdf pdf-requisition" src="{{ path('orderRequisitionPdf', { participantId: participant.id, orderId: order.id, type: 'requisition' }) }}#view=FitH"></iframe>
+                        <iframe name="requisition" class="pdf pdf-requisition" src="{{ path('orderRequisitionPdf', { participantId: participant.id, orderId: order.id }) }}#view=FitH"></iframe>
                     </div>
                 </div>
             {% else %}


### PR DESCRIPTION
[[HPRO-415](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-415)]

Users who's browsers are configured to not allow embedded PDFs previously had no way of downloading or opening the PDFs in a new window/tab.  This adds a link that opens the PDF in a new window.  If a browser is not configured to view PDFs at all (embedded or not), the PDF will be downloaded (and, at least in Chrome, the new tab will be automatically closed).

A direct link to PDFs has been added for biobank order labels, biobank order requisitions, and SOP documents.

### Chrome setting that breaks embedded PDFs
![screen shot 2018-10-17 at 4 27 55 pm](https://user-images.githubusercontent.com/860499/47117363-c5462200-d229-11e8-88bf-bd82f8206ba8.png)

### New open/download link
![screen shot 2018-10-17 at 4 28 07 pm](https://user-images.githubusercontent.com/860499/47117383-d131e400-d229-11e8-89d8-b9200375274a.png)
