### PR TITLE
[DASH1-138] Fix console JavaScript error on page resize

### DIFF
--- a/web/assets/js/dashboard.js
+++ b/web/assets/js/dashboard.js
@@ -75,7 +75,9 @@ function launchSpinner(divId) {
 }
 
 function stopSpinner(divId) {
-    $('#' + divId).data('spinner').stop();
+    if ($('#' + divId).data('spinner')) {
+        $('#' + divId).data('spinner').stop();
+    }
 }
 
 function removePlotlyLink(divId) {


### PR DESCRIPTION
@jt2k noticed this while testing something else. When the page is resized, Plotly attempts to re-render its graphs. However, our logic also tells it to stop the spinner when drawing the chart. Because there isn't a spinner to stop, the console log shows an error.

[[DASH1-138](https://precisionmedicineinitiative.atlassian.net/projects/DASH1/issues/DASH1-138)]