### PR TITLE
[HPRO-614] Work queue export fails when a patient status filter is set

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -227,7 +227,9 @@ class WorkQueueController extends AbstractController
         //For ajax requests
         if ($request->isXmlHttpRequest()) {
             $params = array_merge($params, array_filter($request->request->all()));
-            $params['siteOrganizationId'] = $app->getSiteOrganizationId();
+            if (!empty($params['patientStatus'])) {
+                $params['siteOrganizationId'] = $app->getSiteOrganizationId();
+            }
             $participants = $this->participantSummarySearch($organization, $params, $app, $type = 'wQTable');
             $ajaxData = [];
             $ajaxData['recordsTotal'] = $ajaxData['recordsFiltered'] = $app['pmi.drc.participants']->getTotal();
@@ -281,7 +283,9 @@ class WorkQueueController extends AbstractController
         $params = array_filter($request->query->all());
         $params['_count'] = $pageSize;
         $params['_sort:desc'] = 'consentForStudyEnrollmentAuthored';
-        $params['siteOrganizationId'] = $app->getSiteOrganizationId();
+        if (!empty($params['patientStatus'])) {
+            $params['siteOrganizationId'] = $app->getSiteOrganizationId();
+        }
 
         $stream = function() use ($app, $params, $organization, $hasFullDataAccess, $limit, $pageSize) {
             $output = fopen('php://output', 'w');

--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -108,8 +108,8 @@ class WorkQueueController extends AbstractController
             $rdrParams['organization'] = $params['organization_id'];
         }
         // Patient status query parameter format Organization:Status
-        if (!empty($params['patientStatus'])) {
-            $rdrParams['patientStatus'] = $app->getSiteOrganizationId() . ':' . $params['patientStatus'];
+        if (!empty($params['patientStatus']) && !empty($params['siteOrganizationId'])) {
+            $rdrParams['patientStatus'] = $params['siteOrganizationId'] . ':' . $params['patientStatus'];
         }
 
         // convert age range to dob filters - using string instead of array to support multiple params with same name
@@ -227,6 +227,7 @@ class WorkQueueController extends AbstractController
         //For ajax requests
         if ($request->isXmlHttpRequest()) {
             $params = array_merge($params, array_filter($request->request->all()));
+            $params['siteOrganizationId'] = $app->getSiteOrganizationId();
             $participants = $this->participantSummarySearch($organization, $params, $app, $type = 'wQTable');
             $ajaxData = [];
             $ajaxData['recordsTotal'] = $ajaxData['recordsFiltered'] = $app['pmi.drc.participants']->getTotal();
@@ -280,6 +281,7 @@ class WorkQueueController extends AbstractController
         $params = array_filter($request->query->all());
         $params['_count'] = $pageSize;
         $params['_sort:desc'] = 'consentForStudyEnrollmentAuthored';
+        $params['siteOrganizationId'] = $app->getSiteOrganizationId();
 
         $stream = function() use ($app, $params, $organization, $hasFullDataAccess, $limit, $pageSize) {
             $output = fopen('php://output', 'w');


### PR DESCRIPTION
This issue is we are calling session variable`$app->getSiteOrganizationId()` in `participantSummarySearch` function which is being looped while doing work queue export and causing the session start error.