### PR TITLE
[HPRO-448] Fix selection of awardee in site selector

### DIFF
--- a/src/Pmi/Controller/DefaultController.php
+++ b/src/Pmi/Controller/DefaultController.php
@@ -15,6 +15,7 @@ use Pmi\Audit\Log;
 use Pmi\Drc\Exception\ParticipantSearchExceptionInterface;
 use Pmi\WorkQueue\WorkQueue;
 use Pmi\Order\Order;
+use Pmi\Security\User;
 
 class DefaultController extends AbstractController
 {
@@ -140,7 +141,7 @@ class DefaultController extends AbstractController
     {
         if ($request->request->has('site')) {
             $siteId = $request->request->get('site');
-            if (!$app->isValidSite($siteId)) {
+            if (strpos($siteId, User::AWARDEE_PREFIX) !== 0 && !$app->isValidSite($siteId)) {
                 $app->addFlashError("Sorry, there is a problem with your site's configuration. Please contact your site administrator.");
                 return $app['twig']->render('site-select.html.twig', ['siteEmail' => $siteId]);
             }


### PR DESCRIPTION
[[HPRO-448](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-448)]

Selecting a site or awardee context uses the same interface, even though they are two different roles.  This change fixes a bug where users belonging to multiple site/awardee groups would get an error when selecting an awardee context because the awardee is not a valid site.