### PR TITLE
[DASH1-110] Make contextual help tab-specific

### DIFF
--- a/views/dashboard/base.html.twig
+++ b/views/dashboard/base.html.twig
@@ -55,7 +55,7 @@
               <div class="alert alert-success"><button type="button" class="close" data-dismiss="alert">&times;</button>{{ flashMessage }}</div>
           {% endfor %}
       </div>
-        <h2 id="dashboard-heading"><i class="fa fa-tachometer" aria-hidden="true"></i> Dashboard <i class="fa fa-question-circle text-info pull-right" style="cursor: pointer;" id="dashboard-help"></i> </h2>
+        <h2 id="dashboard-heading"><i class="fa fa-tachometer" aria-hidden="true"></i> Dashboard <i class="fa fa-question-circle text-info pull-right" style="cursor: pointer;" id="dashboard-help" data-target="{{ global.request.attributes.get('_route') }}_help_modal"></i> </h2>
         {% block body %}{% endblock %}
     </div>
 

--- a/views/dashboard/partials/modal-dashboard-help.html.twig
+++ b/views/dashboard/partials/modal-dashboard-help.html.twig
@@ -1,75 +1,213 @@
-<div class="modal fade" id="dashboad-help-modal" tabindex="-1" role="dialog" aria-labelledby="loading-modal" aria-hidden="true">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h2 class="text-center">Dashboard Help</h2>
-            </div>
-            <div class="modal-body">
-                <h3>General Usage/ Plot Options</h3>
-                <p>To view any individual metric, select it from the dropdown in the <strong>Plot Options</strong> pane and the associated plot will automatically update. Every plot has an end date that specifies the last day of metrics used to compute the plot.</p>
-                <p>Changing any value in the Plot Options pane will cause the associated plot to automatically update.</p>
-                <h3>Advanced Filters</h3>
-                <p>With any plot, you can filter the source data by selecting individual or groups of HPOs. This will calculate the selected metric by only using data corresponding to the selected centers. To view this data, select the desired centers individually and click <strong>Filter Results</strong>. You can also select/deselect entire groups or all centers by using the <strong>Group</strong> or <strong>All</strong> toggles, respectively.</p>
-                <h3>Using Plots</h3>
-                <p>All plots, whether bar- or map-based, can be zoomed or panned by either clicking and dragging or using the plot zoom controls in the upper right-hand corner of the plot. Every element displayed on the plot will contain additional information that is displayed on mouse hover. Double clicking any plot will reset the zoom to its default level. You can also export an image of the current view by clicking the camera icon in the plot control bar.</p>
-                <h3>Available Dashboards</h3>
-                <p>There are 4 available plots in the dashboard: <strong>Total Progress to Date</strong>, <strong>Real-Time Data</strong>, <strong>Participants by Region</strong>, and <strong>Participants by Lifecycle Phase</strong>.</p>
-                <h4 class="text-primary">Total Progress to Date</h4>
-                <p>This plot will show various participant metrics and their associated values grouped over time. The available
-                metrics include:</p>
+<div class="modal fade" id="dashboard_totalProgress_help_modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h2>Total Progress to Date</h2>
+      </div>
+      <div class="modal-body">
+        <p>This plot will show various participant metrics and their associated values grouped over time. The available metrics include:</p>
+        <ul>
+          <li>
+            <strong>Enrollment Status:</strong>
+            <ul>
+              <li><strong>Registered:</strong> A person who created an account by entering a name and either a mobile phone number or an email address and has chosen a language preference but has not yet completed the informed consent process. A registered participant has a unique AoURP participant identifier (PID).</li>
+              <li>
+                <strong>Consented:</strong> A person who meets the eligibility and inclusion criteria and is enrolled in AoURP. A consented individual has completed the primary informed consent process and the HIPAA Authorization/EHR consent (if available and where relevant, based on AoURP capacity to effectively search for and access records). A consented individual hasn’t yet participated in any research program activities such as completion of questionnaires or providing physical measurements and biospecimens.
                 <ul>
