### PR TITLE
[HPRO-208] Implement system for managing and displaying page-specific notices

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,6 +18,7 @@ var ASSETS = {
         NODE_DIR + '/datatables.net-buttons-bs/js/buttons.bootstrap.js',
         NODE_DIR + '/jsbarcode/dist/barcodes/JsBarcode.code128.min.js',
         NODE_DIR + '/inputmask/dist/jquery.inputmask.bundle.js',
+        NODE_DIR + '/bootstrap-toggle/js/bootstrap-toggle.js',
         ASSETS_DIR + '/js/parsley-comparison.js',
         ASSETS_DIR + '/js/bootstrap-session-timeout.js',
         ASSETS_DIR + '/js/app.js',
@@ -30,7 +31,8 @@ var ASSETS = {
         NODE_DIR + '/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css',
         NODE_DIR + '/datatables.net-bs/css/dataTables.bootstrap.css',
         NODE_DIR + '/datatables.net-responsive-bs/css/responsive.bootstrap.css',
-        NODE_DIR + '/datatables.net-buttons-bs/css/buttons.bootstrap.css'
+        NODE_DIR + '/datatables.net-buttons-bs/css/buttons.bootstrap.css',
+        NODE_DIR + '/bootstrap-toggle/css/bootstrap-toggle.css'
     ],
     'csslocal': [
         ASSETS_DIR + '/css/app.css'

--- a/package-lock.json
+++ b/package-lock.json
@@ -440,6 +440,11 @@
             "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.0.tgz",
             "integrity": "sha512-F1yTDO9OHKH0xjl03DsOe8Nu1OWBIeAugGMhy3UTIYDdbbIPesQIhCEbj+HEr6wqlwweGAlP8F3OBC6kEuhFuw=="
         },
+        "bootstrap-toggle": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/bootstrap-toggle/-/bootstrap-toggle-2.2.2.tgz",
+            "integrity": "sha1-K4hTT8G5mGdPh3+Yug2LW3Q+lv4="
+        },
         "brace-expansion": {
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dependencies": {
         "backbone": "^1.3.3",
         "bootstrap": "^3.4.0",
+        "bootstrap-toggle": "^2.2.2",
         "browser-sync": "^2.26.3",
         "datatables.net": "^1.10.19",
         "datatables.net-bs": "^2.1.1",

--- a/sql/healthpro/notices.sql
+++ b/sql/healthpro/notices.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `notices` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `url` varchar(255) NOT NULL,
+  `message` text NOT NULL,
+  `full_page` tinyint(1) NOT NULL DEFAULT 0,
+  `start_ts` timestamp NULL DEFAULT NULL,
+  `end_ts` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) DEFAULT CHARSET=utf8mb4;

--- a/sql/healthpro/notices.sql
+++ b/sql/healthpro/notices.sql
@@ -5,5 +5,6 @@ CREATE TABLE `notices` (
   `full_page` tinyint(1) NOT NULL DEFAULT 0,
   `start_ts` timestamp NULL DEFAULT NULL,
   `end_ts` timestamp NULL DEFAULT NULL,
+  `status` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/sql/migrations/026-create-notices.sql
+++ b/sql/migrations/026-create-notices.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `notices` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `url` varchar(255) NOT NULL,
+  `message` text NOT NULL,
+  `full_page` tinyint(1) NOT NULL DEFAULT 0,
+  `start_ts` timestamp NULL DEFAULT NULL,
+  `end_ts` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) DEFAULT CHARSET=utf8mb4;

--- a/sql/migrations/026-create-notices.sql
+++ b/sql/migrations/026-create-notices.sql
@@ -5,5 +5,6 @@ CREATE TABLE `notices` (
   `full_page` tinyint(1) NOT NULL DEFAULT 0,
   `start_ts` timestamp NULL DEFAULT NULL,
   `end_ts` timestamp NULL DEFAULT NULL,
+  `status` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -435,16 +435,19 @@ class HpoApplication extends AbstractApplication
             }
         }
 
