### PR TITLE
[DASH1-87] Update terminology for enrollment status

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -112,13 +112,13 @@ class DashboardController extends AbstractController
                 if ($history) {
                     $display_values = [
                         'core' => 'Core Participant',
-                        'registered' => 'Member',
+                        'registered' => 'Registered',
                         'consented' => 'Consented'
                     ];
                 } else {
                     $display_values = [
-                        'MEMBER' => 'Member',
-                        'FULL_PARTICIPANT' => 'Full Participant',
+                        'MEMBER' => 'Consented',
+                        'FULL_PARTICIPANT' => 'Core Participant',
                         'INTERESTED' => 'Registered'
                     ];
                 }
@@ -592,7 +592,7 @@ class DashboardController extends AbstractController
             'Baseline PPI Modules Complete',
             'Physical Measurements',
             'Samples Received',
-            'Full Participant'
+            'Core Participant'
         ];
 
         foreach ($metrics_keys as $index => $metric_val) {


### PR DESCRIPTION
Prior to this PR, the label for "Member" was incorrectly used. This aligns us with the new terms, outlined as:

> **Registered:** A person who created an account by entering a name and either a mobile phone number or an email address and has chosen a language preference but has not yet completed the informed consent process. A registered participant has a unique AoURP participant identifier (PID).
> **Consented:** A person who meets the eligibility and inclusion criteria and is enrolled in AoURP. A consented individual has completed the primary informed consent process and the HIPAA Authorization/EHR consent(if available and where relevant,based on AoURP capacity to effectively search for and access records). A consented individual hasn’t yet participated in any research program activities such as completion of questionnaires or providing physical measurements and biospecimens.
> **Core Participant:** A person who completed the required PPI modules and provided physical measurements and biospecimens. A core participant can contribute to other activities such as providing digital health data using sensor modules and/or wearables, if available.

[[DASH1-87](https://precisionmedicineinitiative.atlassian.net/projects/DASH1/issues/DASH1-76)]