### PR TITLE
[HPRO-458] Fix DatePeriod bug when start and end dates are the same

### DIFF
--- a/src/Pmi/Drc/RdrMetrics.php
+++ b/src/Pmi/Drc/RdrMetrics.php
@@ -126,8 +126,8 @@ class RdrMetrics
     private function getDateRangeBins($start_date, $end_date, $batch)
     {
         $dateRangeBins = [];
-        $startDate = new \DateTime($start_date);
-        $endDate = new \DateTime($end_date);
+        $startDate = new \DateTime($start_date . '00:00:00');
+        $endDate = new \DateTime($end_date . '23:59:59');
 
         $interval = new \DateInterval(sprintf('P%dD', $batch));
         $period = new \DatePeriod($startDate, $interval, $endDate);


### PR DESCRIPTION
This bug shows up when you have the same start and end date because internally the `DatePeriod` class does not consider that any period has elapsed between them. The fix is to append the appropriate times to the arguments, particularly the `$endDate`.

[[HPRO-458](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-458)]