### PR TITLE
[HPRO-606] Fix processed timestamps under "Process" tab in Biobank view

### DIFF
--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1369,7 +1369,7 @@ class Order
                 if (!empty($sample->processed)) {
                     $processedSamples[] = $sampleCode;
                     $processedTs = $sample->processed;
-                    $processedSamplesTs[$sampleCode] = $sample->processed;
+                    $processedSamplesTs[$sampleCode] = (new \DateTime($sample->processed))->getTimestamp();
                 }
                 if (!empty($sample->finalized)) {
                     $finalizedSamples[] = $sampleCode;


### PR DESCRIPTION
![Screen Shot 2020-04-23 at 1 54 51 PM](https://user-images.githubusercontent.com/80459/80138337-45112300-856a-11ea-9e5f-49c92bd1035e.png)

There was a formatting mismatch between what the `revertOrder` method this was modeled on and what our dataset needed.

[HPRO-606]

[HPRO-606]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-606