### PR TITLE
[HPRO-589] Add 'Today's Quest Biobank Orders' Tab

### DIFF
--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -268,11 +268,9 @@ class BiobankController extends AbstractController
         $today = $startTime->format('Y-m-d');
 
         $quanumOrders = $app['pmi.drc.participants']->getOrders([
-            'participant_id' => $participant_id,
             'startDate' => $today,
             'endDate' => date('Y-m-d'),
             'origin' => 'careevolution',
-            'kitId' => null,
             'page' => '1',
             'pageSize' => '1000'
         ]);

--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -22,6 +22,7 @@ class BiobankController extends AbstractController
         ['order', '/{biobankId}/order/{orderId}'],
         ['quanumOrder', '/{biobankId}/quanum-order/{orderId}'],
         ['ordersToday', '/review/orders/today'],
+        ['quanumOrdersToday', '/review/quanum-orders/today'],
         ['ordersUnfinalized', '/review/orders/unfinalized'],
         ['ordersUnlocked', '/review/orders/unlocked'],
         ['ordersRecentModify', '/review/orders/recent/modify']
@@ -117,7 +118,7 @@ class BiobankController extends AbstractController
                 'origin' => 'careevolution'
             ]);
             if (isset($quanumOrders[0])) {
-                $order = (new Order())->loadFromJsonObject($quanumOrders[0])->toArray();
+                $order = (new Order($app))->loadFromJsonObject($quanumOrders[0])->toArray();
                 $participant = $app['pmi.drc.participants']->getById($order['participant_id']);
                 if ($participant->biobankId) {
                     return $app->redirectToRoute('biobank_quanumOrder', [
@@ -164,7 +165,7 @@ class BiobankController extends AbstractController
         $quanumOrders = $app['pmi.drc.participants']->getOrdersByParticipant($participant->id);
         foreach ($quanumOrders as $quanumOrder) {
             if (in_array($quanumOrder->origin, ['careevolution'])) {
-                $orders[] = (new Order())->loadFromJsonObject($quanumOrder)->toArray();
+                $orders[] = (new Order($app))->loadFromJsonObject($quanumOrder)->toArray();
             }
         }
 
@@ -249,6 +250,40 @@ class BiobankController extends AbstractController
         $orders = $review->getTodayOrders($today);
 
         return $app['twig']->render('biobank/orders-today.html.twig', [
+            'orders' => $orders
+        ]);
+    }
+
+    public function quanumOrdersTodayAction(Application $app, Request $request)
+    {
+        // Get beginning of today (at midnight) in user's timezone
+        $startString = 'today';
+        // Allow overriding start time to test in non-prod environments
+        if (!$app->isProd() && intval($request->query->get('days')) > 0) {
+            $startString = '-' . intval($request->query->get('days')) . ' days';
+        }
+        $startTime = new \DateTime($startString, new \DateTimeZone($app->getUserTimezone()));
+        // Get MySQL date/time string in UTC
+        $startTime->setTimezone(new \DateTimezone('UTC'));
+        $today = $startTime->format('Y-m-d');
+
+        $quanumOrders = $app['pmi.drc.participants']->getOrders([
+            'participant_id' => $participant_id,
+            'startDate' => $today,
+            'endDate' => date('Y-m-d'),
+            'origin' => 'careevolution',
+            'kitId' => null,
+            'page' => '1',
+            'pageSize' => '1000'
+        ]);
+        $orders = [];
+        foreach ($quanumOrders as $quanumOrder) {
+            if (in_array($quanumOrder->origin, ['careevolution'])) {
+                $orders[] = (new Order($app))->loadFromJsonObject($quanumOrder)->toArray();
+            }
+        }
+
+        return $app['twig']->render('biobank/orders-quanum-today.html.twig', [
             'orders' => $orders
         ]);
     }

--- a/src/Pmi/Controller/BiobankController.php
+++ b/src/Pmi/Controller/BiobankController.php
@@ -263,13 +263,12 @@ class BiobankController extends AbstractController
             $startString = '-' . intval($request->query->get('days')) . ' days';
         }
         $startTime = new \DateTime($startString, new \DateTimeZone($app->getUserTimezone()));
-        // Get MySQL date/time string in UTC
-        $startTime->setTimezone(new \DateTimezone('UTC'));
         $today = $startTime->format('Y-m-d');
+        $endDate = (new \DateTime('today', new \DateTimezone('UTC')))->format('Y-m-d');
 
         $quanumOrders = $app['pmi.drc.participants']->getOrders([
             'startDate' => $today,
-            'endDate' => date('Y-m-d'),
+            'endDate' => $endDate,
             'origin' => 'careevolution',
             'page' => '1',
             'pageSize' => '1000'

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1396,13 +1396,13 @@ class Order
 
         // Extract participantId
         preg_match('/^Patient\/(P\d+)$/i', $object->subject, $subject_matches);
-        $participant = $this->app['pmi.drc.participants']->getById($subject_matches[1]);
+        $participantId = $subject_matches[1];
 
         $this->order['id'] = $object->id;
-        $this->order['participant_id'] = $participant->id;
+        $this->order['participant_id'] = $participantId;
         $this->order['order_id'] = $kitId;
         $this->order['rdr_id'] = $object->id;
-        $this->order['biobank_id'] = $participant->biobankId;
+        $this->order['biobank_id'] = $object->biobankId;
         $this->order['type'] = 'kit';
         $this->order['oh_type'] = 'kit';
         $this->order['h_type'] = 'kit';

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1402,7 +1402,7 @@ class Order
         $this->order['participant_id'] = $participantId;
         $this->order['order_id'] = $kitId;
         $this->order['rdr_id'] = $object->id;
-        $this->order['biobank_id'] = $object->biobankId;
+        $this->order['biobank_id'] = (property_exists($object, 'biobankId')) ? $object->biobankId : null;
         $this->order['type'] = 'kit';
         $this->order['oh_type'] = 'kit';
         $this->order['h_type'] = 'kit';

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1368,8 +1368,8 @@ class Order
                 }
                 if (!empty($sample->processed)) {
                     $processedSamples[] = $sampleCode;
-                    $processedTs = new \DateTime($sample->processed);
-                    $processedSamplesTs[$sampleCode] = $processedTs->getTimestamp();
+                    $processedTs = $sample->processed;
+                    $processedSamplesTs[$sampleCode] = $sample->processed;
                 }
                 if (!empty($sample->finalized)) {
                     $finalizedSamples[] = $sampleCode;
@@ -1396,13 +1396,16 @@ class Order
 
         // Extract participantId
         preg_match('/^Patient\/(P\d+)$/i', $object->subject, $subject_matches);
+        $participant = $this->app['pmi.drc.participants']->getById($subject_matches[1]);
 
         $this->order['id'] = $object->id;
-        $this->order['participant_id'] = $subject_matches[1] ? $subject_matches[1] : 'Unknown';
+        $this->order['participant_id'] = $participant->id;
         $this->order['order_id'] = $kitId;
         $this->order['rdr_id'] = $object->id;
+        $this->order['biobank_id'] = $participant->biobankId;
         $this->order['type'] = 'kit';
         $this->order['oh_type'] = 'kit';
+        $this->order['h_type'] = 'kit';
         $this->order['created_ts'] = $object->created;
         $this->order['processed_ts'] = $processedTs;
         $this->order['collected_ts'] = $collectedTs;
@@ -1414,6 +1417,7 @@ class Order
         $this->order['processed_samples'] = json_encode(!empty($processedSamples) ? $processedSamples : []);
         $this->order['processed_samples_ts'] = json_encode(!empty($processedSamplesTs) ? $processedSamplesTs : []);
         $this->order['finalized_samples'] = json_encode(!empty($finalizedSamples) ? $finalizedSamples : []);
+        $this->order['finalizedSamples'] = !empty($finalizedSamples) ? join($finalizedSamples, ', ') : '';
         $this->order['finalized_ts'] = !empty($finalizedTs) ? $finalizedTs : null;
         $this->order['collected_notes'] = $collectedNotes;
         $this->order['processed_notes'] = $processedNotes;
@@ -1421,11 +1425,15 @@ class Order
         $this->order['fedex_tracking'] = !empty($trackingNumber) ? $trackingNumber : null;
         $this->order['collected_user_id'] = !empty($order->collectedInfo) ? $order->collectedInfo->author->value : false;
         $this->order['collected_site'] = null;
+        $this->order['collected_site_name'] = 'A Quest Site';
         $this->order['processed_user_id'] = !empty($order->processedInfo) ? $order->processedInfo->author->value : false;
         $this->order['processed_site'] = null;
+        $this->order['processed_site_name'] = 'A Quest Site';
         $this->order['finalized_user_id'] = !empty($order->finalizedInfo) ? $order->finalizedInfo->author->value : false;
         $this->order['finalized_site'] = null;
+        $this->order['finalized_site_name'] = 'A Quest Site';
         $this->order['failedToReachRDR'] = false;
+        $this->order['orderStatus'] = 'Finalized';
         $this->order['status'] = 'finalized';
 
         $this->order['origin'] = $object->origin;

--- a/views/biobank/orders-quanum-today.html.twig
+++ b/views/biobank/orders-quanum-today.html.twig
@@ -21,11 +21,8 @@
                 <th>Biobank ID</th>
                 <th>Status</th>
                 <th class="col-created">Created</th>
-                <th>Created Site</th>
                 <th>Collected</th>
-                <th>Collected Site</th>
                 <th>Processed</th>
-                <th>Processed Site</th>
                 <th>Finalized</th>
                 <th>Finalized Site</th>
                 <th>Finalized Samples</th>
@@ -40,7 +37,7 @@
                         </td>
                     {% endif %}
                     <td>
-                        <a href="{{ path('biobank_order', { biobankId: order.biobank_id, orderId: order.id }) }}">{{ order.order_id }}</a>
+                        <a href="{{ path('biobank_quanumOrder', { biobankId: order.biobank_id, orderId: order.id }) }}">{{ order.order_id }}</a>
                     </td>
                     <td>
                         <a href="{{ path('biobank_participant', { biobankId: order.biobank_id }) }}">{{ order.biobank_id }}</a>
@@ -51,20 +48,11 @@
                     <td data-order="{{ order.created_ts }}">
                         {{ macros.displayDate(order, 'created_ts') }}
                     </td>
-                    <td>
-                        {{ macros.displaySite(order.created_site_name, order.site) }}
-                    </td>
                     <td data-order="{{ order.collected_ts }}">
                         {{ macros.displayDate(order, 'collected_ts') }}
                     </td>
-                    <td>
-                        {{ macros.displaySite(order.collected_site_name, order.collected_site) }}
-                    </td>
                     <td data-order="{{ order.processed_ts }}">
                         {{ macros.displayDate(order, 'processed_ts') }}
-                    </td>
-                    <td>
-                        {{ macros.displaySite(order.processed_site_name, order.processed_site) }}
                     </td>
                     <td data-order="{{ order.finalized_ts is defined }}">
                         {% set showOrderFinalizedTs = order.finalized_ts and order.h_type != 'unlock' and not (order.finalized_ts and order.rdr_id is empty) %}

--- a/views/biobank/orders-quanum-today.html.twig
+++ b/views/biobank/orders-quanum-today.html.twig
@@ -87,6 +87,7 @@
         $(document).ready(function () {
             $('table').DataTable({
                 order: [[$('.col-created').index(), 'desc']],
+                searching: false,
                 pageLength: 25
             });
         });

--- a/views/biobank/orders-recent-modify.html.twig
+++ b/views/biobank/orders-recent-modify.html.twig
@@ -8,12 +8,7 @@
     <div class="page-header">
         <h2><i class="fa fa-list" aria-hidden="true"></i> Participant Review</h2>
     </div>
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ path('biobank_ordersToday') }}">Today's Biobank Orders</a></li>
-        <li role="presentation"><a href="{{ path('biobank_ordersUnfinalized') }}">Unfinalized Biobank Orders</a></li>
-        <li role="presentation"><a href="{{ path('biobank_ordersUnlocked') }}">Unlocked Biobank Orders</a></li>
-        <li role="presentation" class="active"><a href="{{ path('biobank_ordersRecentModify') }}">Recently Modified Biobank Orders</a></li>
-    </ul>
+    {% include 'biobank/partials/participant-review-tabs.html.twig' %}
     <br/>
     <table class="table table-striped table-bordered table-small">
         <thead>

--- a/views/biobank/orders-unfinalized.html.twig
+++ b/views/biobank/orders-unfinalized.html.twig
@@ -8,12 +8,7 @@
     <div class="page-header">
         <h2><i class="fa fa-list" aria-hidden="true"></i> Participant Review</h2>
     </div>
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ path('biobank_ordersToday') }}">Today's Biobank Orders</a></li>
-        <li role="presentation" class="active"><a href="{{ path('biobank_ordersUnfinalized') }}">Unfinalized Biobank Orders</a></li>
-        <li role="presentation"><a href="{{ path('biobank_ordersUnlocked') }}">Unlocked Biobank Orders</a></li>
-        <li role="presentation"><a href="{{ path('biobank_ordersRecentModify') }}">Recently Modified Biobank Orders</a></li>
-    </ul>
+    {% include 'biobank/partials/participant-review-tabs.html.twig' %}
     <br />
     <table class="table table-striped table-bordered table-small">
         <thead>

