### PR TITLE
[DASH1-82] Add enrollment status filter for Region tab

### DIFF
--- a/src/Pmi/Console/Command/MetricsCommand.php
+++ b/src/Pmi/Console/Command/MetricsCommand.php
@@ -25,7 +25,7 @@ class MetricsCommand extends Command
     private static $STRATIFICATIONS = [
         'TOTAL', 'ENROLLMENT_STATUS', 'GENDER_IDENTITY', 'AGE_RANGE', 'RACE',
         'EHR_CONSENT', 'EHR_RATIO', 'FULL_STATE', 'FULL_CENSUS', 'FULL_AWARDEE',
-        'LIFECYCLE'
+        'LIFECYCLE', 'GEO_STATE', 'GEO_CENSUS', 'GEO_AWARDEE'
     ];
     private static $STATUSES = ['INTERESTED', 'MEMBER', 'FULL_PARTICIPANT'];
 

--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -317,7 +317,7 @@ class DashboardController extends AbstractController
 
         // make sure metrics data exists first, if metrics cache or API fail return value will be false
         if (!empty($metrics)) {
-            if ($stratification == 'FULL_STATE') {
+            if ($stratification == 'GEO_STATE') {
                 // Roll up the extra HPO dimension by date
                 $metrics = $this->combineHPOsByDate($metrics, $centers);
 
@@ -372,7 +372,7 @@ class DashboardController extends AbstractController
                         "titleside" => 'right'
                     ]
                 ];
-            } elseif ($stratification == 'FULL_CENSUS') {
+            } elseif ($stratification == 'GEO_CENSUS') {
                 // Roll up the extra HPO dimension by date
                 $metrics = $this->combineHPOsByDate($metrics, $centers);
 
@@ -439,7 +439,7 @@ class DashboardController extends AbstractController
                         "titleside" => 'right'
                     ]
                 ];
