### PR TITLE
[DASH1-140] Fix filter toggles where name has parenthesis

### DIFF
--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -373,8 +373,15 @@ abstract class AbstractApplication extends Application
         }));
 
         // Register custom Twig path_exists function
-        $this['twig']->addFunction(new Twig_SimpleFunction('path_exists', function($name) {
+        $this['twig']->addFunction(new Twig_SimpleFunction('path_exists', function ($name) {
             return !is_null($this['routes']->get($name));
+        }));
+
+        // Convert a string into a slug
+        $this['twig']->addFilter(new Twig_SimpleFilter('slugify', function ($text) {
+            $output = trim(strtolower($text));
+            $output = str_replace([' ', '-', '(', ')', ':'], '-', $output);
+            return $output;
         }));
 
         /**

--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -380,7 +380,7 @@ abstract class AbstractApplication extends Application
         // Convert a string into a slug
         $this['twig']->addFilter(new Twig_SimpleFilter('slugify', function ($text) {
             $output = trim(strtolower($text));
-            $output = str_replace([' ', '-', '(', ')', ':'], '-', $output);
+            $output = preg_replace('/[^a-z0-9]/', '-', $output);
             return $output;
         }));
 

--- a/src/Pmi/Drc/RdrHelper.php
+++ b/src/Pmi/Drc/RdrHelper.php
@@ -54,10 +54,12 @@ class RdrHelper
             $endpoint = $this->endpoint;
         }
 
-        $client = new \Memcache();
-        $cachePool = new MemcacheCachePool($client);
+        if (class_exists('Memcache')) {
+            $client = new \Memcache();
+            $cachePool = new MemcacheCachePool($client);
 
-        $googleClient->setCache($cachePool);
+            $googleClient->setCache($cachePool);
+        }
 
         return $googleClient->authorize(new HttpClient([
             'base_uri' => $endpoint,

--- a/src/Pmi/Drc/RdrHelper.php
+++ b/src/Pmi/Drc/RdrHelper.php
@@ -54,12 +54,10 @@ class RdrHelper
             $endpoint = $this->endpoint;
         }
 
-        if (class_exists('Memcache')) {
-            $client = new \Memcache();
-            $cachePool = new MemcacheCachePool($client);
+        $client = new \Memcache();
+        $cachePool = new MemcacheCachePool($client);
 
-            $googleClient->setCache($cachePool);
-        }
+        $googleClient->setCache($cachePool);
 
         return $googleClient->authorize(new HttpClient([
             'base_uri' => $endpoint,

--- a/views/dashboard/partials/filters.html.twig
+++ b/views/dashboard/partials/filters.html.twig
@@ -34,7 +34,7 @@
                             {% if show_recruitment_centers == true %}
                             <h4>Recruitment Origin <a href="javascript:void(0);" class="toggle-all-center-filters label label-primary pull-right">All <span class="fa fa-toggle-on"></span></a></h4>
                             {% for group, centers in recruitment_centers %}
-                                {% set group_id = group|lower|split(' ')|join('-') %}
+                                {% set group_id = group|slugify %}
                                 <ul class="list-group {{ group_id }}-center-filters">
                                     <li class="list-group-item"><h4 class="list-group-item-heading">{{ group }}
                                             {% if centers|length > 1 %}
@@ -57,7 +57,7 @@
                             {% if show_organizations == true %}
                             <h4>Organization <a href="javascript:void(0);" class="toggle-all-organization-filters label label-primary pull-right">All <span class="fa fa-toggle-on"></span></a></h4>
                             {% for group, orgs in organizations %}
-                                {% set group_id = group|lower|split(' ')|join('-') %}
+                                {% set group_id = group|slugify %}
                                 <ul class="list-group {{ group_id }}-organization-filters">
                                     <li class="list-group-item"><h4 class="list-group-item-heading">{{ group }}
                                             {% if orgs|length > 1 %}


### PR DESCRIPTION
The prior implementation of this took the name, lowercased it, split on whitespace and then joined it back together with dashes. Trouble with that is when the name contains other characters that may trip up the selector in jQuery. This implementation abstracts that away into a custom Twig function that 'slugify's the the name a bit better, though there are still cases where an org name could trip it up. If we needed a more robust solution, I'd advise using a third-party package specialized to the task.

[[DASH1-140](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-140)]