-        $noticeService = new NoticeService($this['em']);
-        $notices = $noticeService->getCurrentNotices($request->getPathInfo());
-        foreach ($notices as $notice) {
-            if ($notice['full_page']) {
-                return new Response($this['twig']->render('full-page-notice.html.twig', [
-                    'message' => $notice['message']
-                ]));
+        // Prevent notice display in all admin pages
+        if (strpos($request->attributes->get('_route'), 'admin') === false) {
+            $noticeService = new NoticeService($this['em']);
+            $notices = $noticeService->getCurrentNotices($request->getPathInfo());
+            foreach ($notices as $notice) {
+                if ($notice['full_page']) {
+                    return new Response($this['twig']->render('full-page-notice.html.twig', [
+                        'message' => $notice['message']
+                    ]));
+                }
             }
+            $app['twig']->addGlobal('global_notices', $notices);
         }
-        $app['twig']->addGlobal('global_notices', $notices);
     }
 
     protected function afterCallback(Request $request, Response $response)

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Pmi\Entities\Configuration;
 use Pmi\Security\UserProvider;
 use Pmi\Audit\Log;
+use Pmi\Service\NoticeService;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
 
 class HpoApplication extends AbstractApplication
@@ -433,6 +434,10 @@ class HpoApplication extends AbstractApplication
                 }
             }
         }
+
+        $noticeService = new NoticeService($this['em']);
+        $notices = $noticeService->getCurrentNotices($request->getPathInfo());
+        $app['twig']->addGlobal('global_notices', $notices);
     }
 
     protected function afterCallback(Request $request, Response $response)

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -437,6 +437,13 @@ class HpoApplication extends AbstractApplication
 
         $noticeService = new NoticeService($this['em']);
         $notices = $noticeService->getCurrentNotices($request->getPathInfo());
+        foreach ($notices as $notice) {
+            if ($notice['full_page']) {
+                return new Response($this['twig']->render('full-page-notice.html.twig', [
+                    'message' => $notice['message']
+                ]));
+            }
+        }
         $app['twig']->addGlobal('global_notices', $notices);
     }
 

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -435,19 +435,16 @@ class HpoApplication extends AbstractApplication
             }
         }
 
-        // Prevent notice display in all admin pages
-        if (strpos($request->attributes->get('_route'), 'admin') === false) {
-            $noticeService = new NoticeService($this['em']);
-            $notices = $noticeService->getCurrentNotices($request->getPathInfo());
-            foreach ($notices as $notice) {
-                if ($notice['full_page']) {
-                    return new Response($this['twig']->render('full-page-notice.html.twig', [
-                        'message' => $notice['message']
-                    ]));
-                }
+        $noticeService = new NoticeService($this['em']);
+        $notices = $noticeService->getCurrentNotices($request->getPathInfo());
+        foreach ($notices as $notice) {
+            if ($notice['full_page']) {
+                return new Response($this['twig']->render('full-page-notice.html.twig', [
+                    'message' => $notice['message']
+                ]));
             }
-            $app['twig']->addGlobal('global_notices', $notices);
         }
+        $app['twig']->addGlobal('global_notices', $notices);
     }
 
     protected function afterCallback(Request $request, Response $response)

--- a/src/Pmi/Audit/Log.php
+++ b/src/Pmi/Audit/Log.php
@@ -39,6 +39,9 @@ class Log
     const PROBLEM_NOTIFIY = 'PROBLEM_NOTIFIY';
     const QUEUE_RESEND_EVALUATION = 'QUEUE_RESEND_EVALUATION';
     const MISSING_MEASUREMENTS_ORDERS_NOTIFY = 'MISSING_MEASUREMENTS_ORDERS_NOTIFY';
+    const NOTICE_EDIT = 'NOTICE_EDIT';
+    const NOTICE_ADD = 'NOTICE_ADD';
+    const NOTICE_DELETE = 'NOTICE_DELETE';
 
     public function __construct($app, $action, $data)
     {

--- a/src/Pmi/Controller/AdminController.php
+++ b/src/Pmi/Controller/AdminController.php
@@ -462,7 +462,8 @@ class AdminController extends AbstractController
 
         return $app['twig']->render('admin/notices/edit.html.twig', [
             'notice' => $notice,
-            'form' => $form->createView()
+            'form' => $form->createView(),
+            'data' => $form->getData()
         ]);
     }
 }

--- a/src/Pmi/Controller/AdminController.php
+++ b/src/Pmi/Controller/AdminController.php
@@ -428,7 +428,7 @@ class AdminController extends AbstractController
         $form = $app['form.factory']->createNamed(
             'form',
             NoticeType::class,
-            $notice,
+            $notice ?: ['status' => 1],
             ['timezone' => $app->getUserTimezone()]
         );
 
@@ -462,8 +462,7 @@ class AdminController extends AbstractController
 
         return $app['twig']->render('admin/notices/edit.html.twig', [
             'notice' => $notice,
-            'form' => $form->createView(),
-            'data' => $form->getData()
+            'form' => $form->createView()
         ]);
     }
 }

