### PR TITLE
[HPRO-554] Add participant id validation before checking cache and hitting RDR

### DIFF
--- a/src/Pmi/Drc/RdrHelper.php
+++ b/src/Pmi/Drc/RdrHelper.php
@@ -80,6 +80,11 @@ class RdrHelper
         return $this->cache;
     }
 
+    public function getLogger()
+    {
+        return $this->logger;
+    }
+
     public function logException(\Exception $e)
     {
         $this->lastError = $e->getMessage();

--- a/src/Pmi/Drc/RdrParticipants.php
+++ b/src/Pmi/Drc/RdrParticipants.php
@@ -224,13 +224,21 @@ class RdrParticipants
 
     public function getById($id, $refresh = null)
     {
+        if (!is_string($id) || !preg_match('/^\w+$/', $id)) {
+            return false;
+        }
+
         $participant = false;
         $cacheKey = 'rdr_participant_' . $id;
 
         if ($this->cacheEnabled && !$refresh) {
-            $cacheItem = $this->cache->getItem($cacheKey);
-            if ($cacheItem->isHit()) {
-                $participant = $cacheItem->get();
+            try {
+                $cacheItem = $this->cache->getItem($cacheKey);
+                if ($cacheItem->isHit()) {
+                    $participant = $cacheItem->get();
+                }
+            } catch (\Exception $e) {
+                $this->rdrHelper->getLogger()->error($e);
             }
         }
         if (!$participant) {


### PR DESCRIPTION
HPRO-554

Note that the validation on participant ID only enforces word characters to avoid adding RDR business logic to HealthPro in case participant ID format changes in the future. There is no harm in checking for an alphanumeric participant ID even if it doesn't match the current `P1234...` format. We just want to prevent cache lookup errors and avoid completely unnecessary RDR requests.

In addition to the id validation, I am also catching exceptions from cache retrieval and logging so that we can gracefully fail on unexpected cache exceptions.

