### PR TITLE
[DASH1-134] Relabel 'Consented' to 'Fully Consented'

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -233,13 +233,13 @@ class DashboardController extends AbstractController
                 if ($history) {
                     $display_values = [
                         'registered' => 'Registered',
-                        'consented' => 'Consented',
+                        'consented' => 'Fully Consented',
                         'core' => 'Core Participant'
                     ];
                 } else {
                     $display_values = [
                         'INTERESTED' => 'Registered',
-                        'MEMBER' => 'Consented',
+                        'MEMBER' => 'Fully Consented',
                         'FULL_PARTICIPANT' => 'Core Participant'
                     ];
                 }

--- a/views/dashboard/partials/filters.html.twig
+++ b/views/dashboard/partials/filters.html.twig
@@ -20,7 +20,7 @@
                                     <label><input type="checkbox" name="enrollment_statuses[]" value="INTERESTED" class="enrollment-status-filter" checked> Registered</label>
                                 </li>
                                 <li class="list-group-item">
-                                    <label><input type="checkbox" name="enrollment_statuses[]" value="MEMBER" class="enrollment-status-filter" checked> Consented</label>
+                                    <label><input type="checkbox" name="enrollment_statuses[]" value="MEMBER" class="enrollment-status-filter" checked> Fully Consented</label>
                                 </li>
                                 <li class="list-group-item">
                                     <label><input type="checkbox" name="enrollment_statuses[]" value="FULL_PARTICIPANT" class="enrollment-status-filter" checked> Core Participant</label>

--- a/views/dashboard/participants-by-region.html.twig
+++ b/views/dashboard/participants-by-region.html.twig
@@ -111,7 +111,7 @@
             mappedEnrollmentStatuses.push('Registered');
           }
           if (enrollmentStatuses.indexOf('MEMBER') !== -1) {
-            mappedEnrollmentStatuses.push('Consented');
+            mappedEnrollmentStatuses.push('Fully Consented');
           }
           if (enrollmentStatuses.indexOf('FULL_PARTICIPANT') !== -1) {
             mappedEnrollmentStatuses.push('Core');


### PR DESCRIPTION
> This allows the "Participant" Status to be more explicitly differentiated from "Fully Consented" as becoming a participant denotes signing the primary consent. "Fully Consented" lets users know that there is something above and beyond just signing the primary consent.

## Tab 1

![Tab 1 - Legend](https://user-images.githubusercontent.com/80459/57722595-61af9600-764c-11e9-8769-64284534feed.png)
![Tab 1 - Table](https://user-images.githubusercontent.com/80459/57722596-61af9600-764c-11e9-94ab-6a9648fb9f7f.png)

## Tab 2

![Tab 2 - Filters](https://user-images.githubusercontent.com/80459/57722611-68d6a400-764c-11e9-8503-9caaaabf125a.png)
![Tab 2 - Legend](https://user-images.githubusercontent.com/80459/57722612-696f3a80-764c-11e9-878d-564060520426.png)
![Tab 2 - Table](https://user-images.githubusercontent.com/80459/57722614-696f3a80-764c-11e9-9ab9-552749007a85.png)

## Tab 3

![Tab 3 - Filters](https://user-images.githubusercontent.com/80459/57722616-6d02c180-764c-11e9-97f5-4355ca3837bc.png)

[[DASH1-134](https://precisionmedicineinitiative.atlassian.net/projects/DASH1/issues/DASH1-134)]