### PR TITLE
[HPRO-555] Change id columns for awardees and organizations table to VARBINARY

### DIFF
--- a/sql/healthpro/awardees.sql
+++ b/sql/healthpro/awardees.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `awardees` (
-  `id` varchar(20) NOT NULL,
+  `id` varbinary(255) NOT NULL,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/sql/healthpro/organizations.sql
+++ b/sql/healthpro/organizations.sql
@@ -1,5 +1,5 @@
 CREATE TABLE `organizations` (
-  `id` varchar(80) NOT NULL,
+  `id` varbinary(255) NOT NULL,
   `name` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/sql/migrations/031-organizations-awardees-id-varbinary.sql
+++ b/sql/migrations/031-organizations-awardees-id-varbinary.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `awardees` MODIFY COLUMN `id` varbinary(255) NOT NULL;
+ALTER TABLE `organizations` MODIFY COLUMN `id` varbinary(255) NOT NULL;

--- a/tests/Pmi/SiteSync/AwardeesTest.php
+++ b/tests/Pmi/SiteSync/AwardeesTest.php
@@ -1,0 +1,56 @@
+<?php
+use Tests\Pmi\AbstractWebTestCase;
+
+class AwardeesTest extends AbstractWebTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->removeTestAwardees();
+    }
+
+    protected function tearDown()
+    {
+        $this->removeTestAwardees();
+    }
+
+    protected function removeTestAwardees()
+    {
+        $awardeesRepository = $this->app['em']->getRepository('awardees');
+        $awardeesRepository->delete('UNITTEST');
+        $awardeesRepository->delete('UNITTEST ');
+    }
+
+    public function testTrailingSpaceNoCollision()
+    {
+        $awardeesRepository = $this->app['em']->getRepository('awardees');
+        $result = $awardeesRepository->insert([
+            'id' => 'UNITTEST',
+            'name' => 'Unit test'
+        ]);
+        $result = $awardeesRepository->insert([
+            'id' => 'UNITTEST ',
+            'name' => 'Unit test'
+        ]);
+
+        $awardee = $awardeesRepository->fetchOneBy(['id' => 'UNITTEST ']);
+        $this->assertNotNull($awardee);
+        $this->assertSame('UNITTEST ', $awardee['id']);
+    }
+
+    /**
+     * @expectedException Doctrine\DBAL\Exception\UniqueConstraintViolationException
+     */
+    public function testDuplicateIdCollision()
+    {
+        $awardeesRepository = $this->app['em']->getRepository('awardees');
+        $result = $awardeesRepository->insert([
+            'id' => 'UNITTEST',
+            'name' => 'Unit test'
+        ]);
+        $result = $awardeesRepository->insert([
+            'id' => 'UNITTEST',
+            'name' => 'Unit test'
+        ]);
+    }
+}

--- a/tests/Pmi/SiteSync/OrganizationsTest.php
+++ b/tests/Pmi/SiteSync/OrganizationsTest.php
@@ -1,0 +1,56 @@
+<?php
+use Tests\Pmi\AbstractWebTestCase;
+
+class OrganizationsTest extends AbstractWebTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->removeTestOrganizations();
+    }
+
+    protected function tearDown()
+    {
+        $this->removeTestOrganizations();
+    }
+
+    protected function removeTestOrganizations()
+    {
+        $organizationsRepository = $this->app['em']->getRepository('organizations');
+        $organizationsRepository->delete('UNITTEST');
+        $organizationsRepository->delete('UNITTEST ');
+    }
+
+    public function testTrailingSpaceNoCollision()
+    {
+        $organizationsRepository = $this->app['em']->getRepository('organizations');
+        $result = $organizationsRepository->insert([
+            'id' => 'UNITTEST',
+            'name' => 'Unit test'
+        ]);
+        $result = $organizationsRepository->insert([
+            'id' => 'UNITTEST ',
+            'name' => 'Unit test'
+        ]);
+
+        $organization = $organizationsRepository->fetchOneBy(['id' => 'UNITTEST ']);
+        $this->assertNotNull($organization);
+        $this->assertSame('UNITTEST ', $organization['id']);
+    }
+
+    /**
+     * @expectedException Doctrine\DBAL\Exception\UniqueConstraintViolationException
+     */
+    public function testDuplicateIdCollision()
+    {
+        $organizationsRepository = $this->app['em']->getRepository('organizations');
+        $result = $organizationsRepository->insert([
+            'id' => 'UNITTEST',
+            'name' => 'Unit test'
+        ]);
+        $result = $organizationsRepository->insert([
+            'id' => 'UNITTEST',
+            'name' => 'Unit test'
+        ]);
+    }
+}


### PR DESCRIPTION
HPRO-555

[MySQL VARCHAR columns ignore trailing whitespace](https://dev.mysql.com/doc/refman/5.7/en/char.html). This led to an issue in the test environment where the test awardee API returned two organizations with the same id but one with a trailing space, resulting in a duplicate key collision. This change treats the id as a binary column to avoid the MySQL VARCHAR padding behavior.

The side affect of this is that comparisons are now case sensitive, but the IDs should be case sensitive anyways. Also, sorting will be affected, but we are not sorting organizations or awardees by ID anywhere.

There are places where we join to the awardees.id or organizations.id column from columns that are still VARCHAR. We should determine whether we want to make this change across all tables.