### PR TITLE
[HPRO-601] Add GRPC module to Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,16 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
         git-all \
         nodejs \
         openjdk-11-jdk \
+        libzstd-dev \
+        zlib1g-dev \
+        autoconf \
+        g++ \
       && docker-php-ext-install pdo_mysql \
       && rm -rf /var/lib/apt/lists/*
+
+# Install GRPC module for PHP
+RUN pecl install grpc \
+      && echo "extension=grpc.so" > /usr/local/etc/php/conf.d/grpc.ini
 
 # Google Cloud Tools
 WORKDIR /opt

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,7 @@ RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
       && rm -rf /var/lib/apt/lists/*
 
 # Install GRPC module for PHP
-RUN pecl install grpc \
-      && echo "extension=grpc.so" > /usr/local/etc/php/conf.d/grpc.ini
+RUN pecl install grpc
 
 # Google Cloud Tools
 WORKDIR /opt


### PR DESCRIPTION
In HPRO-596, we added updated the local server command to use the php.ini to match the GAE configuration. This includes loading the grpc PHP extension. However, the grpc extension is not installed in the Docker container. This PR adds the install steps.

[HPRO-601]

[HPRO-601]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-601