### PR TITLE
[HPRO-552] Disable session garbage collection

### DIFF
--- a/php.ini.dist
+++ b/php.ini.dist
@@ -4,3 +4,4 @@ error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 session.cookie_httponly = 1
 session.cookie_secure = 1
 extension=grpc.so
+session.gc_probability = 0


### PR DESCRIPTION
HPRO-552

Session garbage collection is currently failing due to the limit of datastore entities that can be deleted at once. This temporarily disables garbage collection on user requests. We should probably move this cleanup to a cron job anyways.