### PR TITLE
[DASH1-119] EHR Metrics > Flatten to current day

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -299,7 +299,6 @@ class DashboardController extends AbstractController
         $traces_obj = [];
         $interval_counts = [];
 
-        // Reverse the arrays, as the last item added appears as first value in chart
         $trace_names = array_keys($display_values);
 
         // if we got this far, we have data!
@@ -821,6 +820,10 @@ class DashboardController extends AbstractController
                 ];
                 break;
             case 'Organizations':
+                // Sort by organization_name
+                usort($metrics, function ($a, $b) {
+                    return strcmp($a['organization_name'], $b['organization_name']);
+                });
                 // Render as a table
                 $ehr_data = [];
                 foreach (array_values($metrics) as $i => $metrics) {

--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -759,23 +759,12 @@ class DashboardController extends AbstractController
 
         switch ($mode) {
             case 'ParticipantsOverTime':
-                $dates = [];
-                $received = [];
-                $received_text = [];
-                $consented = [];
-                $consented_text = [];
-                foreach ($metrics as $row) {
-                    array_push($dates, $row['date']);
-                    array_push($received, (int) $row['metrics']['EHR_RECEIVED']);
-                    array_push($received_text, number_format($row['metrics']['EHR_RECEIVED']));
-                    array_push($consented, (int) $row['metrics']['EHR_CONSENTED']);
-                    array_push($consented_text, number_format($row['metrics']['EHR_CONSENTED']));
-                }
+                $dates = [date('Y-m-d')];
                 $ehr_data = [
                     [
                         "x" => $dates,
-                        "y" => $received,
-                        "text" => $received_text,
+                        "y" => [(int) $metrics['EHR_RECEIVED']],
+                        "text" => [number_format($metrics['EHR_RECEIVED'])],
                         "type" => 'bar',
                         "hoverinfo" => 'text+name',
                         "name" => 'EHR Data Received',
@@ -785,8 +774,8 @@ class DashboardController extends AbstractController
                     ],
                     [
                         "x" => $dates,
-                        "y" => $consented,
-                        "text" => $consented_text,
+                        "y" => [(int) $metrics['EHR_CONSENTED']],
+                        "text" => [number_format($metrics['EHR_CONSENTED'])],
                         "type" => 'bar',
                         "hoverinfo" => 'text+name',
                         "name" => 'Total Participants EHR Consent',

--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -743,7 +743,7 @@ class DashboardController extends AbstractController
         $mode = $request->get('mode');
         $start_date = $request->get('start_date', date('Y-m-d'));
         $end_date = $request->get('end_date', date('Y-m-d'));
-        $interval = $request->get('interval', 'quarter');
+        $interval = $request->get('interval', 'day');
         $organizations = $request->get('organizations', []);
         $params = [];
 

--- a/views/dashboard/ehr.html.twig
+++ b/views/dashboard/ehr.html.twig
@@ -9,29 +9,9 @@
             <div class="row">
                 <div id="ehr-filters" class="col-md-3">
                     {% include 'dashboard/partials/filters.html.twig' with {id: 'ehr', show_organizations: true, show_recruitment_centers: false, show_enrollment_status: false} %}
-                    <div class="panel panel-default">
-                        <div class="panel-heading">
-                            <div class="panel-title">
-                                <h4 class="text-primary">Plot Options</h4>
-                            </div>
-                        </div>
-                        <div class="panel-body">
-                            <div class="row form-group-sm">
-                                <div class="col-md-6 col-xs-3 form-group form-group-sm">
-                                    <label for="ehr-start-date">Start</label>
-                                    <input type="text" class="form-control datepicker ehr-time-control" id="ehr-start-date" />
-                                </div>
-                                <div class="col-md-6 col-xs-3 form-group form-group-sm">
-                                    <label for="ehr-end-date">Cutoff</label>
-                                    <input type="text" class="form-control datepicker ehr-time-control" id="ehr-end-date" />
-                                </div>
-                                <div class="col-md-12 col-xs-12 form-group form-group-sm">
-                                    <label>Show Column Totals <input type="checkbox" id="ehr-show-annot" class="ehr-plot-control"></label>
-                                </div>
-                            </div>
-                        </div>
-
-                    </div>
+                    <script>
+                    $('#ehr-filters-content').removeClass('collapse')
+                    </script>
                 </div>
                 <div class="col-md-9">
                   <div id="plotly-ehr-participant" class="plotly-div"></div>
@@ -43,14 +23,6 @@
                   <div class="row">
                     <div class="col-md-12">
                       <hr />
-                    </div>
-                  </div>
-                  <div class="row">
-                    <div class="col-md-12">
-                      <div id="plotly-ehr-organization-count" class="plotly-div"></div>
-                      <div class="table-responsive">
-                        <div id="table-ehr-organization-count" class="table-div"></div>
-                      </div>
                     </div>
                   </div>
                   <div class="row">
@@ -96,27 +68,9 @@ function showError(div, msg) {
  */
 function renderMetricsEhrPlots() {  
     // throw error if date selection is invalid
-    var ehrStartDate = $('#ehr-start-date').val();
-    var ehrEndDate = $('#ehr-end-date').val();
     var ehrOrganizations = loadOrganizationFilters('ehr');
     if (ehrOrganizations.length == 0) {
         alert('You must select at least one organization to plot results');
-        return false;
-    }
-
-    // Restrict min/max dates based on selections
-    $(document).ready(function() {
-        $('#ehr-end-date').data("DateTimePicker").minDate(ehrStartDate);
-        $('#ehr-start-date').data("DateTimePicker").maxDate(ehrEndDate);
-        $('#ehr-start-date').on("dp.change", function(e) {
-            $('#ehr-end-date').data("DateTimePicker").minDate(e.date);
-        });
-        $('#ehr-end-date').on("dp.change", function(e) {
-            $('#ehr-start-date').data("DateTimePicker").maxDate(e.date);
-        });
-    });
-    if (new Date(ehrStartDate) > new Date(ehrEndDate)) {
-        alert('Your date selection is invalid: The selected cutoff date of ' + ehrEndDate + ' is before ' + ehrStartDate + '. Please select a valid date range.');
         return false;
     }
 
@@ -127,7 +81,6 @@ function renderMetricsEhrPlots() {
 
     // gather params
     var ehrInterval = $('#ehr-interval').val();
-    var showAnnot = $('#ehr-show-annot').is(':checked');
     var ehrParticipantWidth = $('#plotly-ehr-participant').width() - 30;
     var ehrSitesWidth = $('#plotly-ehr-sites').width() - 30;
 
@@ -140,9 +93,6 @@ function renderMetricsEhrPlots() {
         $.getJSON('/dashboard/metrics_load_ehr', {
                 csrf_token: CsrfToken,
                 mode: 'ParticipantsOverTime',
-                start_date: ehrStartDate,
-                end_date: ehrEndDate,
-                interval: 'quarter',
                 organizations: ehrOrganizations
             })
             .done(function(data) {
@@ -161,14 +111,10 @@ function renderMetricsEhrPlots() {
                             fixedrange: true
                         },
                         xaxis: {
-                            fixedrange: true
+                            fixedrange: false,
+                             tickformat: '%Y-%m-%d'
                         }
                     };
-
-                    // load column totals if requested
-                    if (showAnnot) {
-                        loadBarChartAnnotations(data, progressAnnot);
-                    }
 
                     // load table data
                     loadTableData(tableDiv, data, ehrParticipantLayout.title);
@@ -194,68 +140,6 @@ function renderMetricsEhrPlots() {
     }
 
     /**
-     * Organizations Active Over Time
-     */
-    function updateOrganizationsActiveOverTime() {
-        var plotlyDiv = $('#plotly-ehr-organization-count');
-        var tableDiv = $('#table-ehr-organization-count');
-        $.getJSON('/dashboard/metrics_load_ehr', {
-                csrf_token: CsrfToken,
-                mode: 'OrganizationsActiveOverTime',
-                start_date: ehrStartDate,
-                end_date: ehrEndDate,
-                interval: 'quarter',
-                organizations: ehrOrganizations
-            })
-            .done(function(data) {
-                $(plotlyDiv).empty();
-                $(tableDiv).empty();
-                if (data.length != 0) {
-                    var progressAnnot = [];
-                    var ehrOrganizationCountLayout = {
-                        title: '<b>Organizations</b> providing <b>EHR Data</b>',
-                        font: PLOTLY_LABEL_FONT,
-                        width: ehrSitesWidth,
-                        height: ehrSitesWidth / 1.66,
-                        hovermode: 'closest',
-                        annotations: progressAnnot,
-                        yaxis: {
-                            fixedrange: true
-                        },
-                        xaxis: {
-                            fixedrange: true
-                        }
-                    };
-
-                    // load column totals if requested
-                    if (showAnnot) {
-                        loadBarChartAnnotations(data, progressAnnot);
-                    }
-
-                    // load table data
-                    loadTableData(tableDiv, data, ehrOrganizationCountLayout.title);
-
-                    // render plot, remove plotly link
-                    Plotly.newPlot('plotly-ehr-organization-count', data, ehrOrganizationCountLayout, PLOTLY_OPTS);
-                    removePlotlyLink('plotly-ehr-organization-count');
-
-                    // set toggle traces switch to on, regardless of previous state
-                    $('#toggle-traces .toggle-switch').attr('class', 'fa fa-toggle-on toggle-switch');
-
-                } else {
-                    showError(plotlyDiv, ErrorMessages.no_data);
-                }
-            })
-            .fail(function(jqXHR) {
-                try {
-                    showError(plotlyDiv, JSON.parse(jqXHR.responseText).error);
-                } catch (e) {
-                    showError(plotlyDiv, ErrorMessages.general);
-                }
-            });
-    }
-
-    /**
      * Organizations Table
      */
     function updateOrganizations() {
@@ -263,22 +147,38 @@ function renderMetricsEhrPlots() {
         $.getJSON('/dashboard/metrics_load_ehr', {
                 csrf_token: CsrfToken,
                 mode: 'Organizations',
-                start_date: ehrStartDate,
-                end_date: ehrEndDate,
                 interval: 'quarter',
                 organizations: ehrOrganizations
             })
             .done(function(data) {
                 $(tableDiv).empty()
                 if (data.length != 0) {
-                    // load column totals if requested
-                    if (showAnnot) {
-                        loadBarChartAnnotations(data, progressAnnot);
-                    }
-
                     // load table data
                     $(tableDiv).html('<table class="table table-striped"><thead></thead><tbody></tbody></table>')
                     $('thead', tableDiv).append('<tr><th>Organization</th><th>Total Participants</th><th>Total EHR Consent</th><th>Total Core</th><th>Total EHR Data Received</th><th>Last EHR Submission Date</th></tr>');
+                    // Calculate totals to show at top
+                    var columnTotals = {
+                      total_primary_consented: 0,
+                      total_ehr_consented: 0,
+                      total_core_participants: 0,
+                      total_ehr_data_received: 0
+                    }
+                    $(data).each(function(i, row) {
+                      columnTotals.total_primary_consented += row.total_primary_consented
+                      columnTotals.total_ehr_consented += row.total_ehr_consented
+                      columnTotals.total_core_participants += row.total_core_participants
+                      columnTotals.total_ehr_data_received += row.total_ehr_data_received
+                    });
+                    var totalRow = $('<tr class="info" />')
+                    totalRow.append('<td>Total</td>')
+                    totalRow.append('<td>' +  columnTotals.total_primary_consented + '</td>')
+                    totalRow.append('<td>' +  columnTotals.total_ehr_consented + '</td>')
+                    totalRow.append('<td>' +  columnTotals.total_core_participants + '</td>')
+                    totalRow.append('<td>' +  columnTotals.total_ehr_data_received + '</td>')
+                    totalRow.append('<td>&nbsp;</td>')
+                    totalRow.css({fontWeight: 'bold'})
+                    $('tbody', tableDiv).append(totalRow)
+                    // Render row level data
                     $(data).each(function(i, row) {
                         var organizationRow = $('<tr />')
                         organizationRow.append('<td>' + row.organization_name + '</td>')
@@ -304,7 +204,7 @@ function renderMetricsEhrPlots() {
     }
 
     // Call them in sequence
-    $.when(updateParticipantsOverTime(), updateOrganizationsActiveOverTime(), updateOrganizations()).done(function() {
+    $.when(updateParticipantsOverTime(), updateOrganizations()).done(function() {
         $('#loading-modal').modal('hide');
     });
 


### PR DESCRIPTION
This PR remove the time-series nature of the EHR Metrics dashboard and shows only the most recent day. This is done as a workaround to some issues we have with historical tracking.

(Includes #512)

[[DASH1-110](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-119)]