### PR TITLE
[DASH1-118] Hide empty rows from dashboard table

### DIFF
--- a/web/assets/js/dashboard.js
+++ b/web/assets/js/dashboard.js
@@ -189,12 +189,14 @@ function loadTableData(tableTarget, sourceData, colTitle) {
     // load scores
     var tableBody = $('#' + tableId + '-body');
     $($(sourceData).get().reverse()).each(function(index, row) {
-        var newRow = $('<tr>');
-        newRow.append($('<td>').text(row['name']));
-        $(row['y']).each(function(i, count) {
-            newRow.append($('<td>').text(count));
-        });
-        tableBody.append(newRow);
+        if (row.y.length) {
+          var newRow = $('<tr>');
+          newRow.append($('<td>').text(row['name']));
+          $(row['y']).each(function(i, count) {
+              newRow.append($('<td>').text(count));
+          });
+          tableBody.append(newRow);
+        }
     });
 }
 


### PR DESCRIPTION
This bug fix was part of the now-reverted #530. Without it, the "More than one gender identity" row will appear without any cell values until the RDR update/backfill deploys.

[[DASH1-118](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-118)]