--- a/src/Pmi/EntityManager/EntityManager.php
+++ b/src/Pmi/EntityManager/EntityManager.php
@@ -20,7 +20,8 @@ class EntityManager
         'awardees' => 'doctrine',
         'missing_notifications_log' => 'doctrine',
         'evaluations_history' => 'doctrine',
-        'orders_history' => 'doctrine'
+        'orders_history' => 'doctrine',
+        'notices' => 'doctrine'
     ];
 
     protected $timezone;

--- a/src/Pmi/Form/NoticeType.php
+++ b/src/Pmi/Form/NoticeType.php
@@ -57,6 +57,17 @@ class NoticeType extends AbstractType
                 'constraints' => [
                     new Constraints\DateTime()
                 ]
+            ])
+            ->add('status', Type\CheckboxType::class, [
+                'label' => false,
+                'required' => false,
+                'attr' => [
+                    'data-toggle' => 'toggle',
+                    'data-on' => 'Enable',
+                    'data-off' => 'Disable',
+                    'data-onstyle' => 'success'
+                ],
+                'data' => true
             ]);
     }
 

--- a/src/Pmi/Form/NoticeType.php
+++ b/src/Pmi/Form/NoticeType.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type;
 use Symfony\Component\Validator\Constraints;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\CallbackTransformer;
 
 class NoticeType extends AbstractType
 {
@@ -69,6 +70,17 @@ class NoticeType extends AbstractType
                 ],
                 'data' => true
             ]);
+
+        // Convert status field int values into boolean
+        $builder->get('status')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($int) {
+                    return (bool)$int;
+                },
+                function ($bool) {
+                    return $bool ? 1 : 0;
+                }
+            ));
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Pmi/Form/NoticeType.php
+++ b/src/Pmi/Form/NoticeType.php
@@ -67,8 +67,7 @@ class NoticeType extends AbstractType
                     'data-on' => 'Enable',
                     'data-off' => 'Disable',
                     'data-onstyle' => 'success'
-                ],
-                'data' => true
+                ]
             ]);
 
         // Convert status field int values into boolean

--- a/src/Pmi/Form/NoticeType.php
+++ b/src/Pmi/Form/NoticeType.php
@@ -1,0 +1,69 @@
+<?php
+namespace Pmi\Form;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type;
+use Symfony\Component\Validator\Constraints;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class NoticeType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('url', Type\TextType::class, [
+                'label' => 'URL Pattern',
+                'required' => true,
+                'constraints' => [
+                    new Constraints\NotBlank(),
+                    new Constraints\Type('string'),
+                    new Constraints\Regex('/^[a-zA-Z0-9_\-\/\*]+$/') // valid URL, with asterisks
+                ]
+            ])
+            ->add('message', Type\TextareaType::class, [
+                'required' => true,
+                'constraints' => [
+                    new Constraints\NotBlank(),
+                    new Constraints\Type('string')
+                ]
+            ])
+            ->add('full_page', Type\ChoiceType::class, [
+                'label' => 'Full Page?',
+                'required' => true,
+                'choices' => [
+                    'No'=> 0,
+                    'Yes' => 1
+                ]
+            ])
+            ->add('start_ts', Type\DateTimeType::class, [
+                'required' => false,
+                'label' => 'Start Time (optional)',
+                'widget' => 'single_text',
+                'format' => 'M/d/yyyy h:mm a',
+                'view_timezone' => $options['timezone'],
+                'model_timezone' => 'UTC',
+                'constraints' => [
+                    new Constraints\DateTime()
+                ]
+            ])
+            ->add('end_ts', Type\DateTimeType::class, [
+                'required' => false,
+                'label' => 'End Time (optional)',
+                'widget' => 'single_text',
+                'format' => 'M/d/yyyy h:mm a',
+                'view_timezone' => $options['timezone'],
+                'model_timezone' => 'UTC',
+                'constraints' => [
+                    new Constraints\DateTime()
+                ]
+            ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'timezone' => 'UTC',
+        ]);
+    }
+}