-                  <li><strong>Enrollment Status</strong>:
-                    <ul>
-                      <li><strong>Registered:</strong> A person who created an account by entering a name and either a mobile phone number or an email address and has chosen a language preference but has not yet completed the informed consent process. A registered participant has a unique AoURP participant identifier (PID).</li>
-                      <li><strong>Consented:</strong> A person who meets the eligibility and inclusion criteria and is enrolled in AoURP. A consented individual has completed the primary informed consent process and the HIPAA Authorization/EHR consent (if available and where relevant, based on AoURP capacity to effectively search for and access records). A consented individual hasn’t yet participated in any research program activities such as completion of questionnaires or providing physical measurements and biospecimens.
-                        <ul>
-                          <li><em>Note:</em> DV Participants who have completed the primary informed consent process and the DV EHR Intent to Share are included in Consented participant counts.</li>
-                        </ul>
-                      </li>
-                      <li><strong>Core Participant:</strong> A person who completed the required PPI modules and provided physical measurements and biospecimens. A core participant can contribute to other activities such as providing digital health data using sensor modules and/or wearables, if available.
-                        <ul>
-                          <li><em>Note:</em> Core Participant status requires receipt of sample for sequencing at the biobank.</li>
-                        </ul>
-                      </li>
-                    </ul>
-                  </li>
-                  <li><strong>Gender Identity</strong></li>
-                  <li><strong>Age Range</strong></li>
-                  <li><strong>Race</strong></li>
-                  <li><strong>Total Registered Participants</strong></li>
+                  <li><em>Note:</em> DV Participants who have completed the primary informed consent process and the DV EHR Intent to Share are included in Consented participant counts.</li>
                 </ul>
-                <p>The Total Progress to date plot has an additional start date to specify a discrete range of dates to calculate (this defaults to one week from the current date). You can also choose to see of rollup of values bucketed by days, weeks, or months by using the <strong>Interval</strong> dropdown. On bar charts, you can display column totals above each bar by clicking <strong>Show Column Totals</strong>.</p>
-                <h4 class="text-primary">Participants by Region</h4>
-                <p>The Participants by Region plot is a choropleth map of the United States showing counts of consented participants that correspond to geographic locations. These include:</p>
+              </li>
+              <li>
+                <strong>Core Participant:</strong> A person who completed the required PPI modules and provided physical measurements and biospecimens. A core participant can contribute to other activities such as providing digital health data using sensor modules and/or wearables, if available.
                 <ul>
-                    <li><strong>State</strong> of residence</li>
-                    <li><strong>Census Region</strong> of residence</li>
-                    <li><strong>Recruitment Origin</strong> (what HPO a participant registered through)</li>
+                  <li><em>Note:</em> Core Participant status requires receipt of sample for sequencing at the biobank.</li>
                 </ul>
-                <p>The values shown on the map are calculated as a percentage against that particular metric's target goal for the current year. For States & Census Regions, this is one-third of one percent (0.333%) of the total population recorded in the 2010 United States Census. For Recruitment Origin, this is the target total registration goal for the associated center.</p>
-                <p>The <strong>Color Profile</strong> dropdown allows you to re-color the map in a variety of shades (this only applies to the State and Census Region metrics).</p>
-                <h4 class="text-primary">Participants by Lifecycle Phase</h4>
-                <p>The Participants by Lifecycle Phase is a bar chart showing the progression of participants through the registration process. This measures counts at various milestones and gates 'eligibility' based on how many participants have completed the upstream events. The time points show are:</p>
-                <ul>
-                    <li><strong>Primary Consent</strong></li>
-                    <li><strong>Consent for enrollment</strong></li>
-                    <li><strong>Consent completed (both enrollment and health records)</strong></li>
-                    <li><strong>PPI module on lifestyle</strong></li>
-                    <li><strong>PPI module on overall health</strong></li>
-                    <li><strong>PPI module on 'the basics'</strong></li>
-                    <li><strong>Baseline PPI modules completed (3 previous PPI modules)</strong></li>
-                    <li><strong>Physical measurements recorded</strong></li>
-                    <li><strong>Samples received</strong></li>
-                    <li><strong>Core participants</strong></li>
-                </ul>
-                <p>For the Registration, Consent, PPI modules, and Physical Measurements milestones, we are counting participants who have completed these milestones. Sample collection is defined as participants for whom <em>4ml of blood or saliva</em> has been collected and received. Core Participants are defined as any participant that has completed all of the above milestones.</p>
-                <p>Eligibility for Consent is defined as any participant that has registered. Eligibility for any milestone from PPI modules onward is defined as any participant that has completed the primary consent for enrollment.</p>
-            </div>
-            <div class="modal-footer">
-                <button class="close" data-dismiss="modal">×</button>
-            </div>
-        </div>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <strong>Gender Identity</strong>
+            <ul>
+              <li>This plot will show the total number of individuals who have completed the Basics PPI module by gender identity over time. Participants who select an option other than “man” are considered <strong>underrepresented in biomedical research (UBR)</strong>.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Age Range</strong>
+            <ul>
+              <li>This plot will show the total number of individuals who have completed the Basics PPI module by age over time. Participants who are younger than 18 or older than 65 are considered <strong>underrepresented in biomedical research (UBR)</strong>.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Race</strong>
+            <ul>
+              <li>This plot will show the total number of individuals who have completed the Basics PPI module by race and ethnicity over time. Participants can select multiple options to indicate race and ethnicity. All values that are not “White” are considered <strong>underrepresented in biomedical research (UBR)</strong>.</li>
+            </ul>
+          </li>
+          <li>
+            <strong>Total Registered Participants</strong>
+            <ul>
+              <li>This plot will show the total number of individuals with a unique AoURP participant identifier (PID) over time.</li>
+            </ul>
+          </li>
+        </ul>
+        <p>The Total Progress to date plot has an additional start date to specify a discrete range of dates to calculate (this defaults to one week from the current date). You can also choose to see of rollup of values bucketed by days, weeks, or months by using the <strong>Interval</strong> dropdown. On bar charts, you can display column totals above each bar by clicking <strong>Show Column Totals</strong>.</p>
+        <h3>General Usage/ Plot Options</h3>
+        <p>To view any individual metric, select it from the dropdown in the Plot Options pane and the associated plot will automatically update. Every plot has an end date that specifies the last day of metrics used to compute the plot. Changing any value in the <strong>Plot Options</strong> pane will cause the associated plot to automatically update.</p>
+        <h3>Advanced Filters</h3>
+        <p>With any plot, you can filter the source data by selecting individual or groups of Awardees or, where available, Organizations. This action will calculate the selected metric by only using data corresponding to the selection(s). To view this data, select the desired centers individually and click <strong>Filter Results</strong>. You can also select/deselect entire groups or all centers by using the <strong>Group</strong> or <strong>All</strong> toggles, respectively.</p>
+        <h3>Using Plots</h3>
+        <p>All plots, whether bar or map-based, can be zoomed or panned by either clicking and dragging or using the plot zoom controls in the upper right-hand corner of the plot. Every element displayed on the plot will contain additional information that is displayed on mouse hover. Double clicking any plot will reset the zoom to its default level. You can also export an image of the current view by clicking the camera icon in the plot control bar.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
     </div>