--- a/views/biobank/orders-unlocked.html.twig
+++ b/views/biobank/orders-unlocked.html.twig
@@ -8,12 +8,7 @@
     <div class="page-header">
         <h2><i class="fa fa-list" aria-hidden="true"></i> Participant Review</h2>
     </div>
-    <ul class="nav nav-tabs">
-        <li role="presentation"><a href="{{ path('biobank_ordersToday') }}">Today's Biobank Orders</a></li>
-        <li role="presentation"><a href="{{ path('biobank_ordersUnfinalized') }}">Unfinalized Biobank Orders</a></li>
-        <li role="presentation" class="active"><a href="{{ path('biobank_ordersUnlocked') }}">Unlocked Biobank Orders</a></li>
-        <li role="presentation"><a href="{{ path('biobank_ordersRecentModify') }}">Recently Modified Biobank Orders</a></li>
-    </ul>
+    {% include 'biobank/partials/participant-review-tabs.html.twig' %}
     <br />
     <table class="table table-striped table-bordered table-small">
         <thead>

--- a/views/biobank/partials/participant-review-tabs.html.twig
+++ b/views/biobank/partials/participant-review-tabs.html.twig
@@ -1,0 +1,8 @@
+{% set current_route = app.request_stack.currentRequest.attributes.get('_route') %}
+<ul class="nav nav-tabs">
+    <li role="presentation" {% if current_route == 'biobank_ordersToday' %}class="active"{% endif %}><a href="{{ path('biobank_ordersToday') }}">Today's Biobank Orders</a></li>
+    <li role="presentation" {% if current_route == 'biobank_quanumOrdersToday' %}class="active"{% endif %}><a href="{{ path('biobank_quanumOrdersToday') }}">Today's Quest Biobank Orders</a></li>
+    <li role="presentation" {% if current_route == 'biobank_ordersUnfinalized' %}class="active"{% endif %}><a href="{{ path('biobank_ordersUnfinalized') }}">Unfinalized Biobank Orders</a></li>
+    <li role="presentation" {% if current_route == 'biobank_ordersUnlocked' %}class="active"{% endif %}><a href="{{ path('biobank_ordersUnlocked') }}">Unlocked Biobank Orders</a></li>
+    <li role="presentation" {% if current_route == 'biobank_ordersRecentModify' %}class="active"{% endif %}><a href="{{ path('biobank_ordersRecentModify') }}">Recently Modified Biobank Orders</a></li>
+</ul>


### PR DESCRIPTION

![Screen Shot 2020-04-08 at 4 12 45 PM](https://user-images.githubusercontent.com/80459/78834211-d6519880-79b3-11ea-8023-7af75aadb4b4.png)

Add a view of orders matching the current date from the Quest Biobank data source. Non-production deployments can use the `?days=<int>` flag for testing purposes.

Also centralized the tabs into a partial to reduce repeated code.

[HPRO-589]

[HPRO-589]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-589