### PR TITLE
[HPRO-444] Add invalid site check exception for TEST awardee

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -456,18 +456,23 @@ class HpoApplication extends AbstractApplication
     public function isValidSite($email)
     {
         $user = $this->getUser();
-        if ($this->isProd() && $user && $user->belongsToSite($email)) {
-            $site = $user->getSite($email);
-            $sites = $this['em']->getRepository('sites')->fetchOneBy([
-                'google_group' => $site->id,
+        if (!$user || !$user->belongsToSite($email)) {
+            return false;
+        }
+        if ($this->isProd()) {
+            $siteGroup = $user->getSite($email);
+            $site = $this['em']->getRepository('sites')->fetchOneBy([
+                'google_group' => $siteGroup->id,
             ]);
-            // check if the site exists and has a mayolink account number
-            if (!empty($sites) && !empty($sites['mayolink_account']) ) {
-                return true;
-            } else {
+            if (!$site) {
+                return false;
+            }
+            if (empty($site['mayolink_account']) && $site['awardee_id'] !== 'TEST') {
+                // Site is invalid if it doesn't have a MayoLINK account id, unless it is in the TEST awardee
                 return false;
             }
         }
+
         return true;
     }
 


### PR DESCRIPTION
[[HPRO-444](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-444)]

This allows users to proceed with selecting a TEST site (e.g. "Prod HPO Site A") even if it is not configured with a MayoLINK ID.  Users in this site are not able to create orders so the MayoLINK ID does not need to be set.