### PR TITLE
[DASH1-141] Refactor EHR dashboard to use single endpoint

### DIFF
--- a/src/Pmi/Console/Command/MetricsEHRCommand.php
+++ b/src/Pmi/Console/Command/MetricsEHRCommand.php
@@ -21,12 +21,7 @@ class MetricsEHRCommand extends Command
     /**
      * @var array
      */
-    private static $MODES = ['ParticipantsOverTime', 'OrganizationsActiveOverTime', 'Organizations'];
-
-    /**
-     * @var array
-     */
-    private static $INTERVALS = ['week', 'month', 'quarter'];
+    private static $MODES = ['ParticipantsOverTime', 'Organizations'];
 
     /**
      * Configure
@@ -38,25 +33,11 @@ class MetricsEHRCommand extends Command
         $this
             ->setName('pmi:metricsehr')
             ->addOption(
-                'start_date',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Date range beginning.',
-                date('Y-m-d', strtotime('today - 30 days'))
-            )
-            ->addOption(
                 'end_date',
                 null,
                 InputOption::VALUE_REQUIRED,
                 'Date range ending.',
                 date('Y-m-d')
-            )
-            ->addOption(
-                'interval',
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Interval of reporting.',
-                'week'
             )
             ->addOption(
                 'mode',
@@ -98,23 +79,10 @@ class MetricsEHRCommand extends Command
     {
         $output->setFormatter(new OutputFormatter(true));
 
-        $start_date = $input->getOption('start_date');
         $end_date = $input->getOption('end_date');
-        $interval = $input->getOption('interval');
         $mode = $input->getOption('mode');
         $organizations = $input->getOption('organizations');
         $pretty = ($input->getOption('pretty') !== false) ? JSON_PRETTY_PRINT : 0;
-
-        // Validate interval
-        if (!in_array($interval, self::$INTERVALS)) {
-            $output->writeln(sprintf(
-                '<error>Invalid interval: "%s"; Valid options: %s</error>',
-                $interval,
-                join(', ', self::$INTERVALS)
-            ));
-            // Throw a non-zero exit status
-            return 1;
-        }
 
         // Validate mode
         if (!is_null($mode) && !in_array($mode, self::$MODES)) {
@@ -122,17 +90,6 @@ class MetricsEHRCommand extends Command
                 '<error>Invalid mode: "%s"; Valid options: %s</error>',
                 $mode,
                 join(', ', self::$MODES)
-            ));
-            // Throw a non-zero exit status
-            return 1;
-        }
-
-        // Validate start and end dates
-        if ((bool) !strtotime($start_date) || (bool) !strtotime($end_date)) {
-            $output->writeln(sprintf(
-                '<error>Invalid dates: "%s", "%s"</error>',
-                $start_date,
-                $end_date
             ));
             // Throw a non-zero exit status
             return 1;
@@ -157,7 +114,7 @@ class MetricsEHRCommand extends Command
         }
 
         $metricsApi = new RdrMetrics($app['pmi.drc.rdrhelper']);
-        $data = $metricsApi->ehrMetrics($mode, $start_date, $end_date, $interval, $organizations);
+        $data = $metricsApi->ehrMetrics($mode, $end_date, $organizations);
 
         $output->writeln(json_encode($data, $pretty));
     }

--- a/src/Pmi/Console/Command/MetricsEHRCommand.php
+++ b/src/Pmi/Console/Command/MetricsEHRCommand.php
@@ -105,11 +105,8 @@ class MetricsEHRCommand extends Command
         if ($input->getOption('debug')) {
             $output->writeln('<info>Debugging Information</info>');
             $output->writeln('  Mode:                  ' . $mode);
-            $output->writeln('  Start Date:            ' . $start_date);
             $output->writeln('  End Date:              ' . $end_date);
-            $output->writeln('  Interval:              ' . $interval);
             $output->writeln('  Organizations:         ' . json_encode($organizations));
-            $output->writeln('  Additional Parameters: ' . json_encode($params));
             $output->writeln('');
         }
 

--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -761,18 +761,14 @@ class DashboardController extends AbstractController
 
         // get request attributes
         $mode = $request->get('mode');
-        $start_date = $request->get('start_date', date('Y-m-d'));
         $end_date = $request->get('end_date', date('Y-m-d'));
-        $interval = $request->get('interval', 'day');
         $organizations = $request->get('organizations', []);
         $params = [];
 
         $metrics = $this->getMetricsEHRObject(
             $app,
             $mode,
-            $start_date,
             $end_date,
-            $interval,
             $organizations,
             $params
         );
@@ -910,9 +906,7 @@ class DashboardController extends AbstractController
      *
      * @param Application $app
      * @param string      $mode
-     * @param string      $start_date
      * @param string      $end_date
-     * @param string      $interval
      * @param string      $centers
      * @param array       $params
      *
@@ -921,9 +915,7 @@ class DashboardController extends AbstractController
     private function getMetricsEHRObject(
         Application $app,
         $mode,
-        $start_date,
         $end_date,
-        $interval,
         $organizations,
         $params = []
     ) {
@@ -933,9 +925,7 @@ class DashboardController extends AbstractController
 
             $metrics = $metricsApi->ehrMetrics(
                 $mode,
-                $start_date,
                 $end_date,
-                $interval,
                 $organizations,
                 $params
             );

--- a/src/Pmi/Drc/RdrHelper.php
+++ b/src/Pmi/Drc/RdrHelper.php
@@ -54,10 +54,12 @@ class RdrHelper
             $endpoint = $this->endpoint;
         }
 
-        $client = new \Memcache();
-        $cachePool = new MemcacheCachePool($client);
+        if (class_exists('\Memcache')) {
+            $client = new \Memcache();
+            $cachePool = new MemcacheCachePool($client);
 
-        $googleClient->setCache($cachePool);
+            $googleClient->setCache($cachePool);
+        }
 
         return $googleClient->authorize(new HttpClient([
             'base_uri' => $endpoint,

--- a/views/dashboard/ehr.html.twig
+++ b/views/dashboard/ehr.html.twig
@@ -14,10 +14,10 @@
                     </script>
                 </div>
                 <div class="col-md-9">
-                  <div id="plotly-ehr-participant" class="plotly-div"></div>
+                  <div id="plotly-ehr-participants" class="plotly-div"></div>
                   <div class="col-md-12">
                     <div class="table-responsive">
-                      <div id="table-ehr-participant" class="table-div"></div>
+                      <div id="table-ehr-participants" class="table-div"></div>
                     </div>
                   </div>
                   <div class="row">
@@ -75,16 +75,15 @@ function renderMetricsEhrPlots() {
     $('.table-div').empty();
 
     // gather params
-    var ehrInterval = $('#ehr-interval').val();
-    var ehrParticipantWidth = $('#plotly-ehr-participant').width() - 30;
+    var ehrParticipantWidth = $('#plotly-ehr-participants').width() - 30;
     var ehrSitesWidth = $('#plotly-ehr-sites').width() - 30;
 
     /**
      * Participants Over Time
      */
     function updateParticipantsOverTime() {
-        var plotlyDiv = $('#plotly-ehr-participant');
-        var tableDiv = $('#table-ehr-participant');
+        var plotlyDiv = $('#plotly-ehr-participants');
+        var tableDiv = $('#table-ehr-participants');
         $.getJSON('/dashboard/metrics_load_ehr', {
                 csrf_token: CsrfToken,
                 mode: 'ParticipantsOverTime',
@@ -115,8 +114,8 @@ function renderMetricsEhrPlots() {
                     loadTableData(tableDiv, data, ehrParticipantLayout.title);
 
                     // render plot, remove plotly link
-                    Plotly.newPlot('plotly-ehr-participant', data, ehrParticipantLayout, PLOTLY_OPTS);
-                    removePlotlyLink('plotly-ehr-participant');
+                    Plotly.newPlot('plotly-ehr-participants', data, ehrParticipantLayout, PLOTLY_OPTS);
+                    removePlotlyLink('plotly-ehr-participants');
 
                     // set toggle traces switch to on, regardless of previous state
                     $('#toggle-traces .toggle-switch').attr('class', 'fa fa-toggle-on toggle-switch');
@@ -142,7 +141,6 @@ function renderMetricsEhrPlots() {
         $.getJSON('/dashboard/metrics_load_ehr', {
                 csrf_token: CsrfToken,
                 mode: 'Organizations',
-                interval: 'quarter',
                 organizations: ehrOrganizations
             })
             .done(function(data) {
@@ -226,7 +224,7 @@ $('.ehr-time-control').on('change', function() {
 
 // re-render on window resizeEnd if tab is visible
 $(window).on('resizeEnd', function() {
-    if ($('#plotly-ehr-participant').is(':visible')) {
+    if ($('#plotly-ehr-participants').is(':visible')) {
         renderMetricsEhrPlots();
     }
 });

--- a/views/dashboard/ehr.html.twig
+++ b/views/dashboard/ehr.html.twig
@@ -26,11 +26,6 @@
                     </div>
                   </div>
                   <div class="row">
-                    <div class="col-md-12">
-                      <hr />
-                    </div>
-                  </div>
-                  <div class="row">
                       <div class="col-md-12">
                           <h4 class="text-center">Organization Data</h4>
                           <div class="table-responsive">
@@ -111,8 +106,8 @@ function renderMetricsEhrPlots() {
                             fixedrange: true
                         },
                         xaxis: {
-                            fixedrange: false,
-                             tickformat: '%Y-%m-%d'
+                            fixedrange: true,
+                            tickformat: '%Y-%m-%d'
                         }
                     };
 


### PR DESCRIPTION
This is the follow-on work to DASH1-124. During QA, we caught some inconsistencies in the data being returned between the ParticipantsOverTime and Organizations endpoint, most likely attributed to cache timing. There is a consolidated endpoint (by omitting the type of data the user is after) that would guarantee the two data sets would be in sync at all times. This ticket is to refactor the existing dashboard to rely on that approach.

[[DASH1-141](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-141)]