-            } elseif ($stratification == 'FULL_AWARDEE') {
+            } elseif ($stratification == 'GEO_AWARDEE') {
                 $map_data = [];
                 $categorized_centers = $this->getCentersList($app);
                 $recruitment_centers = [];

--- a/views/dashboard/filters.html.twig
+++ b/views/dashboard/filters.html.twig
@@ -11,7 +11,7 @@
                    <div class="row">
                         <div class="col-xs-12">
                             <p class="text-center"><a href="javascript:void(0);" class="redraw-plotly btn btn-primary"><span class="fa fa-filter"></span> Filter Results</a></p>
-                            {% if id == 'real-time' %}
+                            {% if show_enrollment_status == true %}
                             <hr class="divider" />
                             <h4>Enrollment Status <a href="javascript:void(0);" class="toggle-all-enrollment-filters label label-primary pull-right">All <span class="fa fa-toggle-on"></span></a></h4>
                             <!-- TODO: After more facets are supported in Metrics API 2, use passed values instead of hard-coding -->

--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -503,9 +503,9 @@
                                 <div class="col-md-12 col-xs-4 form-group form-group-sm">
                                     <label for="map-mode">Display Metric</label>
                                     <select class="form-control region-plot-control" id="map-mode">
-                                        <option value="FULL_STATE" selected>State</option>
-                                        <option value="FULL_CENSUS">Census Region</option>
-                                        <option value="FULL_AWARDEE">Recruitment Origin</option>
+                                        <option value="GEO_STATE" selected>State</option>
+                                        <option value="GEO_CENSUS">Census Region</option>
+                                        <option value="GEO_AWARDEE">Recruitment Origin</option>
                                     </select>
                                 </div>
                                 <div class="col-md-12 col-xs-4 form-group form-group-sm">
@@ -540,12 +540,19 @@
             </div>
 
             <script type="text/javascript">
+                // Default to showing only 'Core' participants
+
+
                 // function to grab current filter values and load JSON from load_map_data REST endpoint
                 // success handler calls Plotly.newplot()
                 function renderMapPlot(dialogType) {
                     var regionCenters = loadRecruitmentFilters('participants-by-region');
+                    var enrollmentStatuses = loadEnrollmentFilters('participants-by-region');
                     if (regionCenters.length == 0) {
                         alert('You must select at least one recruitment center to plot results');
+                        return false;
+                    } else if (enrollmentStatuses.length == 0) {
+                        alert('You must select at least one enrollment status to plot results');
                         return false;
                     } else {
                         var spinnerLoc = 'plotly-participants-by-region';
@@ -568,10 +575,25 @@
                             regionCenters = ['ALL'];
                         }
 
-                        if (mapMode == 'FULL_AWARDEE') {
+                        if (mapMode == 'GEO_AWARDEE') {
                             $('#map-color-profile').prop('disabled', true);
                         } else {
                             $('#map-color-profile').prop('disabled', false);
+                        }
+
+                        var enrollmentFilterText = 'Participants';
+                        if (enrollmentStatuses.length < 3) {
+                          var mappedEnrollmentStatuses = [];
+                          if (enrollmentStatuses.indexOf('INTERESTED') !== -1) {
+                            mappedEnrollmentStatuses.push('Registered');
+                          }
+                          if (enrollmentStatuses.indexOf('MEMBER') !== -1) {
+                            mappedEnrollmentStatuses.push('Consented');
+                          }
+                          if (enrollmentStatuses.indexOf('FULL_PARTICIPANT') !== -1) {
+                            mappedEnrollmentStatuses.push('Core');
+                          }
+                          enrollmentFilterText = mappedEnrollmentStatuses.join(', ') + ' Participants';
                         }
 
                         // load data from metrics API
@@ -580,6 +602,7 @@
                           stratification: mapMode,
                           end_date: mapCutoff,
                           centers: regionCenters,
+                          enrollment_statuses: enrollmentStatuses,
                           history: true,
                           color_profile: mapColor 
                         })
@@ -589,7 +612,7 @@
                                     mapModeText += ' of residence'
                                 }
                                 var mapLayout = {
-                                    title: "<b>Core Participants</b> by <b>" + mapModeText.toLowerCase() + '</b> as of ' + mapCutoff,
+                                    title: '<b>' + enrollmentFilterText + '</b> by <b>' + mapModeText.toLowerCase() + '</b> as of ' + mapCutoff,
                                     font: PLOTLY_LABEL_FONT,
                                     width: mapWidth,
                                     height: mapWidth / 1.66,
@@ -631,6 +654,10 @@
 
                 // load plot on tab show (to save loading time)
                 $('#participants-by-region-nav').on('shown.bs.tab', function (e) {
+                    // Set default filter to show 'Core' participants only
+                    $('#participants-by-region .enrollment-status-filter').prop('checked', false)
+                    $('#participants-by-region .enrollment-status-filter[value="FULL_PARTICIPANT"]').prop('checked', true)
+
                     // if plot has not been shown yet, render and then store state
                     // this will prevent points render calls once map has been initialized
                     if (!PLOTS_SHOWN['participants-by-region-nav']) {

--- a/views/dashboard/index.html.twig
+++ b/views/dashboard/index.html.twig
@@ -26,7 +26,7 @@
         <div id="total-progress" class="tab-pane pad active fade in">
             <div class="row">
                 <div id="total-progress-filters" class="col-md-3">
-                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'total-progress'} %}
+                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'total-progress', show_enrollment_status: false} %}
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <div class="panel-title">
@@ -222,7 +222,7 @@
                           try {
                             setMetricsError(spinnerLoc, JSON.parse(jqXHR.responseText).error);
                           } catch (e) {
-                            setMetricsError(spinnerLoc, 'An error occurred while loading data the data');
+                            setMetricsError(spinnerLoc, 'An error occurred while loading the data.');
                           }
                         });
                     }
@@ -278,7 +278,7 @@
         <div id="real-time" class="tab-pane pad fade">
             <div class="row">
                 <div id="real-time-filters" class="col-md-3">
