### PR TITLE
[HPRO-578] Enable users of the non-PII biospecimen view to look up Quest Samples

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -61,13 +61,13 @@ class HpoApplication extends AbstractApplication
         $this->registerDb();
         return $this;
     }
-    
+
     protected function registerSecurity()
     {
         $this['app.googlegroups_authenticator'] = function ($app) {
             return new \Pmi\Security\GoogleGroupsAuthenticator($app);
         };
-        
+
         $app = $this;
         // include `/` in common routes because homeAction will redirect based on role
         $commonRegex = '^/(logout|login-return|keepalive|client-timeout|agree)?$';
@@ -93,7 +93,7 @@ class HpoApplication extends AbstractApplication
             'security.access_rules' => [
                 [['path' => $anonRegex], 'IS_AUTHENTICATED_ANONYMOUSLY'],
                 [['path' => '^/_dev($|\/)$'], 'IS_AUTHENTICATED_FULLY'],
-                [['path' => $commonRegex], 'IS_AUTHENTICATED_FULLY'],                
+                [['path' => $commonRegex], 'IS_AUTHENTICATED_FULLY'],
                 [['path' => '^/dashboard($|\/)'], 'ROLE_DASHBOARD'],
                 [['path' => '^/admin($|\/)'], 'ROLE_ADMIN'],
                 [['path' => '^/workqueue($|\/)'], ['ROLE_USER', 'ROLE_AWARDEE']],
@@ -101,8 +101,8 @@ class HpoApplication extends AbstractApplication
                 [['path' => '^/site($|\/)'], ['ROLE_USER', 'ROLE_AWARDEE']],
                 [['path' => '^/help($|\/)'], ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_AWARDEE', 'ROLE_DV_ADMIN']],
                 [['path' => '^/settings($|\/)'], ['ROLE_USER', 'ROLE_ADMIN', 'ROLE_AWARDEE', 'ROLE_DV_ADMIN']],
-                [['path' => '^/biobank\/\w+\/order\/\w+$'], ['ROLE_AWARDEE']],
                 [['path' => '^/biobank($|\/)'], ['ROLE_BIOBANK', 'ROLE_SCRIPPS']],
+                [['path' => '^/biobank\/\w+\/order\/\w+$'], ['ROLE_AWARDEE']],
                 [['path' => '^/.*$'], 'ROLE_USER'],
             ]
         ]);
@@ -112,7 +112,7 @@ class HpoApplication extends AbstractApplication
     {
         // default two-factor setting
         $this->configuration['enforce2fa'] = $this->isProd();
-        
+
         $appDir = realpath(__DIR__ . '/../../../');
         $configFile = $appDir . '/dev_config/config.yml';
         if ($this->isLocal() && file_exists($configFile)) {
@@ -134,7 +134,7 @@ class HpoApplication extends AbstractApplication
                 foreach ($configs as $key => $val) {
                     $this->configuration[$key] = $val;
                 }
-            }            
+            }
         }
 
         // unit tests don't have access to Datastore
@@ -145,12 +145,12 @@ class HpoApplication extends AbstractApplication
                 $this->configuration[$config->key] = $config->value;
             }
         }
-        
+
         foreach ($override as $key => $val) {
             $this->configuration[$key] = $val;
         }
     }
-    
+
     protected function registerDb()
     {
         $socket = $this->getConfig('mysql_socket');
@@ -220,10 +220,10 @@ class HpoApplication extends AbstractApplication
 
         // prevent browsers from sending unencrypted requests
         $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
-        
+
         // "low" security finding: prevent MIME type sniffing
         $response->headers->set('X-Content-Type-Options', 'nosniff');
-        
+
         // "low" security finding: enable XSS Protection
         // http://blog.innerht.ml/the-misunderstood-x-xss-protection/
         $response->headers->set('X-XSS-Protection', '1; mode=block');
@@ -232,7 +232,7 @@ class HpoApplication extends AbstractApplication
         // Recommendation from security team is to add no-store as well.
         $response->headers->addCacheControlDirective('no-cache, no-store');
     }
