### PR TITLE
[DASH1-137] Add Retention PPI modules to Lifecycle dashboard

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -657,7 +657,6 @@ class DashboardController extends AbstractController
         $end_date = $request->get('end_date');
         $centers = $request->get('centers');
         $enrollment_statuses = $request->get('enrollment_statuses');
-        $history = $request->get('history', true); // Data available only through history flag
 
         // Use 'ALL' keyword to send empty filter for awardee
         if ($centers == ['ALL']) {
@@ -674,7 +673,8 @@ class DashboardController extends AbstractController
             $centers,
             $enrollment_statuses,
             [
-                'history' => $history
+                'history' => true,
+                'version' => self::API_VERSION
             ]
         );
         $metrics = $this->combineHPOsByDate($metrics, $centers);

--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -652,6 +652,7 @@ class DashboardController extends AbstractController
         }
 
         // get request attributes
+        $mode = $request->get('mode');
         $stratification = $request->get('stratification');
         $end_date = $request->get('end_date');
         $centers = $request->get('centers');
@@ -684,24 +685,51 @@ class DashboardController extends AbstractController
             ], 400);
         }
 
-        $display_values = [
-            'Registered' => 'Registered',
-            'Consent_Enrollment' => 'Primary Consent',
-            'Consent_Complete' => 'Primary+EHR/EHR-lite Consent',
-            'PPI_Module_The_Basics' => 'PPI Module: The Basics',
-            'PPI_Module_Overall_Health' => 'PPI Module: Overall Health',
-            'PPI_Module_Lifestyle' => 'PPI Module: Lifestyle',
-            'Baseline_PPI_Modules_Complete' => 'Baseline PPI Modules Complete',
-            'Physical_Measurements' => 'Physical Measurements',
-            'Samples_Received' => 'Samples Received',
-            'Full_Participant' => 'Core Participant'
-        ];
+        switch ($mode) {
+            case 'ppi_baseline':
+                $display_values = [
+                    'PPI_Module_The_Basics' => 'PPI Module: The Basics',
+                    'PPI_Module_Overall_Health' => 'PPI Module: Overall Health',
+                    'PPI_Module_Lifestyle' => 'PPI Module: Lifestyle',
+                    'Baseline_PPI_Modules_Complete' => 'Baseline PPI Modules Complete',
+                ];
+                break;
+            case 'ppi_retention':
+                $display_values = [
+                    'PPI_Module_Healthcare_Access' => 'PPI Module: Healthcare Access and Utilization',
+                    'PPI_Module_Family_Health' => 'PPI Module: Family History',
+                    'PPI_Module_Medical_History' => 'PPI Module: Personal Medical History',
+                    'PPI_Retention_Modules_Complete' => '3 Retention Modules Complete',
+                ];
+                break;
+            case 'overview':
+            default:
+                $display_values = [
+                    'Registered' => 'Registered',
+                    'Consent_Enrollment' => 'Primary Consent',
+                    'Consent_Complete' => 'Primary+EHR/EHR-lite Consent',
+                    'Baseline_PPI_Modules_Complete' => 'Baseline PPI Modules Complete',
+                    'PPI_Retention_Modules_Complete' => '3 Retention Modules Complete',
+                    'Physical_Measurements' => 'Physical Measurements',
+                    'Samples_Received' => 'Samples Received',
+                    'Full_Participant' => 'Core Participant'
+                ];
+                break;
+        }
 
         $completed = [];
         $completed_text = [];
         $not_completed = [];
         $not_completed_text = [];
         foreach ($display_values as $display_key => $display_val) {
+            // Guard against empty values
+            if (!isset($metrics[0]['metrics']['completed'][$display_key])) {
+                $metrics[0]['metrics']['completed'][$display_key] = null;
+            }
+            if (!isset($metrics[0]['metrics']['not_completed'][$display_key])) {
+                $metrics[0]['metrics']['not_completed'][$display_key] = null;
+            }
+
             array_push($completed, $metrics[0]['metrics']['completed'][$display_key]);
             array_push($completed_text, sprintf(
                 '%s: %d',
@@ -741,6 +769,7 @@ class DashboardController extends AbstractController
                 ]
             ]
         ];
+
         // return json
         return $app->json($pipeline_data);
     }

