### PR TITLE
[HPRO-522] Use Monolog for logging

### DIFF
--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -164,8 +164,10 @@ abstract class AbstractApplication extends Application
         $this->register(new MonologServiceProvider(), [
             // adjust 400 errors to debug log level
             'monolog.exception.logger_filter' => $this->protect(function ($e) {
-                if ($e instanceof HttpExceptionInterface && $e->getStatusCode() < 500) {
+                if ($e instanceof HttpExceptionInterface && $e->getStatusCode() == 404) {
                     return Logger::DEBUG;
+                } elseif ($e instanceof HttpExceptionInterface && $e->getStatusCode() < 500) {
+                    return Logger::INFO;
                 }
                 return Logger::CRITICAL;
             })
@@ -378,12 +380,6 @@ abstract class AbstractApplication extends Application
 
         // Set error callback using error template
         $this->error(function (Exception $e, $request, $code) {
-
-            // syslog 500 errors
-            if ($code >= 500) {
-                $this->logException($e);
-            }
-
             // If not in debug mode or error is < 500, render the error template
             if (isset($this['errorTemplate']) && (!$this['debug'] || $code < 500)) {
                 return $this['twig']->render($this['errorTemplate'], ['code' => $code]);

--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -175,6 +175,7 @@ abstract class AbstractApplication extends Application
             $handler = new SyslogHandler(false, LOG_USER, Logger::INFO);
             $formatter = new LineFormatter("%message% %context% %extra%", null, true);
             $formatter->includeStacktraces();
+            $formatter->ignoreEmptyContextAndExtra();
             $handler->setFormatter($formatter);
             $monolog->pushHandler($handler);
             return $monolog;

--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -3,6 +3,7 @@ namespace Pmi\Application;
 
 use Exception;
 use Memcache;
+use Monolog\Formatter\LineFormatter;
 use Monolog\Handler\SyslogHandler;
 use Monolog\Logger;
 use Pmi\Audit\Log;
@@ -167,11 +168,15 @@ abstract class AbstractApplication extends Application
                     return Logger::DEBUG;
                 }
                 return Logger::CRITICAL;
-            }),
+            })
         ]);
         // Add syslog handler
         $this->extend('monolog', function($monolog, $app) {
-            $monolog->pushHandler(new SyslogHandler('healthpro', LOG_USER, Logger::INFO));
+            $handler = new SyslogHandler(false, LOG_USER, Logger::INFO);
+            $formatter = new LineFormatter("%message% %context% %extra%", null, true);
+            $formatter->includeStacktraces();
+            $handler->setFormatter($formatter);
+            $monolog->pushHandler($handler);
             return $monolog;
         });
         // Override routing.listener to disable routing info logging (see RoutingServiceProvider)

--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -375,7 +375,7 @@ abstract class AbstractApplication extends Application
 
             // syslog 500 errors
             if ($code >= 500) {
-                Util::logException($e);
+                $this->logException($e);
             }
 
             // If not in debug mode or error is < 500, render the error template
@@ -548,6 +548,12 @@ abstract class AbstractApplication extends Application
         if (!$this['isUnitTest'] && !$this->isPhpDevServer() && $action != Log::REQUEST) {
             $log->logDatastore();
         }
