### PR TITLE
[HPRO-599] Fix Export CSV Routes

### DIFF
--- a/web/local-router.php
+++ b/web/local-router.php
@@ -5,7 +5,7 @@ if (preg_match('#^/assets/#', $_SERVER["REQUEST_URI"])) {
 } elseif (preg_match('/\\.pdf|csv|json$/', $_SERVER["REQUEST_URI"])) {
     // for non-asset PDF, CSV and JSON URLs, explicitly send to index.php controller to avoid
     // the dev server from assuming these are static assets
-    require 'silex-index.php';
+    require 'index.php';
 } else {
     // everything else can pass through, since index.php is the default controller
     return false;


### PR DESCRIPTION
We had a rule in place where we tried to load the old Silex controller (which is no longer the primary entry point) when a URL ended in certain file extensions.

[HPRO-599]

[HPRO-599]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-599