### PR TITLE
[HPRO-540] Allow defining DB connection in docker-compose configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ php.ini
 /bin/GeoLite2-Country.mmdb
 ci/*.secret
 /deploy_*.txt
+/docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2'
 services:
     mysql:
         environment:
-            MYSQL_ROOT_PASSWORD: ~
+            MYSQL_ROOT_PASSWORD: ''
             MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'
             MYSQL_DATABASE: hpo
         container_name: healthpro-mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
             - ./sql/healthpro:/docker-entrypoint-initdb.d
 
     web:
+        environment:
+            MYSQL_HOST: healthpro-mysql
+            MYSQL_DATABASE: hpo
+            MYSQL_USER: root
+            MYSQL_PASSWORD: ''
         build: .
         container_name: healthpro-web
         hostname: healthpro-web

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -156,6 +156,21 @@ class HpoApplication extends AbstractApplication
         $schema = $this->getConfig('mysql_schema');
         $user = $this->getConfig('mysql_user');
         $password = $this->getConfig('mysql_password');
+        if ($this->isLocal()) {
+            // look for Docker environment variables override
+            if (getenv('MYSQL_HOST')) {
+                $host = getenv('MYSQL_HOST');
+            }
+            if (getenv('MYSQL_DATABASE')) {
+                $schema = getenv('MYSQL_DATABASE');
+            }
+            if (getenv('MYSQL_USER')) {
+                $user = getenv('MYSQL_USER');
+            }
+            if (getenv('MYSQL_PASSWORD') !== false) {
+                $password = getenv('MYSQL_PASSWORD');
+            }
+        }
         if ($socket) {
             $options = [
                 'driver' => 'pdo_mysql',


### PR DESCRIPTION
HPRO-540

This change allows for environment variables to override the DB configuration when running locally and sets the necessary environment variables in the `healthpro-web` container.

As a result of this change, you will no longer need to change the local `dev_config/config.yml` file to match your Docker configuration.