--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -688,17 +688,17 @@ class DashboardController extends AbstractController
         switch ($mode) {
             case 'ppi_baseline':
                 $display_values = [
-                    'PPI_Module_The_Basics' => 'PPI Module: The Basics',
-                    'PPI_Module_Overall_Health' => 'PPI Module: Overall Health',
-                    'PPI_Module_Lifestyle' => 'PPI Module: Lifestyle',
-                    'Baseline_PPI_Modules_Complete' => 'Baseline PPI Modules Complete',
+                    'PPI_Module_The_Basics' => 'The Basics',
+                    'PPI_Module_Overall_Health' => 'Overall Health',
+                    'PPI_Module_Lifestyle' => 'Lifestyle',
+                    'Baseline_PPI_Modules_Complete' => '3 Baseline Modules Complete',
                 ];
                 break;
             case 'ppi_retention':
                 $display_values = [
-                    'PPI_Module_Healthcare_Access' => 'PPI Module: Healthcare Access and Utilization',
-                    'PPI_Module_Family_Health' => 'PPI Module: Family History',
-                    'PPI_Module_Medical_History' => 'PPI Module: Personal Medical History',
+                    'PPI_Module_Healthcare_Access' => 'Healthcare Access and Utilization',
+                    'PPI_Module_Family_Health' => 'Family History',
+                    'PPI_Module_Medical_History' => 'Personal Medical History',
                     'PPI_Retention_Modules_Complete' => '3 Retention Modules Complete',
                 ];
                 break;
@@ -709,7 +709,7 @@ class DashboardController extends AbstractController
                     'Consent_Enrollment' => 'Primary Consent',
                     'Consent_Complete' => 'Primary+EHR/EHR-lite Consent',
                     'Baseline_PPI_Modules_Complete' => 'Baseline PPI Modules Complete',
-                    'PPI_Retention_Modules_Complete' => '3 Retention Modules Complete',
+                    'PPI_Retention_Modules_Complete' => 'Retention PPI Modules Complete',
                     'Physical_Measurements' => 'Physical Measurements',
                     'Samples_Received' => 'Samples Received',
                     'Full_Participant' => 'Core Participant'

--- a/views/dashboard/participants-by-lifecycle.html.twig
+++ b/views/dashboard/participants-by-lifecycle.html.twig
@@ -28,15 +28,32 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-md-9 plotly-div" id="plotly-participants-by-lifecycle"></div>
-            </div>
-            <div class="row">
-                <div class="col-md-12">
-                    <h4 class="text-center">Raw Data</h4>
-                    <div class="table-responsive">
-                        <div id="participants-by-lifecycle-table"></div>
+                <div class="col-md-9 plotly-div">
+                  <!-- Overview -->
+                  <div id="plotly-participants-by-lifecycle-overview"></div>
+                  <div class="table-responsive">
+                      <div id="participants-by-lifecycle-overview-table"></div>
+                  </div>
+                  <div class="row">
+                    <div class="col-md-12">
+                      <hr />
                     </div>
-                </div>
+                  </div>
+                  <!-- Baseline PPI -->
+                  <div id="plotly-participants-by-lifecycle-baseline"></div>
+                  <div class="table-responsive">
+                      <div id="participants-by-lifecycle-baseline-table"></div>
+                  </div>
+                  <div class="row">
+                    <div class="col-md-12">
+                      <hr />
+                    </div>
+                  </div>
+                  <!-- Retention PPI -->
+                  <div id="plotly-participants-by-lifecycle-retention"></div>
+                  <div class="table-responsive">
+                      <div id="participants-by-lifecycle-retention-table"></div>
+                  </div>
             </div>
         </div>
     </div>
@@ -54,8 +71,8 @@
             return false;
         }
 
-        var lcWidth = $('#plotly-participants-by-lifecycle').width() - 30;
-        var spinnerLoc = 'plotly-participants-by-lifecycle';
+        var lcWidth = $('#plotly-participants-by-lifecycle-overview').width() - 30;
+        var spinnerLoc = 'plotly-participants-by-lifecycle-overview';
         if (dialogType == 'spinner') {
             launchSpinner(spinnerLoc);
         } else if (dialogType == 'modal') {
@@ -72,10 +89,13 @@
             lifecycleCenters = ['ALL'];
         }
 
