### PR TITLE
[HPRO-610] Add COPE surveys

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -318,8 +318,10 @@ class WorkQueueController extends AbstractController
                     'Completed Surveys'
                 ];
                 foreach (WorkQueue::$surveys as $survey => $label) {
-                    $headers[] = $label . ' PPI Survey Complete';
-                    $headers[] = $label . ' PPI Survey Completion Date';
+                    if (in_array($survey, WorkQueue::$initialSurveys)) {
+                        $headers[] = $label . ' PPI Survey Complete';
+                        $headers[] = $label . ' PPI Survey Completion Date';
+                    }
                 }
             } else {
                 $headers = [
@@ -360,6 +362,12 @@ class WorkQueueController extends AbstractController
                 $headers[] = 'Deactivation Date';
                 $headers[] = 'gRoR Consent Status';
                 $headers[] = 'gRoR Consent Date';
+                $headers[] = 'Cope May PPI Survey Complete';
+                $headers[] = 'Cope May PPI Survey Completion Date';
+                $headers[] = 'Cope June PPI Survey Complete';
+                $headers[] = 'Cope June PPI Survey Completion Date';
+                $headers[] = 'Cope July PPI Survey Complete';
+                $headers[] = 'Cope July PPI Survey Completion Date';
             }
             fputcsv($output, $headers);
 
@@ -397,8 +405,10 @@ class WorkQueueController extends AbstractController
                             $participant->numCompletedPPIModules
                         ];
                         foreach (WorkQueue::$surveys as $survey => $label) {
-                            $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOn{$survey}"});
-                            $row[] = WorkQueue::dateFromString($participant->{"questionnaireOn{$survey}Authored"}, $app->getUserTimezone());
+                            if (in_array($survey, WorkQueue::$initialSurveys)) {
+                                $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOn{$survey}"});
+                                $row[] = WorkQueue::dateFromString($participant->{"questionnaireOn{$survey}Authored"}, $app->getUserTimezone());
+                            }
                         }
                     } else {
                         $row = [
@@ -447,6 +457,11 @@ class WorkQueueController extends AbstractController
                         $row[] = WorkQueue::dateFromString($participant->suspensionTime, $app->getUserTimezone());
                         $row[] = WorkQueue::csvStatusFromSubmitted($participant->consentForGenomicsROR);
                         $row[] = WorkQueue::dateFromString($participant->consentForGenomicsRORAuthored, $app->getUserTimezone());
+                        $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeMay"});
+                        $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeMayAuthored"}, $app->getUserTimezone());
+                        $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeJune"});
+                        $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeJuneAuthored"}, $app->getUserTimezone());$row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeJuly"});
+                        $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeJulyAuthored"}, $app->getUserTimezone());
                     }
                     fputcsv($output, $row);
                 }

--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -460,7 +460,8 @@ class WorkQueueController extends AbstractController
                         $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeMay"});
                         $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeMayAuthored"}, $app->getUserTimezone());
                         $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeJune"});
-                        $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeJuneAuthored"}, $app->getUserTimezone());$row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeJuly"});
+                        $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeJuneAuthored"}, $app->getUserTimezone());
+                        $row[] = WorkQueue::csvStatusFromSubmitted($participant->{"questionnaireOnCopeJuly"});
                         $row[] = WorkQueue::dateFromString($participant->{"questionnaireOnCopeJulyAuthored"}, $app->getUserTimezone());
                     }
                     fputcsv($output, $row);

--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -362,12 +362,12 @@ class WorkQueueController extends AbstractController
                 $headers[] = 'Deactivation Date';
                 $headers[] = 'gRoR Consent Status';
                 $headers[] = 'gRoR Consent Date';
-                $headers[] = 'Cope May PPI Survey Complete';
-                $headers[] = 'Cope May PPI Survey Completion Date';
-                $headers[] = 'Cope June PPI Survey Complete';
-                $headers[] = 'Cope June PPI Survey Completion Date';
-                $headers[] = 'Cope July PPI Survey Complete';
-                $headers[] = 'Cope July PPI Survey Completion Date';
+                $headers[] = 'COPE May PPI Survey Complete';
+                $headers[] = 'COPE May PPI Survey Completion Date';
+                $headers[] = 'COPE June PPI Survey Complete';
+                $headers[] = 'COPE June PPI Survey Completion Date';
+                $headers[] = 'COPE July PPI Survey Complete';
+                $headers[] = 'COPE July PPI Survey Completion Date';
             }
             fputcsv($output, $headers);
 

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -259,6 +259,16 @@ class WorkQueue
         'CopeJuly' => 'Cope July'
     ];
 
+    public static $initialSurveys = [
+        'TheBasics',
+        'OverallHealth',
+        'Lifestyle',
+        'MedicalHistory',
+        'Medications',
+        'FamilyHealth',
+        'HealthcareAccess'
+    ];
+
     public static $samples = [
         '1SST8' => '8 mL SST',
         '1PST8' => '8 mL PST',

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -254,9 +254,9 @@ class WorkQueue
         'Medications' => 'Meds',
         'FamilyHealth' => 'Family',
         'HealthcareAccess' => 'Access',
-        'CopeMay' => 'Cope May',
-        'CopeJune' => 'Cope June',
-        'CopeJuly' => 'Cope July'
+        'CopeMay' => 'COPE May',
+        'CopeJune' => 'COPE June',
+        'CopeJuly' => 'COPE July'
     ];
 
     public static $initialSurveys = [

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -57,6 +57,12 @@ class WorkQueue
         'questionnaireOnFamilyHealthAuthored',
         'questionnaireOnHealthcareAccess',
         'questionnaireOnHealthcareAccessAuthored',
+        'questionnaireOnCopeMay',
+        'questionnaireOnCopeMayAuthored',
+        'questionnaireOnCopeJune',
+        'questionnaireOnCopeJuneAuthored',
+        'questionnaireOnCopeJuly',
+        'questionnaireOnCopeJulyAuthored',
         'site',
         'organization',
         'physicalMeasurementsFinalizedTime',
@@ -247,7 +253,10 @@ class WorkQueue
         'MedicalHistory' => 'Hist',
         'Medications' => 'Meds',
         'FamilyHealth' => 'Family',
-        'HealthcareAccess' => 'Access'
+        'HealthcareAccess' => 'Access',
+        'CopeMay' => 'Cope May',
+        'CopeJune' => 'Cope June',
+        'CopeJuly' => 'Cope July'
     ];
 
     public static $samples = [


### PR DESCRIPTION
HPRO-610

COPE surveys have been added to the participant details tab and the work queue.

Because the new survey columns need to be added at the end of the CSV export, we can no longer just loop through the surveys for the export, which resulted in this solution that stores the "initial" set of surveys in an array and then tacks on the new surveys manually at the end.