### PR TITLE
v1.5.0 Update reason codes

### DIFF
--- a/src/Pmi/Evaluation/Evaluation.php
+++ b/src/Pmi/Evaluation/Evaluation.php
@@ -45,13 +45,13 @@ class Evaluation
     }
 
     public static $cancelReasons = [
-        'Data entered for wrong participant' => 'DATA_ENTERED_WRONG_PARTICIPANT',
+        'Data entered for wrong participant' => 'PM_CANCEL_WRONG_PARTICIPANT',
         'Other' => 'OTHER'
     ];
 
     public static $restoreReasons = [
-        'Physical Measurements cancelled for wrong participant' => 'PM_CANCELLED_WRONG_PARTICIPANT',
-        'Physical Measurements can be amended versus cancelled' => 'PM_CAN_AMENDED_VERSUS_CANCELLED',
+        'Physical Measurements cancelled for wrong participant' => 'PM_RESTORE_WRONG_PARTICIPANT',
+        'Physical Measurements can be amended versus cancelled' => 'PM_RESTORE_AMEND',
         'Other' => 'OTHER'
     ];
 

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1122,11 +1122,15 @@ class Order
         $reasons = self::$$reasonType;
         // Remove change tracking number option for non-kit orders
         if ($type === self::ORDER_UNLOCK && $this->order['type'] !== 'kit') {
-            unset($reasons['Change Tracking number']);
+            if (($key = array_search('ORDER_AMEND_TRACKING', $reasons)) !== false) {
+                unset($reasons[$key]);
+            }
         }
         // Remove label error option for kit orders
         if ($type === self::ORDER_CANCEL && $this->order['type'] === 'kit') {
-            unset($reasons['Labeling error identified after Finalization']);
+            if (($key = array_search('ORDER_CANCEL_LABEL_ERROR', $reasons)) !== false) {
+                unset($reasons[$key]);
+            }
         }
         $orderModifyForm->add('reason', Type\ChoiceType::class, [
             'label' => 'Reason',

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -87,22 +87,22 @@ class Order
     ];
 
     public static $cancelReasons = [
-        'Order created in error' => 'ORDER_CREATED_ERROR',
-        'Order created for wrong participant' => 'ORDER_CREATED_WRONG_PARTICIPANT',
-        'Labeling error identified after finalization' => 'LABELING_ERROR_AFTER_FINALIZATION',
+        'Order created in error' => 'ORDER_CANCEL_ERROR',
+        'Order created for wrong participant' => 'ORDER_CANCEL_WRONG_PARTICIPANT',
+        'Labeling error identified after finalization' => 'ORDER_CANCEL_LABEL_ERROR',
         'Other' => 'OTHER'
     ];
 
     public static $unlockReasons = [
-        'Add/Remove collected or processed samples' => 'ADD_REMOVE_SAMPLES',
-        'Change collection or processing timestamps' => 'CHANGE_SAMPLES_TIMESTAMPS',
-        'Change Tracking number' => 'CHANGE_TRACKING_NUMBER',
+        'Add/Remove collected or processed samples' => 'ORDER_AMEND_SAMPLES',
+        'Change collection or processing timestamps' => 'ORDER_AMEND_TIMESTAMPS',
+        'Change Tracking number' => 'ORDER_AMEND_TRACKING',
         'Other' => 'OTHER'
     ];
 
     public static $restoreReasons = [
-        'Order cancelled for wrong participant' => 'ORDER_CANCELLED_WRONG_PARTICIPANT',
-        'Order can be amended versus cancelled' => 'ORDER_CAN_AMENDED_VERSUS_CANCELLED',
+        'Order cancelled for wrong participant' => 'ORDER_RESTORE_WRONG_PARTICIPANT',
+        'Order can be amended versus cancelled' => 'ORDER_RESTORE_AMEND',
         'Other' => 'OTHER'
     ];
 


### PR DESCRIPTION
Updates reason "codes" for consistency and clarity.  ("Codes" in quotes because these are still just free text fields in the RDR, but we want to maintain some consistency if/when the reason labels change).  The codes now all start with `(ORDER|PM)_(CANCEL|RESTORE|AMEND)`.

I also changed the way reasons are conditionally removed so that they are removed based on the code, and not the label.

Note: this also fixes a bug where the labeling error reason wasn't removed from the reasons when cancelling a DV kit order due to case sensitivity.