-                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'real-time'} %}
+                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'real-time', show_enrollment_status: true} %}
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <div class="panel-title">
@@ -437,7 +437,7 @@
                       try {
                         setMetricsError(spinnerLoc, JSON.parse(jqXHR.responseText).error);
                       } catch (e) {
-                        setMetricsError(spinnerLoc, 'An error occurred while loading data the data');
+                        setMetricsError(spinnerLoc, 'An error occurred while loading the data.');
                       }
                     });
                 }
@@ -491,7 +491,7 @@
         <div id="participants-by-region" class="tab-pane pad fade">
             <div class="row">
                 <div id="participants-by-region-filters" class="col-md-3">
-                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'participants-by-region'} %}
+                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'participants-by-region', show_enrollment_status: true} %}
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <div class="panel-title">
@@ -620,7 +620,7 @@
                           try {
                             setMetricsError(spinnerLoc, JSON.parse(jqXHR.responseText).error);
                           } catch (e) {
-                            setMetricsError(spinnerLoc, 'An error occurred while loading data the data');
+                            setMetricsError(spinnerLoc, 'An error occurred while loading the data.');
                           }
                         });
                     }
@@ -666,7 +666,7 @@
         <div id="participants-by-lifecycle" class="tab-pane pad fade">
             <div class="row">
                 <div class="col-md-3">
-                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'participants-by-lifecycle'} %}
+                    {% include 'dashboard/filters.html.twig' with {recruitment_centers: recruitment_centers, id: 'participants-by-lifecycle', show_enrollment_status: false} %}
                     <div class="panel panel-default">
                         <div class="panel-heading">
                             <div class="panel-title">

--- a/web/assets/js/dashboard.js
+++ b/web/assets/js/dashboard.js
@@ -197,7 +197,7 @@ function loadRegionTableData(tableTarget, sourceData, plotType, rowLabel) {
     headerRow.append($('<th>').text('Count'));
     var tableBody = $('#' + tableId + '-body');
 
-    if (plotType === 'FULL_STATE') {
+    if (plotType === 'GEO_STATE') {
         // since there are flat arrays of data, grab the location array and use index to keep position
         $(sourceData[0]['locations']).each(function (i, state) {
             newRow = $('<tr>');
@@ -205,7 +205,7 @@ function loadRegionTableData(tableTarget, sourceData, plotType, rowLabel) {
             newRow.append($('<td>').text(sourceData[0]['counts'][i]));
             tableBody.append(newRow);
         });
-    } else if (plotType === 'FULL_CENSUS') {
+    } else if (plotType === 'GEO_CENSUS') {
         // since there are flat arrays of data, grab the location array and use index to keep position
         $(sourceData[0]['regions']).each(function (i, region) {
             newRow = $('<tr>');
@@ -213,7 +213,7 @@ function loadRegionTableData(tableTarget, sourceData, plotType, rowLabel) {
             newRow.append($('<td>').text(sourceData[0]['region_counts'][i]));
             tableBody.append(newRow);
         });
-    } else if (plotType === 'FULL_AWARDEE') {
+    } else if (plotType === 'GEO_AWARDEE') {
         // load scores
         $(sourceData).each(function(index, row) {
             newRow = $('<tr>');


### PR DESCRIPTION
Adds an enrollment status filter to the `Participants by Region` tab, defaulting it show only `Core Participants` by default.

![01 core participants](https://user-images.githubusercontent.com/80459/53660082-acf80200-3c22-11e9-88ff-8654c75029ac.png)
![02 all selected](https://user-images.githubusercontent.com/80459/53660084-acf80200-3c22-11e9-96d3-50d06ed45133.png)
![03 two selected](https://user-images.githubusercontent.com/80459/53660085-acf80200-3c22-11e9-92bf-222a85a44b7d.png)
![04 census region](https://user-images.githubusercontent.com/80459/53660086-ad909880-3c22-11e9-8b46-41de6799a145.png)
![05 awardee](https://user-images.githubusercontent.com/80459/53660087-ad909880-3c22-11e9-8429-0e1baa4e5048.png)

[[DASH1-82](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-82)]