-    
+
     public function switchSite($email)
     {
         $user = $this->getUser();
@@ -278,7 +278,7 @@ class HpoApplication extends AbstractApplication
             $this['security.token_storage']->setToken($token);
         }
     }
-    
+
     /** Returns the user's currently selected HPO site. */
     public function getSite()
     {
@@ -421,11 +421,11 @@ class HpoApplication extends AbstractApplication
             return $this->abort(404);
         }
     }
-    
+
     protected function beforeCallback(Request $request, AbstractApplication $app)
     {
         $app->log(Log::REQUEST);
-        
+
         // log the user out if their session is expired
         if ($this->isLoginExpired() && $request->attributes->get('_route') !== 'logout') {
             return $this->redirectToRoute('logout', ['timeout' => true]);
@@ -496,13 +496,13 @@ class HpoApplication extends AbstractApplication
     {
         $this->setHeaders($response);
     }
-    
+
     protected function finishCallback(Request $request, Response $response)
     {
         if ($this->isLoggedIn()) {
             // only the first route handled is considered a login
             $this['session']->set('isLogin', false);
-            
+
             // unset after the first route handled following loginReturn
             if (!$this->isUpkeepRoute($request)) {
                 $this['session']->set('isLoginReturn', false);

--- a/src/Pmi/Console/Command/BiobankOrderCommand.php
+++ b/src/Pmi/Console/Command/BiobankOrderCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Pmi\Console\Command;
+
+use Pmi\Application\HpoApplication;
+use Pmi\Drc\RdrParticipants;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Metrics Command
+ *
+ * Allows debugging local with the RDR Metrics API endpoint
+ */
+class BiobankOrderCommand extends Command
+{
+    /**
+     * Configure
+     *
+     * @return void
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('pmi:biobank')
+            ->addOption(
+                'start_date',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Date range beginning',
+                date('Y-m-d', strtotime('today - 7 days'))
+            )
+            ->addOption(
+                'end_date',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Date range ending',
+                date('Y-m-d')
+            )
+            ->addOption(
+                'kit_id',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Kit ID',
+                null
+            )
+            ->addOption(
+                'participant_id',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Participant ID',
+                null
+            )
+            ->addOption(
+                'origin',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Order origin.',
+                null
+            )
+            ->addOption(
+                'page_size',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Number of results to return',
+                10
+            )
+            ->addOption(
+                'page',
+                null,
+                InputOption::VALUE_REQUIRED,
+                'Page number of results to return',
+                1
+            )
+            ->addOption(
+                'pretty',
+                null,
+                InputOption::VALUE_NONE,
+                'Pretty formatting for JSON ouput'
+            )
+            ->setDescription('Get latest orders from the Biobank.')
+        ;
+    }
+
+    /**
+     * Execute
+     *
+     * @param IntputInterface $input
+     * @param OutputInterface $output
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $output->setFormatter(new OutputFormatter(true));
+
+        $start_date = $input->getOption('start_date');
+        $end_date = $input->getOption('end_date');
+        $participant_id = $input->getOption('participant_id');
+        $kit_id = $input->getOption('kit_id');
+        $origin = $input->getOption('origin');
+        $page = $input->getOption('page');
+        $pageSize = $input->getOption('page_size');
+        $pretty = ($input->getOption('pretty') !== false) ? JSON_PRETTY_PRINT : 0;
+
+        // Validate start and end dates
+        if ((bool) !strtotime($start_date) || (bool) !strtotime($end_date)) {
+            $output->writeln(sprintf(
+                '<error>Invalid dates: "%s", "%s"</error>',
+                $start_date,
+                $end_date
+            ));
+            // Throw a non-zero exit status
+            return 1;
+        }
+
+        putenv('PMI_ENV=' . HpoApplication::ENV_LOCAL);
+        $app = new HpoApplication([
+            'isUnitTest' => true,
+            'debug' => true
+        ]);
+        $app->setup();
+
+        $service = new RdrParticipants($app['pmi.drc.rdrhelper']);
+        $data = $service->getOrders([
+            'participant_id' => $participant_id,
+            'startDate' => $start_date,
+            'endDate' => $end_date,
+            'origin' => $origin,
+            'kitId' => $kit_id,
+            'page' => $page,
+            'pageSize' => $pageSize
+        ]);
+
+        $output->writeln(json_encode($data, $pretty));
+    }
+}

--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -112,7 +112,10 @@ class BiobankController extends AbstractController
                 ]);
             }
             // Quanum Orders
-            $quanumOrders = $app['pmi.drc.participants']->getOrderByKitId($id, 'careevolution');
+            $quanumOrders = $app['pmi.drc.participants']->getOrders([
+                'kitId' => $id,
+                'origin' => 'careevolution'
+            ]);
             if (isset($quanumOrders[0])) {
                 $order = (new Order())->loadFromJsonObject($quanumOrders[0])->toArray();
                 $participant = $app['pmi.drc.participants']->getById($order['participant_id']);

--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -8,7 +8,6 @@ use Symfony\Component\Validator\Constraints;
 use Symfony\Component\Form\FormError;
 use Pmi\Drc\Exception\ParticipantSearchExceptionInterface;
 use Pmi\Order\Order;
-use Pmi\Drc\BiobankOrder;
 use Pmi\Review\Review;
 
 class BiobankController extends AbstractController
@@ -210,7 +209,7 @@ class BiobankController extends AbstractController
         $quanumOrder = $app['pmi.drc.participants']->getOrder($participant->id, $orderId);
         $order = (new Order($app))->loadFromJsonObject($quanumOrder);
 
-        return $app['twig']->render('biobank/order.html.twig', [
+        return $app['twig']->render('biobank/order-quanum.html.twig', [
             'participant' => $participant,
             'samplesInfo' => $order->getSamplesInfo(),
             'currentStep' => 'finalize',

--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -146,11 +146,11 @@ class BiobankController extends AbstractController
             }
         }
         // Quanum Orders
-        $quanumOrders = $app['pmi.drc.participants']->getOrdersByParticipant($participant->id, [
-            'origin' => 'careevolution'
-        ]);
+        $quanumOrders = $app['pmi.drc.participants']->getOrdersByParticipant($participant->id);
         foreach ($quanumOrders as $quanumOrder) {
-            $orders[] = (new Order())->loadFromJsonObject($quanumOrder)->toArray();
+            if (in_array($quanumOrder->origin, ['careevolution'])) {
+                $orders[] = (new Order())->loadFromJsonObject($quanumOrder)->toArray();
+            }
         }
 
         return $app['twig']->render('biobank/participant.html.twig', [

--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -101,7 +101,7 @@ class BiobankController extends AbstractController
             if (preg_match('/^\d{14}$/', $id)) {
                 $id = substr($id, 0, 10);
             }
-
+            // Internal Order
             $order = $app['em']->getRepository('orders')->fetchOneBy([
                 'order_id' => $id
             ]);
@@ -110,6 +110,18 @@ class BiobankController extends AbstractController
                     'biobankId' => $order['biobank_id'],
                     'orderId' => $order['id']
                 ]);
+            }
+            // Quanum Orders
+            $quanumOrders = $app['pmi.drc.participants']->getOrderByKitId($id, 'careevolution');
+            if (isset($quanumOrders[0])) {
+                $order = (new Order())->loadFromJsonObject($quanumOrders[0])->toArray();
+                $participant = $app['pmi.drc.participants']->getById($order['participant_id']);
+                if ($participant->biobankId) {
+                    return $app->redirectToRoute('biobank_quanumOrder', [
+                        'biobankId' => $participant->biobankId,
+                        'orderId' => $order['id']
+                    ]);
+                }
             }
             $app->addFlashError('Order ID not found');
         }

--- a/src/Pmi/Drc/RdrParticipants.php
+++ b/src/Pmi/Drc/RdrParticipants.php
@@ -4,6 +4,7 @@ namespace Pmi\Drc;
 use Pmi\Entities\Participant;
 use Pmi\Evaluation\Evaluation;
 use Pmi\Order\Order;
+use Pmi\Drc\BiobankOrder;
 use Ramsey\Uuid\Uuid;
 use Symfony\Contracts\Cache\ItemInterface;
 
@@ -343,6 +344,23 @@ class RdrParticipants
             return false;
         }
         return false;
+    }
+
+    public function getOrdersByParticipant($participantId, $query = [])
+    {
+        try {
+            $response = $this->getClient()->request('GET', "Participant/{$participantId}/BiobankOrder", [
+                'query' => $query
+            ]);
+            $result = json_decode($response->getBody()->getContents());
+            if (is_object($result) && is_array($result->data)) {
+                return $result->data;
+            }
+        } catch (\Exception $e) {
+            $this->rdrHelper->logException($e);
+            return [];
+        }
+        return [];
     }
 
     public function getOrder($participantId, $orderId)

--- a/src/Pmi/Drc/RdrParticipants.php
+++ b/src/Pmi/Drc/RdrParticipants.php
@@ -360,6 +360,26 @@ class RdrParticipants
         return [];
     }
 
+    public function getOrderByKitId($kitId, $origin = 'careevolution')
+    {
+        try {
+            $response = $this->getClient()->request('GET', "BiobankOrder", [
+                'query' => [
+                    'kitId' => $kitId,
+                    'origin' => $origin
+                ]
+            ]);
+            $result = json_decode($response->getBody()->getContents());
+            if (is_object($result) && is_array($result->data)) {
+                return $result->data;
+            }
+        } catch (\Exception $e) {
+            $this->rdrHelper->logException($e);
+            return [];
+        }
+        return [];
+    }
+
     public function getOrder($participantId, $orderId)
     {
         try {

--- a/src/Pmi/Drc/RdrParticipants.php
+++ b/src/Pmi/Drc/RdrParticipants.php
@@ -345,12 +345,10 @@ class RdrParticipants
         return false;
     }
 
-    public function getOrdersByParticipant($participantId, $query = [])
+    public function getOrdersByParticipant($participantId)
     {
         try {
-            $response = $this->getClient()->request('GET', "Participant/{$participantId}/BiobankOrder", [
-                'query' => $query
-            ]);
+            $response = $this->getClient()->request('GET', "Participant/{$participantId}/BiobankOrder");
             $result = json_decode($response->getBody()->getContents());
             if (is_object($result) && is_array($result->data)) {
                 return $result->data;

--- a/src/Pmi/Drc/RdrParticipants.php
+++ b/src/Pmi/Drc/RdrParticipants.php
@@ -4,7 +4,6 @@ namespace Pmi\Drc;
 use Pmi\Entities\Participant;
 use Pmi\Evaluation\Evaluation;
 use Pmi\Order\Order;
-use Pmi\Drc\BiobankOrder;
 use Ramsey\Uuid\Uuid;
 use Symfony\Contracts\Cache\ItemInterface;
 

--- a/src/Pmi/Drc/RdrParticipants.php
+++ b/src/Pmi/Drc/RdrParticipants.php
@@ -360,14 +360,11 @@ class RdrParticipants
         return [];
     }
 
-    public function getOrderByKitId($kitId, $origin = 'careevolution')
+    public function getOrders($query = [])
     {
         try {
-            $response = $this->getClient()->request('GET', "BiobankOrder", [
-                'query' => [
-                    'kitId' => $kitId,
-                    'origin' => $origin
-                ]
+            $response = $this->getClient()->request('GET', 'BiobankOrder', [
+                'query' => $query
             ]);
             $result = json_decode($response->getBody()->getContents());
             if (is_object($result) && is_array($result->data)) {

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1397,7 +1397,11 @@ class Order
             }
         }
 
+        // Extract participantId
+        preg_match('/^Patient\/(P\d+)$/i', $object->subject, $subject_matches);
+
         $this->order['id'] = $object->id;
+        $this->order['participant_id'] = $subject_matches[1] ? $subject_matches[1] : 'Unknown';
         $this->order['order_id'] = $kitId;
         $this->order['rdr_id'] = $object->id;
         $this->order['oh_type'] = 'kit';

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1404,12 +1404,14 @@ class Order
         $this->order['participant_id'] = $subject_matches[1] ? $subject_matches[1] : 'Unknown';
         $this->order['order_id'] = $kitId;
         $this->order['rdr_id'] = $object->id;
+        $this->order['type'] = 'kit';
         $this->order['oh_type'] = 'kit';
         $this->order['created_ts'] = $object->created;
         $this->order['processed_ts'] = $processedTs;
         $this->order['collected_ts'] = $collectedTs;
         $this->order['finalized_ts'] = $finalizedTs;
         $this->order['processed_centrifuge_type'] = (!empty($centrifugeType)) ? $centrifugeType : null;
+        $this->order['requested_samples'] = null;
         $this->order['collected_samples'] = json_encode(!empty($collectedSamples) ? $collectedSamples : []);
         $this->order['collected_ts'] = !empty($collectedTs) ? $collectedTs : null;
         $this->order['processed_samples'] = json_encode(!empty($processedSamples) ? $processedSamples : []);

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1385,9 +1385,11 @@ class Order
 
         if (!empty($object->identifier)) {
             foreach ($object->identifier as $identifier) {
-                // Update tracking number
                 if (preg_match('/tracking-number/i', $identifier->system)) {
                     $trackingNumber = $identifier->value;
+                }
+                if (preg_match('/PerfSite/i', $identifier->system)) {
+                    $performingSite = $identifier->value;
                 }
                 if (preg_match('/kit-id/i', $identifier->system)) {
                     $kitId = $identifier->value;
@@ -1414,11 +1416,15 @@ class Order
         $this->order['processed_notes'] = $processedNotes;
         $this->order['finalized_notes'] = $finalizedNotes;
         $this->order['fedex_tracking'] = !empty($trackingNumber) ? $trackingNumber : null;
-        $this->order['collected_user_id'] = false;
-        $this->order['processed_user_id'] = false;
-        $this->order['finalized_user_id'] = false;
+        $this->order['collected_user_id'] = !empty($order->collectedInfo) ? $order->collectedInfo->author->value : false;
+        $this->order['collected_site'] = !empty($performingSite) ? $performingSite : null;
+        $this->order['processed_user_id'] = !empty($order->processedInfo) ? $order->processedInfo->author->value : false;
+        $this->order['processed_site'] = !empty($performingSite) ? $performingSite : null;
+        $this->order['finalized_user_id'] = !empty($order->finalizedInfo) ? $order->finalizedInfo->author->value : false;
+        $this->order['finalized_site'] = !empty($performingSite) ? $performingSite : null;
         $this->order['failedToReachRDR'] = false;
         $this->order['status'] = 'finalized';
+
         $this->order['origin'] = $object->origin;
 
         return $this;

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1388,9 +1388,6 @@ class Order
                 if (preg_match('/tracking-number/i', $identifier->system)) {
                     $trackingNumber = $identifier->value;
                 }
-                if (preg_match('/PerfSite/i', $identifier->system)) {
-                    $performingSite = $identifier->value;
-                }
                 if (preg_match('/kit-id/i', $identifier->system)) {
                     $kitId = $identifier->value;
                 }
@@ -1423,11 +1420,11 @@ class Order
         $this->order['finalized_notes'] = $finalizedNotes;
         $this->order['fedex_tracking'] = !empty($trackingNumber) ? $trackingNumber : null;
         $this->order['collected_user_id'] = !empty($order->collectedInfo) ? $order->collectedInfo->author->value : false;
-        $this->order['collected_site'] = !empty($performingSite) ? $performingSite : null;
+        $this->order['collected_site'] = null;
         $this->order['processed_user_id'] = !empty($order->processedInfo) ? $order->processedInfo->author->value : false;
-        $this->order['processed_site'] = !empty($performingSite) ? $performingSite : null;
+        $this->order['processed_site'] = null;
         $this->order['finalized_user_id'] = !empty($order->finalizedInfo) ? $order->finalizedInfo->author->value : false;
-        $this->order['finalized_site'] = !empty($performingSite) ? $performingSite : null;
+        $this->order['finalized_site'] = null;
         $this->order['failedToReachRDR'] = false;
         $this->order['status'] = 'finalized';
 

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1395,11 +1395,6 @@ class Order
             }
         }
 
-        // Update centrifuge type
-        if (!empty($centrifugeType)) {
-            $updateArray['processed_centrifuge_type'] = $centrifugeType;
-        }
-
         $this->order['id'] = $object->id;
         $this->order['order_id'] = $kitId;
         $this->order['rdr_id'] = $object->id;
@@ -1408,6 +1403,7 @@ class Order
         $this->order['processed_ts'] = $processedTs;
         $this->order['collected_ts'] = $collectedTs;
         $this->order['finalized_ts'] = $finalizedTs;
+        $this->order['processed_centrifuge_type'] = (!empty($centrifugeType)) ? $centrifugeType : null;
         $this->order['collected_samples'] = json_encode(!empty($collectedSamples) ? $collectedSamples : []);
         $this->order['collected_ts'] = !empty($collectedTs) ? $collectedTs : null;
         $this->order['processed_samples'] = json_encode(!empty($processedSamples) ? $processedSamples : []);

--- a/views/biobank/order-quanum.html.twig
+++ b/views/biobank/order-quanum.html.twig
@@ -36,25 +36,6 @@
         </div>
     </div>
 
-    {% if order.status == 'unlock' %}
-        <div class="alert alert-warning well-sm">
-            <i class="fa fa-info-circle" aria-hidden="true"></i>
-            <strong>
-                Unlocked for editing by {{ app.getUserEmailById(order.oh_user_id)|default('Unknown') }} at {{ app.getSiteDisplayName(order.oh_site) }} on {{ order.oh_created_ts|date('F j, Y g:ia', app.userTimezone) }}
-            </strong>
-        </div>
-    {% elseif order.status == 'cancel' %}
-        <div class="alert alert-danger well-sm">
-            <i class="fa fa-info-circle" aria-hidden="true"></i>
-            <strong>
-                Cancelled by {{ app.getUserEmailById(order.oh_user_id)|default('Unknown') }} at {{ app.getSiteDisplayName(order.oh_site) }} on {{ order.oh_created_ts|date('F j, Y g:ia', app.userTimezone) }}
-            </strong>
-            {% if order.reasonDisplayText is not empty %}
-                <br/><strong>Reason:</strong> {{ order.reasonDisplayText }}
-            {% endif %}
-        </div>
-    {% endif %}
-    
     <div role="tabpanel">
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation">

--- a/views/biobank/order-quanum.html.twig
+++ b/views/biobank/order-quanum.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base.html.twig' %}
-{% block title %}Participant {{ participant.id }} - {% endblock %}
+{% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">
         <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>

--- a/views/biobank/order-quanum.html.twig
+++ b/views/biobank/order-quanum.html.twig
@@ -1,0 +1,116 @@
+{% extends 'base.html.twig' %}
+{% block title %}Participant {{ participant.id }} - {% endblock %}
+{% block body %}
+    <div class="page-header">
+        <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>
+    </div>
+    <div class="row">
+        <div class="col-sm-4">
+            <dl class="dl-horizontal">
+                {% if is_granted('ROLE_SCRIPPS') or is_granted('ROLE_AWARDEE') %}
+                    <dt>Participant ID</dt>
+                    <dd>{{ participant.id }}</dd>
+                {% endif %}
+                <dt>Biobank ID</dt>
+                <dd>
+                    {% if is_granted('ROLE_SCRIPPS') or is_granted('ROLE_BIOBANK') %}
+                        <a href="{{ path('biobank_participant', { biobankId: participant.biobankId }) }}">{{ participant.biobankId }}</a>
+                    {% else %}
+                        {{ participant.biobankId }}
+                    {% endif %}
+                </dd>
+                <dt>Paired Awardee</dt>
+                <dd>{{ participant.awardee ? app.getAwardeeDisplayName(participant.awardee) : '(not paired)' }}</dd>
+                <dt>Paired Site</dt>
+                <dd>{{ participant.site ? app.getSiteDisplayName(participant.siteSuffix) : '(not paired)' }}</dd>
+            </dl>
+        </div>
+        <div class="col-sm-4">
+            <p class="lead">
+                Order ID: <strong>{{ order.order_id }}</strong>
+            </p>
+            <h3>
+                <i class="fa fa-medkit" aria-hidden="true"></i>
+                {{ order.created_ts|date('n/j/Y', app.userTimezone) }}
+            </h3>
+        </div>
+    </div>
+
+    {% if order.status == 'unlock' %}
+        <div class="alert alert-warning well-sm">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            <strong>
+                Unlocked for editing by {{ app.getUserEmailById(order.oh_user_id)|default('Unknown') }} at {{ app.getSiteDisplayName(order.oh_site) }} on {{ order.oh_created_ts|date('F j, Y g:ia', app.userTimezone) }}
+            </strong>
+        </div>
+    {% elseif order.status == 'cancel' %}
+        <div class="alert alert-danger well-sm">
+            <i class="fa fa-info-circle" aria-hidden="true"></i>
+            <strong>
+                Cancelled by {{ app.getUserEmailById(order.oh_user_id)|default('Unknown') }} at {{ app.getSiteDisplayName(order.oh_site) }} on {{ order.oh_created_ts|date('F j, Y g:ia', app.userTimezone) }}
+            </strong>
+            {% if order.reasonDisplayText is not empty %}
+                <br/><strong>Reason:</strong> {{ order.reasonDisplayText }}
+            {% endif %}
+        </div>
+    {% endif %}
+    
+    <div role="tabpanel">
+        <ul class="nav nav-tabs" role="tablist">
+            <li role="presentation">
+                <a href="#collect" aria-controls="collect" role="tab" data-toggle="tab">
+                    {% if order.collected_ts is not empty %}
+                        <i class="fa fa-check-circle text-success" aria-hidden="true"></i>
+                    {% endif %}
+                    Collect
+                </a>
+            </li>
+            <li role="presentation" {% if order.collected_ts is empty %} class="disabled" {% endif %}>
+                <a href="#process" aria-controls="collect" role="tab" {% if order.collected_ts is not empty %} data-toggle="tab" {% endif %}>
+                    {% if order.collected_ts is not empty and order.processed_ts is not empty %}
+                        <i class="fa fa-check-circle text-success" aria-hidden="true"></i>
+                    {% endif %}
+                    Process
+                </a>
+            </li>
+            <li role="presentation" {% if order.collected_ts is empty or order.processed_ts is empty %} class="disabled" {% endif %}>
+                <a href="#finalize" aria-controls="collect" role="tab" {% if order.processed_ts is not empty %} data-toggle="tab" {% endif %}>
+                    {% if order.finalized_ts is not empty %}
+                        <i class="fa fa-check-circle text-success" aria-hidden="true"></i>
+                    {% endif %}
+                    Finalize
+                </a>
+            </li>
+        </ul>
+        <br />
+        <div class="tab-content">
+            <div role="tabpanel" class="tab-pane" id="collect">
+                {% include 'partials/biobank-order-details.html.twig' with { type: 'collected' } %}
+            </div>
+            <div role="tabpanel" class="tab-pane" id="process">
+                {% if order.collected_ts is not empty %}
+                    {% include 'partials/biobank-order-details.html.twig' with { type: 'processed' } %}
+                {% endif %}
+            </div>
+            <div role="tabpanel" class="tab-pane" id="finalize">
+                {% if order.collected_ts is not empty and order.processed_ts is not empty %}
+                    {% include 'partials/biobank-order-details.html.twig' with { type: 'finalized' } %}
+                {% endif %}
+                <div class="row">
+                  <div class="col-sm-12">
+                    <h3><i class="fa fa-truck" aria-hidden="true"></i> FedEx Tracking Number</h3>
+                    {{ order.fedex_tracking|default('Not provided.') }}
+                  </div>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}
+{% block pagejs %}
+    <script>
+        $(document).ready(function() {
+            // Switch tab to active step
+            $(".nav-tabs a[href='#{{ currentStep }}']").tab('show');
+        });
+    </script>
+{% endblock %}

--- a/views/biobank/order.html.twig
+++ b/views/biobank/order.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base.html.twig' %}
-{% block title %}Participant {{ participant.id }} - {% endblock %}
+{% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">
         <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>

--- a/views/biobank/order.html.twig
+++ b/views/biobank/order.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base.html.twig' %}
-{% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
+{% block title %}Participant {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">
         <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>

--- a/views/biobank/participant.html.twig
+++ b/views/biobank/participant.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base.html.twig' %}
-{% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
+{% block title %}Participant {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">
         <h2><i class="fa fa-user" aria-hidden="true"></i> Participant Details</h2>

--- a/views/biobank/participant.html.twig
+++ b/views/biobank/participant.html.twig
@@ -1,5 +1,5 @@
 {% extends 'base.html.twig' %}
-{% block title %}Participant {{ participant.id }} - {% endblock %}
+{% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">
         <h2><i class="fa fa-user" aria-hidden="true"></i> Participant Details</h2>

--- a/views/partials/biobank-order-details.html.twig
+++ b/views/partials/biobank-order-details.html.twig
@@ -7,7 +7,7 @@
     {% elseif order.origin is defined and order.origin == 'careevolution' %}
       <div class="alert alert-success well-sm">
           <i class="fa fa-info-circle" aria-hidden="true"></i>
-          <strong>{{ type|capitalize }} by Quest User at {{ attribute(order, type~'_site')|default('Unknown') }}</strong>
+          <strong>{{ type|capitalize }} by Quest User at a Quest Site</strong>
       </div>
     {% endif %}
     {% if type == 'finalized' and order.failedToReachRDR %}

--- a/views/partials/biobank-order-details.html.twig
+++ b/views/partials/biobank-order-details.html.twig
@@ -4,6 +4,11 @@
             <i class="fa fa-info-circle" aria-hidden="true"></i>
             <strong>{{ type|capitalize }} by {{ app.getUserEmailById(attribute(order, type~'_user_id'))|default('Unknown') }} at {{ app.getSiteDisplayName(attribute(order, type~'_site')) }}</strong>
         </div>
+    {% elseif order.origin is defined and order.origin == 'careevolution' %}
+      <div class="alert alert-success well-sm">
+          <i class="fa fa-info-circle" aria-hidden="true"></i>
+          <strong>{{ type|capitalize }} by Quest User at {{ attribute(order, type~'_site')|default('Unknown') }}</strong>
+      </div>
     {% endif %}
     {% if type == 'finalized' and order.failedToReachRDR %}
         <div class="alert alert-danger well-sm">

--- a/views/partials/participant-orders-list.html.twig
+++ b/views/partials/participant-orders-list.html.twig
@@ -10,7 +10,9 @@
                 {% if type is not defined and loop.index == 6 %}
                     <div id="order-overflow">
                 {% endif %}
-                {% if biobankView is defined %}
+                {% if order.origin is defined and order.origin == 'careevolution' %}
+                    <a href="{{ path('biobank_quanumOrder', { biobankId: participant.biobankId, orderId: order.id }) }}" class="btn btn-block btn-lg {% if orderId is defined and order.id == orderId %} btn-warning {% else %} btn-default {% endif %}">
+                {% elseif biobankView is defined %}
                     <a href="{{ path('biobank_order', { biobankId: participant.biobankId, orderId: order.id }) }}" class="btn btn-block btn-lg {% if orderId is defined and order.id == orderId %} btn-warning {% else %} btn-default {% endif %}">
                 {% else %}
                     <a href="{{ path('order', { participantId: participant.id, orderId: order.id }) }}" class="btn btn-block btn-lg {% if orderId is defined and order.id == orderId %} btn-warning {% else %} btn-default {% endif %}">


### PR DESCRIPTION
This PR introduces a means of accessing Biobank orders that did not originate in HealthPro.
 
### Biobank Order Lookup Command

```bash
bin/console pmi:biobank --origin careevolution --start_date 2019-12-01
```


[HPRO-578]

[HPRO-578]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-578