--- a/src/Pmi/Form/NoticeType.php
+++ b/src/Pmi/Form/NoticeType.php
@@ -45,6 +45,16 @@ class NoticeType extends AbstractType
                 'choices' => [
                     'No'=> 0,
                     'Yes' => 1
+                ],
+                'constraints' => [
+                    new Constraints\Callback(function($isFullPage, $context) {
+                        if ($isFullPage) {
+                            $url = $context->getObject()->getParent()->get('url')->getData();
+                            if (preg_match('/^\/?admin/i', $url)) {
+                                $context->buildViolation('Full page notices cannot be used with admin URLs')->addViolation();
+                            }
+                        }
+                    })
                 ]
             ])
             ->add('start_ts', Type\DateTimeType::class, [

--- a/src/Pmi/Form/NoticeType.php
+++ b/src/Pmi/Form/NoticeType.php
@@ -13,6 +13,16 @@ class NoticeType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
+            ->add('status', Type\CheckboxType::class, [
+                'label' => false,
+                'required' => false,
+                'attr' => [
+                    'data-toggle' => 'toggle',
+                    'data-on' => 'Enable',
+                    'data-off' => 'Disable',
+                    'data-onstyle' => 'success'
+                ]
+            ])
             ->add('url', Type\TextType::class, [
                 'label' => 'URL Pattern',
                 'required' => true,
@@ -57,16 +67,6 @@ class NoticeType extends AbstractType
                 'model_timezone' => 'UTC',
                 'constraints' => [
                     new Constraints\DateTime()
-                ]
-            ])
-            ->add('status', Type\CheckboxType::class, [
-                'label' => false,
-                'required' => false,
-                'attr' => [
-                    'data-toggle' => 'toggle',
-                    'data-on' => 'Enable',
-                    'data-off' => 'Disable',
-                    'data-onstyle' => 'success'
                 ]
             ]);
 

--- a/src/Pmi/Service/NoticeService.php
+++ b/src/Pmi/Service/NoticeService.php
@@ -6,7 +6,6 @@ use DateTime;
 class NoticeService
 {
     private $em;
-    private $timezone;
 
     public function __construct($entityManager)
     {

--- a/src/Pmi/Service/NoticeService.php
+++ b/src/Pmi/Service/NoticeService.php
@@ -1,0 +1,49 @@
+<?php
+namespace Pmi\Service;
+
+use DateTime;
+
+class NoticeService
+{
+    private $em;
+    private $timezone;
+
+    public function __construct($entityManager)
+    {
+        $this->em = $entityManager;
+    }
+
+    protected function patternToRegex($pattern)
+    {
+        // temporarily change wildcard asterisks to % to avoid escaping
+        $regex = str_replace('*', '%', $pattern);
+        // escape pattern for regex
+        $regex = preg_quote($regex, '/');
+        // replace wildcards with regex .*
+        $regex = str_replace('%', '.*', $regex);
+        // add delimeters, start and end characters, and case-insensitive modifier
+        $regex = '/^' . $regex . '$/i';
+
+        return $regex;
+    }
+
+    public function getCurrentNotices($url)
+    {
+        $now = (new DateTime())->format('Y-m-d H:i:s');
+        $notices = $this->em->getRepository('notices')->fetchBySql(
+            '(start_ts is null OR start_ts <= ?) AND ' . 
+            '(end_ts is null OR end_ts >= ?)',
+            [$now, $now]
+        );
+
+        $matches = [];
+        foreach ($notices as $notice) {
+            $regex = $this->patternToRegex($notice['url']);
+            if (preg_match($regex, $url)) {
+                $matches[] = $notice;
+            }
+        }
+
+        return $matches;
+    }
+}

--- a/src/Pmi/Service/NoticeService.php
+++ b/src/Pmi/Service/NoticeService.php
@@ -31,6 +31,7 @@ class NoticeService
     {
         $now = (new DateTime())->format('Y-m-d H:i:s');
         $notices = $this->em->getRepository('notices')->fetchBySql(
+            'status = 1 AND ' . 
             '(start_ts is null OR start_ts <= ?) AND ' . 
             '(end_ts is null OR end_ts >= ?)',
             [$now, $now]

--- a/views/admin/index.html.twig
+++ b/views/admin/index.html.twig
@@ -6,11 +6,14 @@
     </div>
 
     <div class="row">
-        <div class="col-sm-6 col-md-4 col-md-offset-2">
+        <div class="col-sm-6 col-md-4">
             <a href="{{ path('admin_sites') }}" class="btn btn-lg btn-default btn-block"><i class="fa fa-hospital-o" aria-hidden="true"></i> Sites</a>
         </div>
         <div class="col-sm-6 col-md-4">
             <a href="{{ path('admin_withdrawalNotifications') }}" class="btn btn-lg btn-default btn-block"><i class="fa fa-bell" aria-hidden="true"></i> Withdrawal Notifications</a>
+        </div>
+        <div class="col-sm-6 col-md-4">
+            <a href="{{ path('admin_notices') }}" class="btn btn-lg btn-default btn-block"><i class="fa fa-info-circle" aria-hidden="true"></i> Page Notices</a>
         </div>
     </div>
 

--- a/views/admin/notices/edit.html.twig
+++ b/views/admin/notices/edit.html.twig
@@ -1,0 +1,31 @@
+{% extends 'base.html.twig' %}
+{% block title %}Edit Notice - {% endblock %}
+{% block body %}
+    <div class="page-header">
+        <h2><i class="fa fa-info-circle" aria-hidden="true"></i> {{ notice ? 'Edit' : 'Create' }} Page Notice</h2>
+    </div>
+    <div class="row">
+        <div class="col-sm-6 col-sm-offset-3">
+            {{ form_start(form, { attr: { class: 'warn-unsaved disable-enter prevent-resubmit' } }) }}
+            {{ form_errors(form) }}
+            {{ form_rest(form) }}
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a class="btn btn-default" href="{{ path('admin_notices') }}">Cancel</a>
+            {% if notice %}
+                <button type="submit" name="delete" class="btn btn-danger pull-right confirm">Delete</button>
+            {% endif %}
+            {{ form_end(form) }}
+        </div>
+    </div>
+{% endblock %}
+
+{% block pagejs %}
+<script>
+$(document).ready(function() {
+    $('#form_start_ts, #form_end_ts').pmiDateTimePicker();
+    $('.confirm').on('click', function() {
+        return confirm('Are you sure you want to delete this notice?');
+    });
+});
+</script>
+{% endblock %}

--- a/views/admin/notices/edit.html.twig
+++ b/views/admin/notices/edit.html.twig
@@ -6,10 +6,7 @@
     </div>
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3">
-            {{ form_start(form, { attr: { class: 'warn-unsaved disable-enter prevent-resubmit' } }) }}
-            {% if notice is empty and data is empty %}
-                {{ form_row(form.status, { attr: { checked: 'checked' } }) }}
-            {% endif %}
+            {{ form_start(form, { attr: { class: 'warn-unsaved prevent-resubmit' } }) }}
             {{ form_errors(form) }}
             {{ form_rest(form) }}
             <button type="submit" class="btn btn-primary">Save</button>

--- a/views/admin/notices/edit.html.twig
+++ b/views/admin/notices/edit.html.twig
@@ -7,6 +7,9 @@
     <div class="row">
         <div class="col-sm-6 col-sm-offset-3">
             {{ form_start(form, { attr: { class: 'warn-unsaved disable-enter prevent-resubmit' } }) }}
+            {% if notice is empty and data is empty %}
+                {{ form_row(form.status, { attr: { checked: 'checked' } }) }}
+            {% endif %}
             {{ form_errors(form) }}
             {{ form_rest(form) }}
             <button type="submit" class="btn btn-primary">Save</button>

--- a/views/admin/notices/index.html.twig
+++ b/views/admin/notices/index.html.twig
@@ -17,7 +17,13 @@
                 <td>{{ notice.full_page ? 'Yes' : 'No' }}</td>
                 <td>{{ notice.start_ts ? notice.start_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
                 <td>{{ notice.end_ts ? notice.end_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
-                <td>{{ notice.status ? 'Enabled' : 'Disabled' }}</td>
+                <td>
+                    {% if notice.status %}
+                        <span class="label label-success">Enabled</span>
+                    {% else %}
+                        <span class="label label-default">Disabled</span>
+                    {% endif %}
+                </td>
             </tr>
         {% endfor %}
         </tbody>

--- a/views/admin/notices/index.html.twig
+++ b/views/admin/notices/index.html.twig
@@ -1,0 +1,25 @@
+{% extends 'base.html.twig' %}
+{% block title %}Page Notices - {% endblock %}
+{% block body %}
+    <div class="page-header">
+        <h2><i class="fa fa-info-circle" aria-hidden="true"></i> Page Notices</h2>
+    </div>
+    <p>
+        <a href="{{ path('admin_notice') }}" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> Add Notice</a>
+    </p>
+    <table class="table table-striped table-hover">
+        <thead><tr><th>URL Pattern</th><th>Message</th><th>Full Page?</th><th>Start</th><th>End</th></tr></thead>
+        <tbody>
+        {% for notice in notices %}
+            <tr>
+                <td><a href="{{ path('admin_notice', { id: notice.id }) }}">{{ notice.url }}</a></td>
+                <td>{{ notice.message|length > 100 ? notice.message|slice(0, 100) ~ '...' : notice.message  }}</td>
+                <td>{{ notice.full_page ? 'Yes' : 'No' }}</td>
+                <td>{{ notice.start_ts ? notice.start_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
+                <td>{{ notice.end_ts ? notice.end_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+{% endblock %}
+

--- a/views/admin/notices/index.html.twig
+++ b/views/admin/notices/index.html.twig
@@ -8,7 +8,7 @@
         <a href="{{ path('admin_notice') }}" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> Add Notice</a>
     </p>
     <table class="table table-striped table-hover">
-        <thead><tr><th>URL Pattern</th><th>Message</th><th>Full Page?</th><th>Start</th><th>End</th></tr></thead>
+        <thead><tr><th>URL Pattern</th><th>Message</th><th>Full Page?</th><th>Start</th><th>End</th><th>Status</th></tr></thead>
         <tbody>
         {% for notice in notices %}
             <tr>
@@ -17,6 +17,7 @@
                 <td>{{ notice.full_page ? 'Yes' : 'No' }}</td>
                 <td>{{ notice.start_ts ? notice.start_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
                 <td>{{ notice.end_ts ? notice.end_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
+                <td>{{ notice.status ? 'Enabled' : 'Disabled' }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/views/admin/notices/index.html.twig
+++ b/views/admin/notices/index.html.twig
@@ -30,3 +30,13 @@
     </table>
 {% endblock %}
 
+{% block pagejs %}
+    <script>
+        $(document).ready(function() {
+            $('table').DataTable({
+                order: [[0, 'asc']],
+                pageLength: 25
+            });
+        });
+    </script>
+{% endblock %}

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -101,7 +101,7 @@
         {% if global_notices is defined and global_notices|length > 0 %}
             {% for notice in global_notices %}
                 <div class="alert alert-warning">
-                    {{ notice.message }}
+                    {{ notice.message|raw }}
                 </div>
             {% endfor %}
         {% endif %}

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -98,6 +98,11 @@
         </div>
     {% endif %}
     <div class="{% block bodycontainer %}container{% endblock %}">
+        {% for notice in global_notices %}
+            <div class="alert alert-warning">
+                {{ notice.message }}
+            </div>
+        {% endfor %}
         <div id="flash-notices">
             {% for flashMessage in app.session.flashbag.get('error') %}
                 <div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ flashMessage }}</div>

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -98,11 +98,13 @@
         </div>
     {% endif %}
     <div class="{% block bodycontainer %}container{% endblock %}">
-        {% for notice in global_notices %}
-            <div class="alert alert-warning">
-                {{ notice.message }}
-            </div>
-        {% endfor %}
+        {% if global_notices is defined and global_notices|length > 0 %}
+            {% for notice in global_notices %}
+                <div class="alert alert-warning">
+                    {{ notice.message }}
+                </div>
+            {% endfor %}
+        {% endif %}
         <div id="flash-notices">
             {% for flashMessage in app.session.flashbag.get('error') %}
                 <div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ flashMessage }}</div>

--- a/views/full-page-notice.html.twig
+++ b/views/full-page-notice.html.twig
@@ -1,0 +1,4 @@
+{% extends 'base.html.twig' %}
+{% block body %}
+    <div class="alert alert-warning">{{ message }}</div>
+{% endblock %}

--- a/views/full-page-notice.html.twig
+++ b/views/full-page-notice.html.twig
@@ -1,4 +1,4 @@
 {% extends 'base.html.twig' %}
 {% block body %}
-    <div class="alert alert-warning">{{ message }}</div>
+    <div class="alert alert-warning">{{ message|raw }}</div>
 {% endblock %}


### PR DESCRIPTION
[[HPRO-208](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-208)]

This adds a new table for page notices and an admin section to manage these notices.  In the application's before callback middleware, notices that apply to the current page are loaded and passed to the view for rendering.  Also, a full page option is available which will just render the base template and message without executing or rendering the requested controller action.

Screenshots of an example:

![screen shot 2019-02-18 at 5 14 59 pm](https://user-images.githubusercontent.com/860499/52980679-e61db000-33a0-11e9-8c7b-1b5bce3a0e32.png)

![screen shot 2019-02-18 at 5 15 55 pm](https://user-images.githubusercontent.com/860499/52980677-e453ec80-33a0-11e9-9187-f4d42bcb07d4.png)