### PR TITLE
[DASH1-87] Restrict realtime requests to 100 days

### DIFF
--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -368,6 +368,12 @@
                     $('#loading-modal').modal('show');
                   }
 
+                  // Restrict users to a 100 day date range for real-time requests
+                  if (moment(tpEndDate).diff(moment(tpStartDate), 'days') > 100) {
+                    setMetricsError(spinnerLoc, 'Please select a date range less than 100 days');
+                    return false;
+                  }
+
                   // gather params
                   var tpInterval = $('#real-time-interval').val();
                   var metricTitle = $('#real-time-metric-attribute option:selected').text();


### PR DESCRIPTION
The API endpoint is not fast enough to meet the request deadline of 60 seconds, even with batching. This PR enforces that limit on the frontend.

[[DASH1-87](https://precisionmedicineinitiative.atlassian.net/projects/DASH1/issues/DASH1-87)]