### PR TITLE
[DASH1-143] Remove extraneous help copy

### DIFF
--- a/views/dashboard/partials/modal-dashboard-help.html.twig
+++ b/views/dashboard/partials/modal-dashboard-help.html.twig
@@ -186,8 +186,6 @@
         <p>The EHR Data:EHR Volume dashboard is a collection of visualizations and data tables that provides insight into the amount of EHR data that has been uploaded by various organizations over time. EHR Data is shared on a quarterly basis, so adjustments to the cutoff date will display metrics as of the most recent quarterly upload.</p>
         <h3>EHR Consent vs. EHR Data</h3>
         <p>This plot provides insight into a comparison between the number of participants who have signed the EHR consent (excludes the DV EHR Intent to Share consent) vs the number of participants for whom the program has received at least some EHR data. Note that the count of participants who have consented to share EHR data is being calculated based on participants paired with organizations that are uploading EHR data and not a total for participants (ex: Unpaired Direct Volunteers).</p>
-        <h3>Organizations providing EHR Data</h3>
-        <p>This plot provides counts of organizations uploading EHR Data over time. EHR Data is uploaded at least on a quarterly basis (per program requirements) so adjustments to the cutoff date will date will display metrics as of the most recent quarter.</p>
         <h3>Organization Data</h3>
         <p>This data table will provide a participant funnel view that covers key markers in the participant journey. A list of additional column descriptions can be found below:</p>
         <ul>


### PR DESCRIPTION
When launching the EHR dashboard, we had some leftover help text that is no longer applicable.

[[DASH1-143](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-143)]