### PR TITLE
[DASH1-82] Adjust minimum dot size on Recruitment Center Origin map

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -485,7 +485,7 @@ class DashboardController extends AbstractController
                             'hoverinfo' => 'text',
                             'text' => [$label],
                             'marker' => [
-                                'size' => ($count/$max_val) * 25,
+                                'size' => (($count/$max_val) * 20) + 5,
                                 'color' => $this->getColorBrewerVal($i),
                                 'line' => [
                                     'color' => 'black',


### PR DESCRIPTION
When viewing the `Registered` tier, the `UNSET` dot is outsized to the others, resulting in them being too small to mouse over on the map. This PR adjusts so that all dots are at least five units large.

[[DASH1-82](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-82)]

### Before

![Screen Shot 2019-03-13 at 11 00 20 AM](https://user-images.githubusercontent.com/80459/54294215-3a224b80-457f-11e9-8026-eb225bb6722c.png)

### After

![Screen Shot 2019-03-13 at 10 45 48 AM](https://user-images.githubusercontent.com/80459/54294082-01827200-457f-11e9-92c8-7df670619987.png)