### PR TITLE
[HPRO-588] Fix session duplicate data issue

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pmi\Application;
 
+use Pmi\Service\UserService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Pmi\Entities\Configuration;
@@ -230,8 +231,9 @@ class HpoApplication extends AbstractApplication
 
     public function setNewRoles($user)
     {
-        if ($user->getAllRoles() != $user->getRoles()) {
-            $token = new PostAuthenticationGuardToken($user, 'main', $user->getRoles());
+        $userRoles = UserService::getRoles($user->getAllRoles(), $this['session']->get('site'), $this['session']->get('awardee'));
+        if ($user->getAllRoles() != $userRoles) {
+            $token = new PostAuthenticationGuardToken($user, 'main', $userRoles);
             $this['security.token_storage']->setToken($token);
         }
     }

--- a/src/Pmi/Security/User.php
+++ b/src/Pmi/Security/User.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pmi\Security;
 
+use Pmi\Service\UserService;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class User implements UserInterface
@@ -30,13 +31,13 @@ class User implements UserInterface
     private $scrippsAccess;
     private $scrippsAwardee;
 
-    public function __construct($googleUser, array $groups, $info = null, $timezone = null, $session = null)
+    public function __construct($googleUser, array $groups, $info = null, $timezone = null, $sessionInfo = null)
     {
         $this->googleUser = $googleUser;
         $this->groups = $groups;
         $this->info = $info;
         $this->timezone = null;
-        $this->session = $session;
+        $this->sessionInfo = $sessionInfo;
         $this->sites = $this->computeSites();
         $this->awardees = $this->computeAwardees();
         $this->dashboardAccess = $this->computeDashboardAccess();
@@ -264,24 +265,7 @@ class User implements UserInterface
 
     public function getRoles()
     {
-        $roles = $this->getAllRoles();
-        if ($this->session->has('site')) {
-            if (($key = array_search('ROLE_AWARDEE', $roles)) !== false) {
-                unset($roles[$key]);
-            }
-            if (($key = array_search('ROLE_AWARDEE_SCRIPPS', $roles)) !== false) {
-                unset($roles[$key]);
-            }
-        }
-        if ($this->session->has('awardee')) {
-            if (($key = array_search('ROLE_USER', $roles)) !== false) {
-                unset($roles[$key]);
-            }
-            if ($this->session->get('awardee')->id !== self::AWARDEE_SCRIPPS && ($key = array_search('ROLE_AWARDEE_SCRIPPS', $roles)) !== false) {
-                unset($roles[$key]);
-            }
-        }
-        return $roles;
+        return UserService::getRoles($this->getAllRoles(), $this->sessionInfo['site'], $this->sessionInfo['awardee']);
     }
     
     public function getPassword()

--- a/src/Pmi/Security/User.php
+++ b/src/Pmi/Security/User.php
@@ -25,7 +25,7 @@ class User implements UserInterface
     private $adminAccess;
     private $info;
     private $timezone;
-    private $session;
+    private $sessionInfo;
     private $adminDvAccess;
     private $biobankAccess;
     private $scrippsAccess;

--- a/src/Pmi/Security/UserProvider.php
+++ b/src/Pmi/Security/UserProvider.php
@@ -34,7 +34,11 @@ class UserProvider implements UserProviderInterface
             }
         }
         $userInfo = $this->getUserInfo($googleUser);
-        return new User($googleUser, $groups, $userInfo, null, $this->app['session']);
+        $sessionInfo = [
+            'site' => $this->app['session']->get('site'),
+            'awardee' => $this->app['session']->get('awardee')
+        ];
+        return new User($googleUser, $groups, $userInfo, null, $sessionInfo);
     }
     
     public function refreshUser(UserInterface $user)

--- a/src/Pmi/Service/UserService.php
+++ b/src/Pmi/Service/UserService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Pmi\Service;
+
+use Pmi\Security\User;
+
+class UserService
+{
+
+    public static function getRoles($roles, $site, $awardee)
+    {
+        if (!empty($site)) {
+            if (($key = array_search('ROLE_AWARDEE', $roles)) !== false) {
+                unset($roles[$key]);
+            }
+            if (($key = array_search('ROLE_AWARDEE_SCRIPPS', $roles)) !== false) {
+                unset($roles[$key]);
+            }
+        }
+        if (!empty($awardee)) {
+            if (($key = array_search('ROLE_USER', $roles)) !== false) {
+                unset($roles[$key]);
+            }
+            if (isset($awardee->id) && $awardee->id !== User::AWARDEE_SCRIPPS && ($key = array_search('ROLE_AWARDEE_SCRIPPS', $roles)) !== false) {
+                unset($roles[$key]);
+            }
+        }
+        return $roles;
+    }
+}


### PR DESCRIPTION
It looks like passing whole session data from `UserProvider` class to `User` class is resulting in duplicate `SessionBagProxydata` in session. Fixed it by passing only desired session info to `User` class.

I deployed this to dev and did some testing haven’t seen any issues.