### PR TITLE
[HPRO-590] Enable Circle CI Pipelines, Adjust Configuration as Needed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,4 @@
-version: 2
-experimental:
-  pipelines: true
+version: 2.1
 jobs:
   build:
     working_directory: ~/vanderbilt/pmi-drc-hpo

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,6 @@
 version: 2
+experimental:
+  pipelines: true
 jobs:
   build:
     working_directory: ~/vanderbilt/pmi-drc-hpo


### PR DESCRIPTION
We received an email March 16 letting us know that all projects in Circle CI would be transitioning to the new Pipelines feature. In an effort to ensure that this does not break anything in our CI/CD setup, this PR aims to address any change we need to make.

[HPRO-590]

[HPRO-590]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-590