### PR TITLE
[HPRO-438] Replace Retire.js with npm audit

### DIFF
--- a/.retireignore.json
+++ b/.retireignore.json
@@ -1,7 +1,0 @@
-[
-    { 
-        "component": "bootstrap",
-        "identifiers" : { "issue": "20184"},
-        "justification" : "https://github.com/twbs/bootstrap/issues/20184 is not a vulnerability in our application because we do not set any data-target attributes dynamically."
-    }
-]

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,17 +18,6 @@
             "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
             "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
         },
-        "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-            "requires": {
-                "co": "^4.6.0",
-                "fast-deep-equal": "^1.0.0",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.3.0"
-            }
-        },
         "align-text": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
@@ -243,21 +232,6 @@
             "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
             "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
         },
-        "asap": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-            "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-        },
-        "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
-        },
-        "assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-        },
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -302,11 +276,6 @@
                 "async-done": "^1.2.2"
             }
         },
-        "asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-        },
         "atob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
@@ -324,16 +293,6 @@
                 "postcss": "^5.2.16",
                 "postcss-value-parser": "^3.2.3"
             }
-        },
-        "aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-        },
-        "aws4": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
         },
         "axios": {
             "version": "0.17.1",
@@ -452,15 +411,6 @@
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
             "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY="
-        },
-        "bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-            "optional": true,
-            "requires": {
-                "tweetnacl": "^0.14.3"
-            }
         },
         "beeper": {
             "version": "1.1.1",
@@ -808,11 +758,6 @@
             "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000830.tgz",
             "integrity": "sha1-bkUlWzRWSf0V/1kHLaHhK7PeLxM="
         },
-        "caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-        },
         "center-align": {
             "version": "0.1.3",
             "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
@@ -923,11 +868,6 @@
                 "through2": "^2.0.1"
             }
         },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
-        },
         "coa": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
@@ -1010,14 +950,6 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
             "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
-        },
-        "combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-            "requires": {
-                "delayed-stream": "~1.0.0"
-            }
         },
         "commander": {
             "version": "2.5.1",
@@ -1238,14 +1170,6 @@
                 "es5-ext": "^0.10.9"
             }
         },
-        "dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
-        },
         "datatables.net": {
             "version": "1.10.19",
             "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.10.19.tgz",
@@ -1341,11 +1265,6 @@
                 "ms": "2.0.0"
             }
         },
-        "debuglog": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
-            "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
-        },
         "decamelize": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -1437,11 +1356,6 @@
             "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
             "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
         },
-        "delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
         "depd": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -1461,15 +1375,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
             "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA="
-        },
-        "dezalgo": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.3.tgz",
-            "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
-            "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-            }
         },
         "duplexer2": {
             "version": "0.0.2",
@@ -1547,15 +1452,6 @@
             "integrity": "sha1-oyWqXlPROiIliJsqxBE7K5Y29Pw=",
             "requires": {
                 "tfunk": "^3.0.1"
-            }
-        },
-        "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
-            "optional": true,
-            "requires": {
-                "jsbn": "~0.1.0"
             }
         },
         "ee-first": {
@@ -1673,6 +1569,13 @@
                 "jquery": "^1.8.3 || ^2.0 || ^3.0",
                 "moment": "^2.10",
                 "moment-timezone": "^0.4.0"
+            },
+            "dependencies": {
+                "bootstrap": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.0.tgz",
+                    "integrity": "sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw=="
+                }
             }
         },
         "error-ex": {
@@ -1906,11 +1809,6 @@
                 }
             }
         },
-        "extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-        },
         "fancy-log": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
@@ -1919,16 +1817,6 @@
                 "chalk": "^1.1.1",
                 "time-stamp": "^1.0.0"
             }
-        },
-        "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "fast-json-stable-stringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "filename-regex": {
             "version": "2.0.1",
@@ -2105,21 +1993,6 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
             "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
-        },
-        "forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-        },
-        "form-data": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-            "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-            "requires": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "^2.1.12"
-            }
         },
         "fragment-cache": {
             "version": "0.2.1",
@@ -2643,14 +2516,6 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
             "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
-        },
-        "getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-            "requires": {
-                "assert-plus": "^1.0.0"
-            }
         },
         "glob": {
             "version": "7.1.2",
@@ -3188,20 +3053,6 @@
                 "glogg": "^1.0.0"
             }
         },
