### PR TITLE
[HPRO-434] Minor changes to error messages and other text

### DIFF
--- a/src/Pmi/Controller/AdminController.php
+++ b/src/Pmi/Controller/AdminController.php
@@ -206,7 +206,7 @@ class AdminController extends AbstractController
                 'disabled' => $disabled,
             ])
             ->add('mayolink_account', Type\TextType::class, [
-                'label' => 'MayoLink Account',
+                'label' => 'MayoLINK Account',
                 'required' => false,
                 'constraints' => new Constraints\Type('string'),
                 'disabled' => $disabled && $isProd,

--- a/src/Pmi/Controller/OrderController.php
+++ b/src/Pmi/Controller/OrderController.php
@@ -728,10 +728,10 @@ class OrderController extends AbstractController
                 $result['status'] = 'success';
                 $result['pdf'] = $pdf;
             } else {
-                $result['errorMessage'] = 'Error loading print labels.';
+                $result['errorMessage'] = 'Error loading labels.';
             }         
         } else {
-            $result['errorMessage'] = 'Mayo account number is not set for this site. Please contact the administrator.';
+            $result['errorMessage'] = 'A MayoLINK account number is not set for this site. Please contact an administrator.';
         }
         return $result;
     }

--- a/views/admin/sites/index.html.twig
+++ b/views/admin/sites/index.html.twig
@@ -14,7 +14,7 @@
     </p>
     {% if sites|length > 0 %}
         <table class="table table-striped table-hover">
-            <thead><tr><th>ID</th><th>Name</th><th>Status</th><th>Google Group</th><th>Awardee</th><th>Organization</th><th>MayoLink Account</th><th>Type</th><th>Email</th></tr></thead>
+            <thead><tr><th>ID</th><th>Name</th><th>Status</th><th>Google Group</th><th>Awardee</th><th>Organization</th><th>MayoLINK Account</th><th>Type</th><th>Email</th></tr></thead>
             <tbody>
             {% for site in sites %}
                 <tr>

--- a/views/order-print-labels.html.twig
+++ b/views/order-print-labels.html.twig
@@ -25,10 +25,10 @@
             {% else %}
                 <div class="panel panel-danger">
                     <div class="panel-heading">
-                        <h3 class="panel-title"><i class="fa fa-times-circle" aria-hidden="true"></i>Error</h3>
+                        <h3 class="panel-title"><i class="fa fa-times-circle" aria-hidden="true"></i> Error</h3>
                     </div>
                     <div class="panel-body">
-                        {{ errorMessage|default('Error loading print labels.') }}
+                        {{ errorMessage|default('Error loading labels.') }}
                     </div>
                 </div>
             {% endif %}

--- a/views/order-print-requisition.html.twig
+++ b/views/order-print-requisition.html.twig
@@ -7,9 +7,9 @@
             {% if order.status == 'edit' or order.status == 'unlock' %}
                 <div class="alert alert-warning" role="alert">
                     {% if order.status == 'edit' %}
-                        This order was edited and finalized so print requisition cannot be generated.
+                        The requisition cannot be generated for edited and finalized orders.
                     {% else %}
-                        Print requisition cannot be generated for unlocked orders.
+                        The requisition cannot be generated for unlocked orders.
                     {% endif %}
                 </div>
             {% elseif order.mayo_id is not empty %}


### PR DESCRIPTION
[[HPRO-434](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-434)]

* Adds a space between the label error icon and title in the panel heading
* Fixes language to consistently refer to "labels" and "requisition"
* Fixes capitalization of MayoLINK