### PR TITLE
[DASH1-151] Move Retention PPI column to end of chart

### DIFF
--- a/src/Pmi/Controller/DashboardController.php
+++ b/src/Pmi/Controller/DashboardController.php
@@ -709,10 +709,10 @@ class DashboardController extends AbstractController
                     'Consent_Enrollment' => 'Primary Consent',
                     'Consent_Complete' => 'Primary+EHR/EHR-lite Consent',
                     'Baseline_PPI_Modules_Complete' => 'Baseline PPI Modules Complete',
-                    'PPI_Retention_Modules_Complete' => 'Retention PPI Modules Complete',
                     'Physical_Measurements' => 'Physical Measurements',
                     'Samples_Received' => 'Samples Received',
-                    'Full_Participant' => 'Core Participant'
+                    'Full_Participant' => 'Core Participant',
+                    'PPI_Retention_Modules_Complete' => 'Retention PPI Modules Complete'
                 ];
                 break;
         }


### PR DESCRIPTION

![Screen Shot 2019-08-13 at 9 11 24 AM](https://user-images.githubusercontent.com/80459/62948624-5898a700-bdaa-11e9-897f-b802e672b078.png)


This made more sense to folks, having the latter step appearing after the "Core Participants" column. _Note: This column is empty in the test environment, but populated in stable/production._

[[DASH1-151](https://precisionmedicineinitiative.atlassian.net/browse/DASH1-151)]