### PR TITLE
[HPRO-510] Fix issues with CircleCI test build process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,7 @@ jobs:
     # To see the list of pre-built images that CircleCI provides for most common languages see
     # https://circleci.com/docs/2.0/circleci-images/
     docker:
-    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
-      command: /sbin/init
+    - image: circleci/php:5.6.40-jessie-node
     steps:
     # Machine Setup
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
     # To see the list of pre-built images that CircleCI provides for most common languages see
     # https://circleci.com/docs/2.0/circleci-images/
     docker:
-    - image: circleci/php:5.6.40-jessie-node
+    - image: circleci/build-image:ubuntu-14.04-XXL-upstart-1189-5614f37
     steps:
     # Machine Setup
     #   If you break your build into multiple jobs with workflows, you will probably want to do the parts of this that are relevant in each


### PR DESCRIPTION
This was a round about way to address an issue that is blocking test runs. The error we received in the console looked something like this:

>CircleCI was unable to run the job runner because we were unable to execute commands in build container.
>
>This typically means that the build container entrypoint or command is terminating the container prematurely, or interfering with executed commands.  Consider clearing entrypoint/command values and try again.

Upon digging, we found [this issue](https://discuss.circleci.com/t/circleci-was-unable-to-run-the-job-runner/31894/17) that appears to line up with what we're experiencing. The support team has pointed out that our Docker image hasn't been updated in more than two years, a product of the migration from their Config v1 to Config v2 paradigm. 

The actual error is caused by a recent change in the way CircleCI starts the Docker images, made to fix an issue they were having with MongoDB. As a result, the other `init` script was not returning the expected value, causing the container to be marked as crashed.

The long term fix will be to roll our own Docker containers that closely align to our deployment environments. The immediate fix is to remove the `init` command, as it is not necessary for our test runs.

[[HPRO-510](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-510)]