### PR TITLE
[HPRO-582] Update Docker configuration to use GAE image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2
+FROM gcr.io/gcp-runtimes/php72:2020-02-19-11-00
 
 # Fix for issue with OpenJDK install
 RUN mkdir -p /usr/share/man/man1
@@ -8,11 +8,9 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
       && apt-get update \
       && apt-get install -y --no-install-recommends \
         libpython2.7-stdlib \
-        default-mysql-client \
         git-all \
         nodejs \
-        openjdk-11-jdk \
-      && docker-php-ext-install pdo_mysql \
+        default-jre \
       && rm -rf /var/lib/apt/lists/*
 
 # Google Cloud Tools


### PR DESCRIPTION
*Note:* @jt2k points out that this will put on the Google App Engine *Flex* environment image, rather than *Standard*. So the actual benefit here may end up somewhat moot. Still, we're moving closer to the versions used in _one_ of the environments available rather than guessing.

---

This appears to run without issue. I left the install steps in place for the emulator, `git`, etc., but we could try removing those one-by-one during more comprehensive testing. Right now, they aren't hurting anything to be side loaded.

[HPRO-582]

[HPRO-582]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-582