+    }
+
+    public function logException(\Exception $exception)
+    {
+        $this['logger']->critical($exception->getMessage());
+        $this['logger']->info(substr($exception->getTraceAsString(), 0, 5120)); // log the first 5KB of the stack trace
     }
 
     /**

--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -554,8 +554,7 @@ abstract class AbstractApplication extends Application
 
     public function logException(\Exception $exception)
     {
-        $this['logger']->critical($exception->getMessage());
-        $this['logger']->info(substr($exception->getTraceAsString(), 0, 5120)); // log the first 5KB of the stack trace
+        $this['logger']->critical('Caught Exception', ['exception' => $exception]);
     }
 
     /**

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -43,6 +43,7 @@ class HpoApplication extends AbstractApplication
         if ($this->getConfig('disable_test_access')) {
             $rdrOptions['disable_test_access'] = $this->getConfig('disable_test_access');
         }
+        $rdrOptions['logger'] = $this['logger'];
 
         $this['pmi.drc.rdrhelper'] = new \Pmi\Drc\RdrHelper($rdrOptions);
         if ($this->participantSource == 'mock') {

--- a/src/Pmi/Audit/Log.php
+++ b/src/Pmi/Audit/Log.php
@@ -96,7 +96,7 @@ class Log
         if ($logArray['data']) {
             $syslogData[] = json_encode($logArray['data']);
         }
-        syslog(LOG_INFO, implode(" ", $syslogData));
+        $this->app['logger']->info(implode(' ', $syslogData));
     }
 
     public function logDatastore()

--- a/src/Pmi/Drc/RdrHelper.php
+++ b/src/Pmi/Drc/RdrHelper.php
@@ -13,6 +13,7 @@ class RdrHelper
     protected $cacheTime = 300;
     protected $lastError;
     protected $disableTestAccess = false;
+    protected $logger;
 
     public function __construct(array $options)
     {
@@ -29,6 +30,7 @@ class RdrHelper
             if (!empty($options['disable_test_access'])) {
                 $this->disableTestAccess  = $options['disable_test_access'];
             }
+            $this->logger = $options['logger'];
             $this->options = $options;
         }
     }
@@ -81,16 +83,16 @@ class RdrHelper
     {
         $this->lastError = $e->getMessage();
         if ($e instanceof \GuzzleHttp\Exception\RequestException && $e->hasResponse()) {
-            syslog(LOG_CRIT, $e->getMessage());
+            $this->logger->critical($e->getMessage());
             $response = $e->getResponse();
             $responseCode = $response->getStatusCode();
             $contents = $response->getBody()->getContents();
-            syslog(LOG_INFO, "Response code: {$responseCode}");
-            syslog(LOG_INFO, "Response body: {$contents}");
+            $this->logger->info("Response code: {$responseCode}");
+            $this->logger->info("Response body: {$contents}");
             $this->lastError = $contents;
         } else {
             // No response - request probably timed out
-            syslog(LOG_ERR, $e->getMessage());
+            $this->logger->error($e->getMessage());
         }
     }
 

--- a/src/Pmi/Mail/Message.php
+++ b/src/Pmi/Mail/Message.php
@@ -112,8 +112,8 @@ class Message
                 try {
                     $mandrill->send($this->to, $this->from, $this->subject, $this->content, $tags);
                 } catch (\Exception $e) {
-                    syslog(LOG_ERR, "Error sending Mandrill message");
-                    syslog(LOG_ERR, $e->getMessage());
+                    $this->app['logger']->error("Error sending Mandrill message");
+                    $this->app['logger']->error($e->getMessage());
                 }
                 break;
 
@@ -122,7 +122,7 @@ class Message
         }
 
         if ($this->app->isLocal()) {
-            syslog(LOG_INFO, "Message contents:\n---\n{$this->content}\n---\n");
+            $this->app['logger']->info("Message contents:\n---\n{$this->content}\n---\n");
         }
 
         return $this;
@@ -160,7 +160,7 @@ class Message
     {
         // Add informational log to mimic GAE mail service logging
         if ($this->app->isLocal()) {
-            syslog(LOG_INFO, "Sending via Mandrill:\n" . 
+            $this->app['logger']->info("Sending via Mandrill:\n" . 
                 "\tFrom: {$this->from}\n" . 
                 "\tTo: " . implode(', ', $this->to) . "\n" .
                 "\tSubject: {$this->subject}\n" .

--- a/src/Pmi/Order/Mayolink/MayolinkOrder.php
+++ b/src/Pmi/Order/Mayolink/MayolinkOrder.php
@@ -44,7 +44,7 @@ class MayolinkOrder
                 'body' => $xml
             ]);            
         } catch (\Exception $e) {
-            syslog(LOG_CRIT, $e->getMessage());
+            $this->app['logger']->critical($e->getMessage());
             return false;
         }
         if ($response->getStatusCode() !== 201) {
@@ -68,7 +68,7 @@ class MayolinkOrder
                 'body' => $xml
             ]);            
         } catch (\Exception $e) {
-            syslog(LOG_CRIT, $e->getMessage());
+            $this->app['logger']->critical($e->getMessage());
             return false;
         }
         if ($response->getStatusCode() !== 200) {
@@ -87,7 +87,7 @@ class MayolinkOrder
                 'auth' => [$this->userName, $this->password]
             ]);            
         } catch (\Exception $e) {
-            syslog(LOG_CRIT, $e->getMessage());
+            $this->app['logger']->critical($e->getMessage());
             return false;       
         }
         if ($response->getStatusCode() !== 200) {

--- a/src/Pmi/Security/GoogleGroupsAuthenticator.php
+++ b/src/Pmi/Security/GoogleGroupsAuthenticator.php
@@ -84,7 +84,7 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
                 }
                 return $this->buildCredentials($this->app->getGoogleUser());
             } catch (\Exception $e) {
-                Util::logException($e);
+                $this->app->logException($e);
                 throw new AuthenticationException(self::OAUTH_FAILURE_MESSAGE);
             }
         } elseif ($this->app->getConfig('gae_auth') && $this->app->getGoogleUser()) {

--- a/src/Pmi/Security/UserProvider.php
+++ b/src/Pmi/Security/UserProvider.php
@@ -29,7 +29,7 @@ class UserProvider implements UserProviderInterface
                 $groups = $this->app['pmi.drc.appsclient'] ? $this->app['pmi.drc.appsclient']->getGroups($googleUser->getEmail()) : [];
                 $this->app['session']->set('googlegroups', $groups);
             } catch (\Exception $e) {
-                Util::logException($e);
+                $this->app->logException($e);
                 throw new AuthenticationException('Failed to retrieve group permissions');
             }
         }

--- a/src/Pmi/Service/EvaluationsQueueService.php
+++ b/src/Pmi/Service/EvaluationsQueueService.php
@@ -47,7 +47,7 @@ class EvaluationsQueueService
                 ]);
             } else {
                 $this->em->getRepository('evaluations_queue')->update($queue['id'], ['attempted_ts' => $now]);
-                syslog(LOG_ERR, "#{$evalId} failed sending to RDR: " .$this->rdr->getLastError());
+                $this->app['logger']->error("#{$evalId} failed sending to RDR: " .$this->rdr->getLastError());
             }
         }
     }

--- a/src/Pmi/Service/PatientStatusService.php
+++ b/src/Pmi/Service/PatientStatusService.php
@@ -49,7 +49,7 @@ class PatientStatusService
                     'id' => $patientStatusHistory['id']
                 ]);
             } else {
-                syslog(LOG_ERR, "#{$patientStatusHistory['id']} failed sending to RDR: " . $this->rdr->getLastError());
+                $this->app['logger']->error("#{$patientStatusHistory['id']} failed sending to RDR: " . $this->rdr->getLastError());
             }
         }
     }

--- a/src/Pmi/Util.php
+++ b/src/Pmi/Util.php
@@ -64,10 +64,4 @@ class Util
         }
         return $result;
     }
-
-    public static function logException($exception)
-    {
-        syslog(LOG_CRIT, $exception->getMessage());
-        syslog(LOG_INFO, substr($exception->getTraceAsString(), 0, 5120)); // log the first 5KB of the stack trace
-    }
 }


### PR DESCRIPTION
[[HPRO-522](https://precisionmedicineinitiative.atlassian.net/browse/HPRO-522)]

Refactors our application logging to use [Monolog](https://github.com/Seldaek/monolog). This will make integrating StackDriver logging and other adjustments for the 2nd gen runtime easier and cleaner.

This PR enables the Monlog service provider and configures it with the SyslogHandler in a way that is equivalent to our previous logging methods (calling syslog directly throughout the application).  This also makes use of Monolog's error handler for exceptions.