### PR TITLE
[DASH1-72] Track tab views in Dashboard

### DIFF
--- a/views/base-head.html.twig
+++ b/views/base-head.html.twig
@@ -47,4 +47,11 @@
     gtag('js', new Date());
     gtag('config', {{ app.getConfig('google_analytics_property')|json_encode|raw }});
 </script>
+{% else %}
+<!-- Analytics Tracking Disabled -->
+<script>
+var ga = function () {
+  console.log('Google Analytics Mock:', arguments);
+}
+</script>
 {% endif %}

--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -212,7 +212,7 @@
                         PLOTS_SHOWN['total-progress-nav'] = true;
                     }
                     // Send pageview event for tab
-                    ga('set', 'page', '/dasboard/total-progress');
+                    ga('set', 'page', '/dashboard/total-progress');
                     ga('send', 'pageview');
                 });
 
@@ -420,7 +420,7 @@
                   PLOTS_SHOWN['real-time-nav'] = true;
                 }
                 // Send pageview event for tab
-                ga('set', 'page', '/dasboard/real-time');
+                ga('set', 'page', '/dashboard/real-time');
                 ga('send', 'pageview');
               });
 
@@ -581,7 +581,7 @@
                         PLOTS_SHOWN['participants-by-region-nav'] = true;
                     }
                     // Send pageview event for tab
-                    ga('set', 'page', '/dasboard/participants-by-region');
+                    ga('set', 'page', '/dashboard/participants-by-region');
                     ga('send', 'pageview');
                 });
 
@@ -729,7 +729,7 @@
                         PLOTS_SHOWN['participants-by-lifecycle-nav'] = true;
                     }
                     // Send pageview event for tab
-                    ga('set', 'page', '/dasboard/participants-by-lifecycle');
+                    ga('set', 'page', '/dashboard/participants-by-lifecycle');
                     ga('send', 'pageview');
                 });
 

--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -212,8 +212,7 @@
                         PLOTS_SHOWN['total-progress-nav'] = true;
                     }
                     // Send pageview event for tab
-                    ga('set', 'page', '/dashboard/total-progress');
-                    ga('send', 'pageview');
+                    ga('send', 'pageview', '/dashboard/total-progress');
                 });
 
                 // re-render on filter change
@@ -420,8 +419,7 @@
                   PLOTS_SHOWN['real-time-nav'] = true;
                 }
                 // Send pageview event for tab
-                ga('set', 'page', '/dashboard/real-time');
-                ga('send', 'pageview');
+                ga('send', 'pageview', '/dashboard/real-time');
               });
 
               // re-render on filter change
@@ -581,8 +579,7 @@
                         PLOTS_SHOWN['participants-by-region-nav'] = true;
                     }
                     // Send pageview event for tab
-                    ga('set', 'page', '/dashboard/participants-by-region');
-                    ga('send', 'pageview');
+                    ga('send', 'pageview', '/dashboard/participants-by-region');
                 });
 
                 // re-render on filter change
@@ -729,8 +726,7 @@
                         PLOTS_SHOWN['participants-by-lifecycle-nav'] = true;
                     }
                     // Send pageview event for tab
-                    ga('set', 'page', '/dashboard/participants-by-lifecycle');
-                    ga('send', 'pageview');
+                    ga('send', 'pageview', '/dashboard/participants-by-lifecycle');
                 });
 
                 // re-render on filter change

--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -211,6 +211,9 @@
                         renderTotalProgressPlot('spinner');
                         PLOTS_SHOWN['total-progress-nav'] = true;
                     }
+                    // Send pageview event for tab
+                    ga('set', 'page', '/dasboard/total-progress');
+                    ga('send', 'pageview');
                 });
 
                 // re-render on filter change
@@ -416,6 +419,9 @@
                   renderRealTimePlot('spinner');
                   PLOTS_SHOWN['real-time-nav'] = true;
                 }
+                // Send pageview event for tab
+                ga('set', 'page', '/dasboard/real-time');
+                ga('send', 'pageview');
               });
 
               // re-render on filter change
@@ -574,6 +580,9 @@
                         renderMapPlot('spinner');
                         PLOTS_SHOWN['participants-by-region-nav'] = true;
                     }
+                    // Send pageview event for tab
+                    ga('set', 'page', '/dasboard/participants-by-region');
+                    ga('send', 'pageview');
                 });
 
                 // re-render on filter change
@@ -719,6 +728,9 @@
                         renderLcPlot('spinner');
                         PLOTS_SHOWN['participants-by-lifecycle-nav'] = true;
                     }
+                    // Send pageview event for tab
+                    ga('set', 'page', '/dasboard/participants-by-lifecycle');
+                    ga('send', 'pageview');
                 });
 
                 // re-render on filter change


### PR DESCRIPTION
Adds Google Analytics tracking to the tabs in Dashboard by setting a fake page (for now -- later version of dashboard may implement URL) and then sending a `pageview` event.

Also implements a change in the base template to mock a `ga()` object.

Reference: https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications

[[DASH1-72](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-72)]