-        "har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-            "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-            }
-        },
         "has": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
@@ -3335,16 +3186,6 @@
             "requires": {
                 "eventemitter3": "1.x.x",
                 "requires-port": "1.x.x"
-            }
-        },
-        "http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
             }
         },
         "iconv-lite": {
@@ -3593,11 +3434,6 @@
                 "html-comment-regex": "^1.1.0"
             }
         },
-        "is-typedarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-        },
         "is-unc-path": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -3651,11 +3487,6 @@
                 }
             }
         },
-        "isstream": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-        },
         "jquery": {
             "version": "3.3.1",
             "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
@@ -3680,27 +3511,6 @@
             "resolved": "https://registry.npmjs.org/jsbarcode/-/jsbarcode-3.11.0.tgz",
             "integrity": "sha512-/ozCd7wsa+VIHo9sUc03HneVEQrH7cVWfJolUT/WOW1m8mJ2e3iYZje6C9X3LFHdczlesqFHRpxLtbVsNtjyow=="
         },
-        "jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "optional": true
-        },
-        "json-parse-better-errors": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
-        },
-        "json-schema": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
-        },
-        "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
         "json-stable-stringify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
@@ -3708,11 +3518,6 @@
             "requires": {
                 "jsonify": "~0.0.0"
             }
-        },
-        "json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsonfile": {
             "version": "3.0.1",
@@ -3726,17 +3531,6 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
-        },
-        "jsprim": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
-            "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-            "requires": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.2.3",
-                "verror": "1.10.0"
-            }
         },
         "just-debounce": {
             "version": "1.0.0",
@@ -4407,11 +4201,6 @@
             "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
-        "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
-        },
         "object-assign": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
@@ -4763,11 +4552,6 @@
                 "pify": "^2.0.0",
                 "pinkie-promise": "^2.0.0"
             }
-        },
-        "performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "pify": {
             "version": "2.3.0",
@@ -5142,20 +4926,10 @@
                 "pump": "^2.0.0"
             }
         },
-        "punycode": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        },
         "q": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
             "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-        },
-        "qs": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "query-string": {
             "version": "4.3.4",
@@ -5211,69 +4985,6 @@
                 "unpipe": "1.0.0"
             }
         },
-        "read-installed": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
-            "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
-            "requires": {
-                "debuglog": "^1.0.1",
-                "graceful-fs": "^4.1.2",
-                "read-package-json": "^2.0.0",
-                "readdir-scoped-modules": "^1.0.0",
-                "semver": "2 || 3 || 4 || 5",
-                "slide": "~1.1.3",
-                "util-extend": "^1.0.1"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                    "optional": true
-                }
-            }
-        },
-        "read-package-json": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.13.tgz",
-            "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
-            "requires": {
-                "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-better-errors": "^1.0.1",
-                "normalize-package-data": "^2.0.0",
-                "slash": "^1.0.0"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "7.1.2",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-                    "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-                    "requires": {
-                        "fs.realpath": "^1.0.0",
-                        "inflight": "^1.0.4",
-                        "inherits": "2",
-                        "minimatch": "^3.0.4",
-                        "once": "^1.3.0",
-                        "path-is-absolute": "^1.0.0"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                    "optional": true
-                },
-                "minimatch": {
-                    "version": "3.0.4",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                    "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-                    "requires": {
-                        "brace-expansion": "^1.1.7"
-                    }
-                }
-            }
-        },
         "read-pkg": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -5302,24 +5013,6 @@
                 "inherits": "~2.0.1",
                 "isarray": "0.0.1",
                 "string_decoder": "~0.10.x"
-            }
-        },
-        "readdir-scoped-modules": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.0.2.tgz",
-            "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
-            "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-                }
             }
         },
         "readdirp": {
@@ -5481,33 +5174,6 @@
                 "remove-trailing-separator": "^1.1.0"
             }
         },
-        "request": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
-            }
-        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5566,17 +5232,6 @@
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
             "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
