### PR TITLE
[HPRO-591] Make scripps/biobank order ready only view available to scripps super user

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -101,6 +101,7 @@ class HpoApplication extends AbstractApplication
                 [['path' => '^/site($|\/)'], ['ROLE_USER', 'ROLE_AWARDEE']],
                 [['path' => '^/help($|\/)'], ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_AWARDEE', 'ROLE_DV_ADMIN']],
                 [['path' => '^/settings($|\/)'], ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_AWARDEE', 'ROLE_DV_ADMIN']],
+                [['path' => '^/biobank\/\w+\/order\/\w+$'], ['ROLE_AWARDEE']],
                 [['path' => '^/biobank($|\/)'], ['ROLE_BIOBANK', 'ROLE_SCRIPPS']],
                 [['path' => '^/.*$'], 'ROLE_USER'],
             ]

--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -508,7 +508,8 @@ class WorkQueueController extends AbstractController
             'evaluations' => $evaluations,
             'problems' => $problems,
             'displayPatientStatusBlock' => false,
-            'readOnly' => true
+            'readOnly' => true,
+            'biobankView' => true
         ]);
     }
 

--- a/views/biobank/order.html.twig
+++ b/views/biobank/order.html.twig
@@ -12,7 +12,13 @@
                     <dd>{{ participant.id }}</dd>
                 {% endif %}
                 <dt>Biobank ID</dt>
-                <dd><a href="{{ path('biobank_participant', { biobankId: participant.biobankId }) }}">{{ participant.biobankId }}</a></dd>
+                <dd>
+                    {% if is_granted('ROLE_SCRIPPS') or is_granted('ROLE_BIOBANK') %}
+                        <a href="{{ path('biobank_participant', { biobankId: participant.biobankId }) }}">{{ participant.biobankId }}</a>
+                    {% else %}
+                        {{ participant.biobankId }}
+                    {% endif %}
+                </dd>
                 <dt>Paired Awardee</dt>
                 <dd>{{ participant.awardee ? app.getAwardeeDisplayName(participant.awardee) : '(not paired)' }}</dd>
                 <dt>Paired Site</dt>

--- a/views/biobank/order.html.twig
+++ b/views/biobank/order.html.twig
@@ -7,7 +7,7 @@
     <div class="row">
         <div class="col-sm-4">
             <dl class="dl-horizontal">
-                {% if is_granted('ROLE_SCRIPPS') %}
+                {% if is_granted('ROLE_SCRIPPS') or is_granted('ROLE_AWARDEE') %}
                     <dt>Participant ID</dt>
                     <dd>{{ participant.id }}</dd>
                 {% endif %}

--- a/views/partials/participant-orders-list.html.twig
+++ b/views/partials/participant-orders-list.html.twig
@@ -6,7 +6,7 @@
         {% if (readOnly is defined or biobankView is defined or participant.isSuspended) and orders|length == 0 %}
             <small class="text-warning">No Records Found</small>
         {% else %}
-            {% for order in orders %}`
+            {% for order in orders %}
                 {% if type is not defined and loop.index == 6 %}
                     <div id="order-overflow">
                 {% endif %}

--- a/views/partials/participant-orders-list.html.twig
+++ b/views/partials/participant-orders-list.html.twig
@@ -6,13 +6,11 @@
         {% if (readOnly is defined or biobankView is defined or participant.isSuspended) and orders|length == 0 %}
             <small class="text-warning">No Records Found</small>
         {% else %}
-            {% for order in orders %}
+            {% for order in orders %}`
                 {% if type is not defined and loop.index == 6 %}
                     <div id="order-overflow">
                 {% endif %}
-                {% if readOnly is defined %}
-                    <div class="btn btn-block btn-lg btn-default btn-readonly">
-                {% elseif biobankView is defined %}
+                {% if biobankView is defined %}
                     <a href="{{ path('biobank_order', { biobankId: participant.biobankId, orderId: order.id }) }}" class="btn btn-block btn-lg {% if orderId is defined and order.id == orderId %} btn-warning {% else %} btn-default {% endif %}">
                 {% else %}
                     <a href="{{ path('order', { participantId: participant.id, orderId: order.id }) }}" class="btn btn-block btn-lg {% if orderId is defined and order.id == orderId %} btn-warning {% else %} btn-default {% endif %}">
@@ -37,11 +35,7 @@
                             <span class="label label-default">Collected</span> {{ order.collected_ts|date('n/j/Y g:ia', app.userTimezone) }}
                         {% endif %}
                     </small>
-                {% if readOnly is defined %}
-                    </div> {# close .btn-readonly div above #}
-                {% else %}
                     </a>
-                {% endif %}
             {% endfor %}
             {% if type is not defined and orders|length > 5 %}
                 </div> {# close .order-overflow div above #}


### PR DESCRIPTION
I'm not sure if want to display participant id in the order detail page for scripps super user. We can display participant id by checking roles but when a user has both (ROLE_AWARDEE and ROLE_BIOBANK) roles the biobank non-pii view will display the participant id.