### PR TITLE
[DASH1-122] Format X-axis on EHR time-series charts

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -766,7 +766,7 @@ class DashboardController extends AbstractController
                 $consented = [];
                 $consented_text = [];
                 foreach ($metrics as $row) {
-                    array_push($dates, $row['date']);
+                    array_push($dates, $this->formatDateToQuarter($row['date']));
                     array_push($received, (int) $row['metrics']['EHR_RECEIVED']);
                     array_push($received_text, number_format($row['metrics']['EHR_RECEIVED']));
                     array_push($consented, (int) $row['metrics']['EHR_CONSENTED']);
@@ -802,7 +802,7 @@ class DashboardController extends AbstractController
                 $orgs = [];
                 $orgs_text = [];
                 foreach ($metrics as $row) {
-                    array_push($dates, $row['date']);
+                    array_push($dates, $this->formatDateToQuarter($row['date']));
                     array_push($orgs, (int) $row['metrics']['ORGANIZATIONS_ACTIVE']);
                     array_push($orgs_text, number_format($row['metrics']['ORGANIZATIONS_ACTIVE']));
                 }
@@ -1216,5 +1216,22 @@ class DashboardController extends AbstractController
             }
         }
         return array_values($output);
+    }
+
+    /**
+     * Format Date to Quarter
+     *
+     * @param string $date
+     * @return string
+     */
+    private function formatDateToQuarter($date)
+    {
+        $ts = strtotime($date);
+        $output = sprintf(
+            'Q%d %d',
+            ceil((int) date('m', $ts)/3),
+            date('Y', $ts)
+        );
+        return $output;
     }
 }

--- a/views/dashboard/ehr.html.twig
+++ b/views/dashboard/ehr.html.twig
@@ -161,7 +161,8 @@ function renderMetricsEhrPlots() {
                             fixedrange: true
                         },
                         xaxis: {
-                            fixedrange: true
+                            type: 'text',
+                            fixedrange: false
                         }
                     };
 


### PR DESCRIPTION
These charts are set up to display the data in quarterly buckets, but Plotly was trying to be helpful by setting the X-axis as a time scale.  This produced weird results on certain resolutions. This PR changes the X-axis to be bucketed as strings indicating the quarter instead.

[[DASH1-122](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-122)]