### PR TITLE
[HPRO-599] Add Symfony profiler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,8 @@
     },
     "require-dev": {
         "phpunit/phpunit": "8.5.*",
-        "symfony/maker-bundle": "^1.15"
+        "symfony/maker-bundle": "^1.15",
+        "symfony/profiler-pack": "^1.0"
     },
     "extra": {
         "root-dir": "symfony"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bb72274327ff68aca4961f50ad45bd0b",
+    "content-hash": "4021edcc431f65b01c9fa22fefa55746",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -8058,6 +8058,100 @@
                 "scaffolding"
             ],
             "time": "2020-04-05T10:50:59+00:00"
+        },
+        {
+            "name": "symfony/profiler-pack",
+            "version": "v1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/profiler-pack.git",
+                "reference": "99c4370632c2a59bb0444852f92140074ef02209"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/profiler-pack/zipball/99c4370632c2a59bb0444852f92140074ef02209",
+                "reference": "99c4370632c2a59bb0444852f92140074ef02209",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "symfony/stopwatch": "*",
+                "symfony/twig-bundle": "*",
+                "symfony/web-profiler-bundle": "*"
+            },
+            "type": "symfony-pack",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A pack for the Symfony web profiler",
+            "time": "2018-12-10T12:11:44+00:00"
+        },
+        {
+            "name": "symfony/web-profiler-bundle",
+            "version": "v5.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/web-profiler-bundle.git",
+                "reference": "0725f9d2a52adf19c19107dcf509da0369146823"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/web-profiler-bundle/zipball/0725f9d2a52adf19c19107dcf509da0369146823",
+                "reference": "0725f9d2a52adf19c19107dcf509da0369146823",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/config": "^4.4|^5.0",
+                "symfony/framework-bundle": "^4.4|^5.0",
+                "symfony/http-kernel": "^4.4|^5.0",
+                "symfony/routing": "^4.4|^5.0",
+                "symfony/twig-bundle": "^4.4|^5.0",
+                "twig/twig": "^2.10|^3.0"
+            },
+            "conflict": {
+                "symfony/form": "<4.4",
+                "symfony/messenger": "<4.4"
+            },
+            "require-dev": {
+                "symfony/browser-kit": "^4.4|^5.0",
+                "symfony/console": "^4.4|^5.0",
+                "symfony/css-selector": "^4.4|^5.0",
+                "symfony/dependency-injection": "^4.4|^5.0",
+                "symfony/stopwatch": "^4.4|^5.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\WebProfilerBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony WebProfilerBundle",
+            "homepage": "https://symfony.com",
+            "time": "2020-06-09T11:33:14+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/symfony.lock
+++ b/symfony.lock
@@ -454,6 +454,9 @@
     "symfony/process": {
         "version": "v4.4.7"
     },
+    "symfony/profiler-pack": {
+        "version": "v1.0.4"
+    },
     "symfony/property-access": {
         "version": "v4.4.7"
     },
@@ -546,6 +549,20 @@
     },
     "symfony/var-exporter": {
         "version": "v4.4.7"
+    },
+    "symfony/web-profiler-bundle": {
+        "version": "3.3",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "3.3",
+            "ref": "6bdfa1a95f6b2e677ab985cd1af2eae35d62e0f6"
+        },
+        "files": [
+            "config/packages/dev/web_profiler.yaml",
+            "config/packages/test/web_profiler.yaml",
+            "config/routes/dev/web_profiler.yaml"
+        ]
     },
     "symfony/yaml": {
         "version": "v4.4.7"

--- a/symfony/.env
+++ b/symfony/.env
@@ -34,4 +34,4 @@ GOOGLE_CLIENT_SECRET=
 DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
 ###< doctrine/doctrine-bundle ###
 
-PMI_ENV=
+PMI_ENV=local

--- a/symfony/.env
+++ b/symfony/.env
@@ -34,4 +34,4 @@ GOOGLE_CLIENT_SECRET=
 DATABASE_URL=mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5.7
 ###< doctrine/doctrine-bundle ###
 
-PMI_ENV=local
+PMI_ENV=

--- a/symfony/config/bundles.php
+++ b/symfony/config/bundles.php
@@ -9,4 +9,5 @@ return [
     Symfony\Bundle\TwigBundle\TwigBundle::class => ['all' => true],
     Twig\Extra\TwigExtraBundle\TwigExtraBundle::class => ['all' => true],
     Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
+    Symfony\Bundle\WebProfilerBundle\WebProfilerBundle::class => ['dev' => true, 'test' => true],
 ];

--- a/symfony/config/packages/dev/web_profiler.yaml
+++ b/symfony/config/packages/dev/web_profiler.yaml
@@ -1,0 +1,6 @@
+web_profiler:
+    toolbar: true
+    intercept_redirects: false
+
+framework:
+    profiler: { only_exceptions: false }

--- a/symfony/config/packages/test/web_profiler.yaml
+++ b/symfony/config/packages/test/web_profiler.yaml
@@ -1,0 +1,6 @@
+web_profiler:
+    toolbar: false
+    intercept_redirects: false
+
+framework:
+    profiler: { collect: false }

--- a/symfony/config/routes/dev/web_profiler.yaml
+++ b/symfony/config/routes/dev/web_profiler.yaml
@@ -1,0 +1,7 @@
+web_profiler_wdt:
+    resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+    prefix: /s/_wdt
+
+web_profiler_profiler:
+    resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+    prefix: /s/_profiler


### PR DESCRIPTION

![Screen Shot 2020-06-17 at 4 37 29 PM](https://user-images.githubusercontent.com/80459/84953311-e921d100-b0b8-11ea-92e9-a4df55317ebb.png)


This PR adds the [Symfony Profiler](https://symfony.com/doc/current/profiler.html) so we can catch deprecation warnings, performance warnings, etc. for the new Symfony routes.

[HPRO-599]

[HPRO-599]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-599