-        // load data from metrics API
+        /**
+         * Overview
+         */
         $.getJSON('/dashboard/metrics_load_lifecycle', {
           csrf_token: CsrfToken,
           stratification: 'LIFECYCLE',
+          mode: 'overview',
           end_date: lcEndDate,
           centers: lifecycleCenters,
           history: true
@@ -110,12 +130,126 @@
                 }
 
                 // load table data
-                var lcTable = $('#participants-by-lifecycle-table');
+                var lcTable = $('#participants-by-lifecycle-overview-table');
                 loadTableData(lcTable, data, 'Status');
 
                 // render plot, remove plotly link and stop spinner
-                Plotly.newPlot('plotly-participants-by-lifecycle', data, lcLayout, PLOTLY_OPTS);
-                removePlotlyLink('plotly-participants-by-lifecycle');
+                Plotly.newPlot('plotly-participants-by-lifecycle-overview', data, lcLayout, PLOTLY_OPTS);
+                removePlotlyLink('plotly-participants-by-lifecycle-overview');
+                stopSpinner(spinnerLoc);
+
+                if (dialogType == 'modal') {
+                    $('#loading-modal').modal('hide');
+                }
+            } else {
+                setMetricsError(spinnerLoc);
+            }
+        });
+
+        /**
+         * PPI Baseline
+         */
+        $.getJSON('/dashboard/metrics_load_lifecycle', {
+          csrf_token: CsrfToken,
+          stratification: 'LIFECYCLE',
+          mode: 'ppi_baseline',
+          end_date: lcEndDate,
+          centers: lifecycleCenters,
+          history: true
+        })
+        .done(function(data) {
+            if (data.length != 0) {
+                var lcAnnot = [];
+                var lcTitle = '<b>Baseline PPI Module Completion</b> as of ' + lcEndDate;
+                var lcLayout = {
+                    title: lcTitle,
+                    font: PLOTLY_LABEL_FONT,
+                    barmode: 'stack',
+                    width: lcWidth,
+                    height: lcWidth / 1.66,
+                    annotations: lcAnnot,
+                    xaxis: {
+                        tickangle: -45,
+                        fixedrange: true
+                    },
+                    yaxis: {
+                        fixedrange: true
+                    },
+                    margin: {
+                        b: 150,
+                        pad: 5
+                    }
+                };
+
+                // load column totals if requested
+                if (lcShowAnnot) {
+                    loadBarChartAnnotations(data, lcAnnot);
+                }
+
+                // load table data
+                var lcTable = $('#participants-by-lifecycle-baseline-table');
+                loadTableData(lcTable, data, 'Status');
+
+                // render plot, remove plotly link and stop spinner
+                Plotly.newPlot('plotly-participants-by-lifecycle-baseline', data, lcLayout, PLOTLY_OPTS);
+                removePlotlyLink('plotly-participants-by-lifecycle-baseline');
+                stopSpinner(spinnerLoc);
+
+                if (dialogType == 'modal') {
+                    $('#loading-modal').modal('hide');
+                }
+            } else {
+                setMetricsError(spinnerLoc);
+            }
+        });
+
+        /**
+         * PPI Retention
+         */
+        $.getJSON('/dashboard/metrics_load_lifecycle', {
+          csrf_token: CsrfToken,
+          stratification: 'LIFECYCLE',
+          mode: 'ppi_retention',
+          end_date: lcEndDate,
+          centers: lifecycleCenters,
+          history: true
+        })
+        .done(function(data) {
+            if (data.length != 0) {
+                var lcAnnot = [];
+                var lcTitle = '<b>Retention PPI Module Completion</b> as of ' + lcEndDate;
+                var lcLayout = {
+                    title: lcTitle,
+                    font: PLOTLY_LABEL_FONT,
+                    barmode: 'stack',
+                    width: lcWidth,
+                    height: lcWidth / 1.66,
+                    annotations: lcAnnot,
+                    xaxis: {
+                        tickangle: -45,
+                        fixedrange: true
+                    },
+                    yaxis: {
+                        fixedrange: true
+                    },
+                    margin: {
+                        b: 150,
+                        pad: 5
+                    }
+                };
+
+                // load column totals if requested
+                if (lcShowAnnot) {
+                    loadBarChartAnnotations(data, lcAnnot);
+                }
+
+                // load table data
+                var lcTable = $('#participants-by-lifecycle-retention-table');
+                loadTableData(lcTable, data, 'Status');
+
+                // render plot, remove plotly link and stop spinner
+                Plotly.newPlot('plotly-participants-by-lifecycle-retention', data, lcLayout, PLOTLY_OPTS);
+                removePlotlyLink('plotly-participants-by-lifecycle-retention');
                 stopSpinner(spinnerLoc);
 
                 if (dialogType == 'modal') {

--- a/views/dashboard/participants-by-lifecycle.html.twig
+++ b/views/dashboard/participants-by-lifecycle.html.twig
@@ -109,7 +109,7 @@
                     font: PLOTLY_LABEL_FONT,
                     barmode: 'stack',
                     width: lcWidth,
-                    height: lcWidth / 1.66,
+                    height: lcWidth / 1.33,
                     annotations: lcAnnot,
                     xaxis: {
                         tickangle: -45,
@@ -166,7 +166,7 @@
                     font: PLOTLY_LABEL_FONT,
                     barmode: 'stack',
                     width: lcWidth,
-                    height: lcWidth / 1.66,
+                    height: lcWidth / 1.33,
                     annotations: lcAnnot,
                     xaxis: {
                         tickangle: -45,
@@ -223,7 +223,7 @@
                     font: PLOTLY_LABEL_FONT,
                     barmode: 'stack',
                     width: lcWidth,
-                    height: lcWidth / 1.66,
+                    height: lcWidth / 1.33,
                     annotations: lcAnnot,
                     xaxis: {
                         tickangle: -45,


### PR DESCRIPTION
This PR adds counts for the three retention PPI modules (as well as their aggregate full completion count) to the dashboard by way of splitting out "Baseline" and "Retention" modules into separate graphs.

- [ ] Requires related RDR change before release.

[[DASH1-137](https://precisionmedicineinitiative.atlassian.net/projects/DASH1/issues/DASH1-137)]