### PR TITLE
[HPRO-532] Enable logging for the cache component

### DIFF
--- a/src/Pmi/Application/AbstractApplication.php
+++ b/src/Pmi/Application/AbstractApplication.php
@@ -575,5 +575,6 @@ abstract class AbstractApplication extends Application
     public function registerCache()
     {
         $this['cache'] = new \Pmi\Cache\DatastoreAdapter();
+        $this['cache']->setLogger($this['logger']);
     }
 }


### PR DESCRIPTION
HPRO-532

Previously, errors in retrieving or saving cache data were silently failing. By passing the logger in to the cache adapter, warnings will now be logged.