### PR TITLE
[HPRO-598] Update npm dependencies to address security issue with minimist (minimal/no risk to HealthPro)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -582,13 +582,14 @@
             }
         },
         "browserslist": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.9.1.tgz",
-            "integrity": "sha512-Q0DnKq20End3raFulq6Vfp1ecB9fh8yUNV55s8sekaDDeqBaCtWlRHCUdaWyUeSSBJM7IbM6HcsyaeYqgeDhnw==",
+            "version": "4.11.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+            "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
             "requires": {
-                "caniuse-lite": "^1.0.30001030",
-                "electron-to-chromium": "^1.3.363",
-                "node-releases": "^1.1.50"
+                "caniuse-lite": "^1.0.30001038",
+                "electron-to-chromium": "^1.3.390",
+                "node-releases": "^1.1.53",
+                "pkg-up": "^2.0.0"
             }
         },
         "bs-recipes": {
@@ -675,9 +676,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001033",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001033.tgz",
-            "integrity": "sha512-8Ibzxee6ibc5q88cM1usPsMpJOG5CTq0s/dKOmlekPbDGKt+UrnOOTPSjQz3kVo6yL7N4SB5xd+FGLHQmbzh6A=="
+            "version": "1.0.30001039",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001039.tgz",
+            "integrity": "sha512-SezbWCTT34eyFoWHgx8UWso7YtvtM7oosmFoXbCkdC6qJzRfBTeTgE9REtKtiuKXuMwWTZEvdnFNGAyVMorv8Q=="
         },
         "chalk": {
             "version": "1.1.3",
@@ -1146,11 +1147,32 @@
             "integrity": "sha512-WcKx5OY+KoSIAxBW6UBBRay1U6vkYheCdjyVNDm85zt5K9mHoGOfsOsqIszfAqrQQFIIKgjh2+FDgIj/zsl21Q=="
         },
         "csso": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.2.tgz",
-            "integrity": "sha512-kS7/oeNVXkHWxby5tHVxlhjizRCSv8QdU7hB2FpdAibDU8FjTAolhNjKNTiLzXtUrKT6HwClE81yXwEk1309wg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/csso/-/csso-4.0.3.tgz",
+            "integrity": "sha512-NL3spysxUkcrOgnpsT4Xdl2aiEiBG6bXswAABQVHcMrfjjBisFOKwLDOmf4wf32aPdcJws1zds2B0Rg+jqMyHQ==",
             "requires": {
-                "css-tree": "1.0.0-alpha.37"
+                "css-tree": "1.0.0-alpha.39"
+            },
+            "dependencies": {
+                "css-tree": {
+                    "version": "1.0.0-alpha.39",
+                    "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.39.tgz",
+                    "integrity": "sha512-7UvkEYgBAHRG9Nt980lYxjsTrCyHFN53ky3wVsDkiMdVqylqRt+Zc+jm5qw7/qyOvN2dHSYtX0e4MbCCExSvnA==",
+                    "requires": {
+                        "mdn-data": "2.0.6",
+                        "source-map": "^0.6.1"
+                    }
+                },
+                "mdn-data": {
+                    "version": "2.0.6",
+                    "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.6.tgz",
+                    "integrity": "sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA=="
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
             }
         },
         "d": {
@@ -1452,9 +1474,9 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "electron-to-chromium": {
-            "version": "1.3.375",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.375.tgz",
-            "integrity": "sha512-zmaFnYVBtfpF8bGRYxgPeVAlXB7N3On8rjBE2ROc6wOpTPpzRWaiHo6KkbJMvlH07CH33uks/TEb6kuMMn8q6A=="
+            "version": "1.3.397",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.397.tgz",
+            "integrity": "sha512-zcUd1p/7yzTSdWkCTrqGvbnEOASy96d0RJL/lc5BDJoO23Z3G/VHd0yIPbguDU9n8QNUTCigLO7oEdtOb7fp2A=="
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -1574,9 +1596,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.17.4",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.4.tgz",
-            "integrity": "sha512-Ae3um/gb8F0mui/jPL+QiqmglkUsaQf7FwBEHYIFkztkneosu9imhqHpBzQ3h1vit8t5iQ74t6PEVvphBZiuiQ==",
+            "version": "1.17.5",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+            "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
             "requires": {
                 "es-to-primitive": "^1.2.1",
                 "function-bind": "^1.1.1",
@@ -2018,9 +2040,9 @@
             "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fsevents": {
-            "version": "1.2.11",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.11.tgz",
-            "integrity": "sha512-+ux3lx6peh0BpvY0JebGyZoiR4D+oYzdPZMKJwkZ+sFkNJzpL7tXc/wehS49gUAxg3tmMHPHZkA8JU2rhhgDHw==",
+            "version": "1.2.12",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+            "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
             "optional": true,
             "requires": {
                 "bindings": "^1.5.0",
@@ -2067,7 +2089,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.1.3",
+                    "version": "1.1.4",
                     "bundled": true,
                     "optional": true
                 },
@@ -2217,7 +2239,7 @@
                     }
                 },
                 "minimist": {
-                    "version": "0.0.8",
+                    "version": "1.2.5",
                     "bundled": true,
                     "optional": true
                 },
@@ -2239,11 +2261,11 @@
                     }
                 },
                 "mkdirp": {
-                    "version": "0.5.1",
+                    "version": "0.5.3",
                     "bundled": true,
                     "optional": true,
                     "requires": {
-                        "minimist": "0.0.8"
+                        "minimist": "^1.2.5"
                     }
                 },
                 "ms": {
@@ -2252,7 +2274,7 @@
                     "optional": true
                 },
                 "needle": {
-                    "version": "2.4.0",
+                    "version": "2.3.3",
                     "bundled": true,
                     "optional": true,
                     "requires": {
@@ -2279,7 +2301,7 @@
                     }
                 },
                 "nopt": {
-                    "version": "4.0.1",
+                    "version": "4.0.3",
                     "bundled": true,
                     "optional": true,
                     "requires": {
@@ -2301,12 +2323,13 @@
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.4.7",
+                    "version": "1.4.8",
                     "bundled": true,
                     "optional": true,
                     "requires": {
                         "ignore-walk": "^3.0.1",
-                        "npm-bundled": "^1.0.1"
+                        "npm-bundled": "^1.0.1",
+                        "npm-normalize-package-bin": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -2376,17 +2399,10 @@
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
-                    },
-                    "dependencies": {
-                        "minimist": {
-                            "version": "1.2.0",
-                            "bundled": true,
-                            "optional": true
-                        }
                     }
                 },
                 "readable-stream": {
-                    "version": "2.3.6",
+                    "version": "2.3.7",
                     "bundled": true,
                     "optional": true,
                     "requires": {
@@ -3498,6 +3514,22 @@
                 }
             }
         },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "requires": {
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                }
+            }
+        },
         "lodash": {
             "version": "4.17.15",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
@@ -3750,9 +3782,9 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "mitt": {
             "version": "1.2.0",
@@ -3779,11 +3811,11 @@
             }
         },
         "mkdirp": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "version": "0.5.5",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
             "requires": {
-                "minimist": "0.0.8"
+                "minimist": "^1.2.5"
             }
         },
         "moment": {
@@ -3844,19 +3876,9 @@
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
         "node-releases": {
-            "version": "1.1.51",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.51.tgz",
-            "integrity": "sha512-1eQEs6HFYY1kMXQPOLzCf7HdjReErmvn85tZESMczdCNVWP3Y7URYLBAyYynuI7yef1zj4HN5q+oB2x67QU0lw==",
-            "requires": {
-                "semver": "^6.3.0"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                }
-            }
+            "version": "1.1.53",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.53.tgz",
+            "integrity": "sha512-wp8zyQVwef2hpZ/dJH7SfSrIPD6YoJz6BDQDpGEkcA0s3LpAQoxBIYmfIq6QAhC1DhwsyCgTaTTcONwX8qzCuQ=="
         },
         "normalize-package-data": {
             "version": "2.5.0",
@@ -4074,6 +4096,27 @@
                 "lcid": "^1.0.0"
             }
         },
