### PR TITLE
[DASH1-118] Add key for 'More than one gender identity'

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -254,7 +254,8 @@ class DashboardController extends AbstractController
                     'UNMAPPED' => 'UNMAPPED',
                     'UNSET' => 'UNSET',
                     'Woman' => 'Woman',
-                    'Prefer not to say' => 'Prefer not to say'
+                    'Prefer not to say' => 'Prefer not to say',
+                    'More than one gender identity' => 'More than one gender identity'
                 ];
                 break;
             case 'AGE_RANGE':


### PR DESCRIPTION
Ensures that we have a proper mapping for the new field as it comes in.

Note that #530 has the fix for the table showing a blank row when this is added.

[[DASH1-118](https://precisionmedicineinitiative.atlassian.net/projects/DASH1/issues/DASH1-118)]