-        },
-        "retire": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/retire/-/retire-1.6.2.tgz",
-            "integrity": "sha512-kw1D0yrWmhylMYVmlTWgh7NnYUw9dk9dLBcDu6MOqcFrFv8KVP+2rXks7T+w4H7SEj+0m4Gg2jm6DfMJ2etmAg==",
-            "requires": {
-                "commander": "2.5.x",
-                "read-installed": "^4.0.3",
-                "request": "~2.x.x",
-                "walkdir": "0.0.7"
-            }
         },
         "rework": {
             "version": "1.0.1",
@@ -5768,16 +5423,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
-        "slash": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-            "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
-        },
-        "slide": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-            "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -6100,22 +5745,6 @@
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
-        "sshpk": {
-            "version": "1.14.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
-            "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
-            "requires": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            }
-        },
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -6344,28 +5973,6 @@
                 "through2": "^2.0.3"
             }
         },
-        "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-            "requires": {
-                "punycode": "^1.4.1"
-            }
-        },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
-        "tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "optional": true
-        },
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6583,20 +6190,10 @@
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
-        "util-extend": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
-            "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
-        },
         "utils-merge": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
-        },
-        "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
         },
         "v8flags": {
             "version": "3.1.1",
@@ -6624,16 +6221,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
             "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ=="
-        },
-        "verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-            "requires": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
         },
         "vinyl": {
             "version": "0.5.3",
@@ -6787,11 +6374,6 @@
             "requires": {
                 "source-map": "^0.5.1"
             }
-        },
-        "walkdir": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
-            "integrity": "sha1-BNoCcKh6d4VAFzzb8KLbSZqNnik="
         },
         "whet.extend": {
             "version": "0.9.9",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
         "jsbarcode": "^3.11.0",
         "merge-stream": "^1.0.0",
         "parsleyjs": "^2.8.1",
-        "retire": "^1.6.2",
         "underscore": "^1.9.1"
     }
 }

--- a/src/Pmi/Console/Command/DeployCommand.php
+++ b/src/Pmi/Console/Command/DeployCommand.php
@@ -156,7 +156,7 @@ class DeployCommand extends Command {
             // ensure that we are up-to-date with the latest NPM dependencies
             $output->writeln('');
             $output->writeln("Checking NPM dependencies...");
-            $this->exec("npm install");
+            $this->exec("npm install --no-audit"); // npm audit will be run below in the runJsSecurityCheck method
 
             // compile (concat/minify/copy) assets
             $output->writeln('');

--- a/src/Pmi/Console/Command/DeployCommand.php
+++ b/src/Pmi/Console/Command/DeployCommand.php
@@ -563,7 +563,7 @@ class DeployCommand extends Command {
     {
         $this->out->writeln("Running npm audit...");
         $process = $this->exec('npm audit', false);
-        if ($process->getExitCode() == 0) {
+        if ($process->getExitCode() === 0) {
             $this->out->writeln('No node modules have known vulnerabilities');
         } else {
             $this->out->writeln('');

--- a/src/Pmi/Console/Command/DeployCommand.php
+++ b/src/Pmi/Console/Command/DeployCommand.php
@@ -561,11 +561,11 @@ class DeployCommand extends Command {
 
     private function runJsSecurityCheck()
     {
-        $this->out->writeln("Running RetireJS scanner...");
-        $process = $this->exec("{$this->appDir}/node_modules/retire/bin/retire --nocache --nodepath {$this->appDir}/node_modules --jspath {$this->appDir}/web/assets/dist/js", false);
+        $this->out->writeln("Running npm audit...");
+        $process = $this->exec('npm audit', false);
         if ($process->getExitCode() == 0) {
-            $this->out->writeln('No JS files or node modules have known vulnerabilities');
-        } else {            
+            $this->out->writeln('No node modules have known vulnerabilities');
+        } else {
             $this->out->writeln('');
             $helper = $this->getHelper('question');
             if (!$helper->ask($this->in, $this->out, new ConfirmationQuestion('<error>Continue despite JS security vulnerabilities?</error> '))) {


### PR DESCRIPTION
[[HPRO-438](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-438)]

Note that the audit output will show up twice when building, since non-local builds run `npm install` first, which will include the audit status.  `npm audit` is later run separately so that we can catch the non-0 exit code if there are vulnerabilities.