### PR TITLE
[HPRO-208] Add Page Notices feature to Dashboards

### DIFF
--- a/views/dashboard/base.html.twig
+++ b/views/dashboard/base.html.twig
@@ -37,14 +37,24 @@
     </nav>
 
     <div class="container">
-        <div id="flash-notices">
-            {% for flashMessage in app.session.flashbag.get('error') %}
-                <div class="alert alert-danger">{{ flashMessage }}</div>
-            {% endfor %}
-            {% for flashMessage in app.session.flashbag.get('notice') %}
-                <div class="alert alert-info">{{ flashMessage }}</div>
-            {% endfor %}
-        </div>
+      {% if global_notices is defined and global_notices|length > 0 %}
+          {% for notice in global_notices %}
+              <div class="alert alert-warning">
+                  {{ notice.message|raw }}
+              </div>
+          {% endfor %}
+      {% endif %}
+      <div id="flash-notices">
+          {% for flashMessage in app.session.flashbag.get('error') %}
+              <div class="alert alert-danger"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ flashMessage }}</div>
+          {% endfor %}
+          {% for flashMessage in app.session.flashbag.get('notice') %}
+              <div class="alert alert-info"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ flashMessage }}</div>
+          {% endfor %}
+          {% for flashMessage in app.session.flashbag.get('success') %}
+              <div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ flashMessage }}</div>
+          {% endfor %}
+      </div>
 
         {% block body %}{% endblock %}
     </div>

--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -1,7 +1,6 @@
 {% extends 'dashboard/base.html.twig' %}
 {% block title %}Dashboard{% endblock %}
 {% block body %}
-    {{ display_message('dashboard_notice', 'alert', { closeButton: true })|raw }}
     <h2 id="dashboard-heading"><i class="fa fa-tachometer" aria-hidden="true"></i> Dashboard <i class="fa fa-question-circle text-info pull-right" style="cursor: pointer;" id="dashboard-help"></i> </h2>
     <div class="modal fade" id="loading-modal" tabindex="-1" role="dialog" aria-labelledby="loading-modal" aria-hidden="true">
         <div class="modal-dialog">


### PR DESCRIPTION
- Adds the new Page Notices feature to the Dashboard base template.
- Adds a missing flash message type (not used, but should be there anyway)
- Removes deprecated `display_message()` call (replaced by Page Notices)

[[HPRO-208](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-208)]