+        "p-limit": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+            "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+            "requires": {
+                "p-try": "^1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "requires": {
+                "p-limit": "^1.1.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        },
         "parse-filepath": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -4206,6 +4249,24 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
                 "pinkie": "^2.0.0"
+            }
+        },
+        "pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+            "requires": {
+                "find-up": "^2.1.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                }
             }
         },
         "plugin-error": {
@@ -5688,22 +5749,42 @@
                 "strip-ansi": "^3.0.0"
             }
         },
-        "string.prototype.trimleft": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
-            "integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
+        "string.prototype.trimend": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
+            "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
+                "es-abstract": "^1.17.5"
+            }
+        },
+        "string.prototype.trimleft": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
+            "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5",
+                "string.prototype.trimstart": "^1.0.0"
             }
         },
         "string.prototype.trimright": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
-            "integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
+            "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "function-bind": "^1.1.1"
+                "es-abstract": "^1.17.5",
+                "string.prototype.trimend": "^1.0.0"
+            }
+        },
+        "string.prototype.trimstart": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
+            "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
             }
         },
         "string_decoder": {
@@ -5951,9 +6032,9 @@
             "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
         },
         "uglify-js": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.0.tgz",
-            "integrity": "sha512-ugNSTT8ierCsDHso2jkBHXYrU8Y5/fY2ZUprfrJUiD7YpuFvV4jODLFmb3h4btQjqr5Nh4TX4XtgDfCU1WdioQ==",
+            "version": "3.8.1",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
+            "integrity": "sha512-W7KxyzeaQmZvUFbGj4+YFshhVrMBGSg2IbcYAjGWGvx8DHvJMclbTDMpffdxFUGPBHjIytk7KJUR/KUXstUGDw==",
             "requires": {
                 "commander": "~2.20.3",
                 "source-map": "~0.6.1"
@@ -5977,9 +6058,9 @@
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
         },
         "underscore": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
-            "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+            "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg=="
         },
         "undertaker": {
             "version": "1.2.1",


### PR DESCRIPTION
Removed node_moudles files and ran `npm update` to fix this issue.