+  </div>
+</div>
+
+<div class="modal fade" id="dashboard_realTime_help_modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+          <h2>Real-Time Data</h2>
+      </div>
+      <div class="modal-body">
+        <p>This plot will show various participant metrics and their associated values grouped over time, similar to the Total Progress to Date plot. One distinct difference is that the calculation of Core Participants is based on the collection of biosamples, rather than the receipt of biosamples at the biobank.  The available metrics include:</p>
+        <ul>
+          <li>
+            <strong>Enrollment Status:</strong>
+            <ul>
+              <li><strong>Registered:</strong> A person who created an account by entering a name and either a mobile phone number or an email address and has chosen a language preference but has not yet completed the informed consent process. A registered participant has a unique AoURP participant identifier (PID).</li>
+              <li>
+                <strong>Consented:</strong> A person who meets the eligibility and inclusion criteria and is enrolled in AoURP. A consented individual has completed the primary informed consent process and the HIPAA Authorization/EHR consent (if available and where relevant,based on AoURP capacity to effectively search for and access records). A consented individual hasn’t yet participated in any research program activities such as completion of questionnaires or providing physical measurements and biospecimens.</li>
+                <ul>
+                  <li><em>Note:</em> DV Participants who have completed the primary informed consent process and the DV EHR Intent to Share are included in Consented participant counts.</li>
+                </ul>
+              <li>
+                <strong>Core Participant:</strong> A person who completed the required PPI modules and provided physical measurements and biospecimens. A core participant can contribute to other activities such as providing digital health data using sensor modules and/or wearables, if available.
+                <ul>
+                  <li><strong><em>Note for Real Time Data calculations:</em> Core Participant status is calculated based on the collection of a biosample and does NOT require receipt of sample for sequencing at the biobank.</strong></li>
+                </ul>
+              </li>
+            </ul>
+          </li>
+        </ul>
+        <h3>General Usage/ Plot Options</h3>
+        <p>To view any individual metric, select it from the dropdown in the Plot Options pane and the associated plot will automatically update. Every plot has an end date that specifies the last day of metrics used to compute the plot. Changing any value in the <strong>Plot Options</strong> pane will cause the associated plot to automatically update.</p>
+        <h3>Advanced Filters</h3>
+        <p>With any plot, you can filter the source data by selecting individual or groups of Awardees or, where available, Organizations. This action will calculate the selected metric by only using data corresponding to the selection(s). To view this data, select the desired centers individually and click <strong>Filter Results</strong>. You can also select/deselect entire groups or all centers by using the <strong>Group</strong> or <strong>All</strong> toggles, respectively.</p>
+        <h3>Using Plots</h3>
+        <p>All plots, whether bar or map-based, can be zoomed or panned by either clicking and dragging or using the plot zoom controls in the upper right-hand corner of the plot. Every element displayed on the plot will contain additional information that is displayed on mouse hover. Double clicking any plot will reset the zoom to its default level. You can also export an image of the current view by clicking the camera icon in the plot control bar.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="dashboard_participantsByRegion_help_modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+          <h2>Participants by Region</h2>
+      </div>
+      <div class="modal-body">
+
+        <p>The Participants by Region plot is a choropleth map of the United States showing counts of participants by enrollment status that correspond to geographic locations. These include:</p>
+        <ul>
+          <li><strong>State</strong> of residence</li>
+          <li><strong>Census Region</strong> of residence</li>
+          <li><strong>Recruitment Origin</strong> (what HPO a participant registered through)</li>
+        </ul>
+        <p>The <strong>Color Profile</strong> dropdown allows you to re-color the map in a variety of shades (this only applies to the State and Census Region metrics).</p>
+        <h3>General Usage/ Plot Options</h3>
+        <p>To view any individual metric, select it from the dropdown in the Plot Options pane and the associated plot will automatically update. Every plot has an end date that specifies the last day of metrics used to compute the plot. Changing any value in the <strong>Plot Options</strong> pane will cause the associated plot to automatically update.</p>
+        <h3>Advanced Filters</h3>
+        <p>With any plot, you can filter the source data by selecting individual or groups of Awardees or, where available, Organizations. This action will calculate the selected metric by only using data corresponding to the selection(s). To view this data, select the desired centers individually and click <strong>Filter Results</strong>. You can also select/deselect entire groups or all centers by using the <strong>Group</strong> or <strong>All</strong> toggles, respectively.</p>
+        <h3>Using Plots</h3>
+        <p>All plots, whether bar or map-based, can be zoomed or panned by either clicking and dragging or using the plot zoom controls in the upper right-hand corner of the plot. Every element displayed on the plot will contain additional information that is displayed on mouse hover. Double clicking any plot will reset the zoom to its default level. You can also export an image of the current view by clicking the camera icon in the plot control bar.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="dashboard_participantsByLifecycle_help_modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+          <h2>Participant by Lifecycle Phase</h2>
+      </div>
+      <div class="modal-body">
+        <p>The Participants by Lifecycle Phase is a bar chart showing the progression of participants through the registration process. This measures counts at various milestones and gates 'eligibility' based on how many participants have completed the upstream events. The time points show are:</p>
+        <ul>
+          <li><strong>Registered</strong></li>
+          <li><strong>Primary Consent</strong></li>
+          <li><strong>Primary + EHR/EHR-lite Consent</strong></li>
+          <li><strong>PPI Module: The Basics</strong></li>
+          <li><strong>PPI Module: Overall Health</strong></li>
+          <li><strong>PPI Module: Lifestyle</strong></li>
+          <li><strong>Baseline PPI Modules Complete (3 previous PPI modules)</strong></li>
+          <li><strong>Physical Measurements recorded</strong></li>
+          <li><strong>Samples Received</strong></li>
+          <li><strong>Core Participant</strong></li>
+        </ul>
+        <p>For the Registration, Consent, PPI modules, and Physical Measurements milestones, we are counting participants who have completed these milestones. Samples Received is defined as participants for whom <em>4ml of blood or saliva</em> has been collected and received at the Biobank for sequencing. Core Participants are defined as any participant that has completed all of the previous milestones.</p>
+        <p>Eligibility for Consent is defined as any participant that has registered. Eligibility for any milestone from PPI modules onward is defined as any participant that has completed the primary consent.</p>
+        <h3>General Usage/ Plot Options</h3>
+        <p>To view any individual metric, select it from the dropdown in the Plot Options pane and the associated plot will automatically update. Every plot has an end date that specifies the last day of metrics used to compute the plot. Changing any value in the <strong>Plot Options</strong> pane will cause the associated plot to automatically update.</p>
+        <h3>Advanced Filters</h3>
+        <p>With any plot, you can filter the source data by selecting individual or groups of Awardees or, where available, Organizations. This action will calculate the selected metric by only using data corresponding to the selection(s). To view this data, select the desired centers individually and click <strong>Filter Results</strong>. You can also select/deselect entire groups or all centers by using the <strong>Group</strong> or <strong>All</strong> toggles, respectively.</p>
+        <h3>Using Plots</h3>
+        <p>All plots, whether bar or map-based, can be zoomed or panned by either clicking and dragging or using the plot zoom controls in the upper right-hand corner of the plot. Every element displayed on the plot will contain additional information that is displayed on mouse hover. Double clicking any plot will reset the zoom to its default level. You can also export an image of the current view by clicking the camera icon in the plot control bar.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="dashboard_ehr_help_modal" tabindex="-1" role="dialog" aria-hidden="true">
+  <div class="modal-dialog modal-lg">
+    <div class="modal-content">
+      <div class="modal-header">
+          <h2>EHR Data</h2>
+      </div>
+      <div class="modal-body">
+
+        <h3>EHR Volume</h3>
+        <p>The EHR Data:EHR Volume dashboard is a collection of visualizations and data tables that provides insight into the amount of EHR data that has been uploaded by various organizations over time. EHR Data is shared on a quarterly basis, so adjustments to the cutoff date will display metrics as of the most recent quarterly upload.</p>
+        <h3>EHR Consent vs. EHR Data</h3>
+        <p>This plot provides insight into a comparison between the number of participants who have signed the EHR consent vs the number of participants for whom the program has received at least some EHR data. Note that the count of participants who have consented to share EHR data is being calculated based on participants paired with organizations that are uploading EHR data and not a total for participants (ex: Unpaired Direct Volunteers).</p>
+        <h3>Organizations providing EHR Data</h3>
+        <p>This plot provides counts of organizations uploading EHR Data over time. EHR Data is uploaded at least on a quarterly basis (per program requirements) so adjustments to the cutoff date will date will display metrics as of the most recent quarter.</p>
+        <h3>Organization Data</h3>
+        <p>This data table will provide a participant funnel view that covers key markers in the participant journey. A list of additional column descriptions can be found below:</p>
+        <ul>
+          <li><strong>Organization Name</strong></li>
+          <li><strong>Total Participants:</strong> Total number of individuals paired with the organization</li>
+          <li><strong>Total Primary Consented:</strong> Total number of participants who have signed the primary consent</li>
+          <li><strong>EHR Consented:</strong> Total number of participants who have signed the EHR consent</li>
+          <li><strong>Core Participants:</strong> Total number participants with a PID, a signed primary consent, a signed EHR Consent, completed first three PPI Modules, submitted Physical Measurements and have a Biosample that has been received at the Biobank for sequencing</li>
+          <li><strong>EHR Data Received:</strong> Total number of participants with EHR data</li>
+          <li><strong>Last EHR Submission Date:</strong> Most recent date of EHR data upload by organization, pulled from bucket logs.</li>
+        </ul>
+        <h3>General Usage/ Plot Options</h3>
+        <p>To view any individual metric, select it from the dropdown in the Plot Options pane and the associated plot will automatically update. Every plot has an end date that specifies the last day of metrics used to compute the plot. Changing any value in the <strong>Plot Options</strong> pane will cause the associated plot to automatically update.</p>
+        <h3>Advanced Filters</h3>
+        <p>With any plot, you can filter the source data by selecting individual or groups of Awardees or, where available, Organizations. This action will calculate the selected metric by only using data corresponding to the selection(s). To view this data, select the desired centers individually and click <strong>Filter Results</strong>. You can also select/deselect entire groups or all centers by using the <strong>Group</strong> or <strong>All</strong> toggles, respectively.</p>
+        <h3>Using Plots</h3>
+        <p>All plots, whether bar or map-based, can be zoomed or panned by either clicking and dragging or using the plot zoom controls in the upper right-hand corner of the plot. Every element displayed on the plot will contain additional information that is displayed on mouse hover. Double clicking any plot will reset the zoom to its default level. You can also export an image of the current view by clicking the camera icon in the plot control bar.</p>
+      </div>
+      <div class="modal-footer">
+        <button class="close" data-dismiss="modal">×</button>
+      </div>
+    </div>
+  </div>
 </div>
 
 <div class="modal fade" id="display-metrics-help-modal" tabindex="-1" role="dialog" aria-labelledby="loading-modal" aria-hidden="true">
@@ -128,7 +266,8 @@
 
 <script type="text/javascript">
     $('#dashboard-help').on('click', function() {
-       $('#dashboad-help-modal').modal('show');
+      var modalId = $('#dashboard-help').data('target');
+      $('#' + modalId).modal('show');
     });
 
     $('#display-metrics-help').on('click', function() {


### PR DESCRIPTION
This PR reduces the rather large help modal for the Dashboards to only apply to the tab route you are visiting. It also adds content for the new EHR Data tab.

[[DASH1-110](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-110)]