### PR TITLE
[HPRO-625] Add frame-ancestors CSP directive and add security headers to Symfony application

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -180,8 +180,9 @@ class HpoApplication extends AbstractApplication
         // prevent clickjacking attacks
         $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
 
-        // whitelist content that the client is allowed to request
-        $whitelist =  "default-src 'self'"
+        // define content security policy
+        $contentSecurityPolicy = "default-src"
+            . " 'self'" // allow all local content
             . " 'unsafe-eval'" // required for setTimeout and setInterval
             . " 'unsafe-inline'" // for the places we are using inline JS
             . " www.google-analytics.com www.googletagmanager.com" // Google Analytics
@@ -189,9 +190,12 @@ class HpoApplication extends AbstractApplication
             . " www.youtube.com" // for training videos hosted on YouTube
             . " *.kaltura.com" // for training videos hosted on Kaltura
             . " cdn.plot.ly;" // allow plot.ly remote requests
-            . " img-src www.google-analytics.com 'self' data:"; // allow Google Analytcs, self, and data: urls for img src
 
-        $response->headers->set('Content-Security-Policy', $whitelist);
+            . " img-src www.google-analytics.com 'self' data:;" // allow Google Analytcs, self, and data: urls for img src
+
+            . " frame-ancestors 'self'"; // accomplishes the same as the X-Frame-Options header above
+
+        $response->headers->set('Content-Security-Policy', $contentSecurityPolicy);
 
         // prevent browsers from sending unencrypted requests
         $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -1,18 +1,21 @@
 <?php
 namespace Pmi\Application;
 
+use App\EventListener\ResponseSecurityHeadersTrait;
+use Pmi\Audit\Log;
+use Pmi\Entities\Configuration;
+use Pmi\Security\User;
+use Pmi\Security\UserProvider;
+use Pmi\Service\NoticeService;
 use Pmi\Service\UserService;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Pmi\Entities\Configuration;
-use Pmi\Security\UserProvider;
-use Pmi\Audit\Log;
-use Pmi\Service\NoticeService;
 use Symfony\Component\Security\Guard\Token\PostAuthenticationGuardToken;
-use Pmi\Security\User;
 
 class HpoApplication extends AbstractApplication
 {
+    use ResponseSecurityHeadersTrait;
+
     protected $configuration = [];
     protected $participantSource = 'rdr';
     protected $siteNameMapper = [];
@@ -173,43 +176,6 @@ class HpoApplication extends AbstractApplication
 
         $this['em'] = new \Pmi\EntityManager\EntityManager();
         $this['em']->setDbal($this['db']);
-    }
-
-    public function setHeaders(Response $response)
-    {
-        // prevent clickjacking attacks
-        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
-
-        // define content security policy
-        $contentSecurityPolicy = "default-src"
-            . " 'self'" // allow all local content
-            . " 'unsafe-eval'" // required for setTimeout and setInterval
-            . " 'unsafe-inline'" // for the places we are using inline JS
-            . " www.google-analytics.com www.googletagmanager.com" // Google Analytics
-            . " storage.googleapis.com" // for SOP PDFs stored in a Google Storage bucket
-            . " www.youtube.com" // for training videos hosted on YouTube
-            . " *.kaltura.com" // for training videos hosted on Kaltura
-            . " cdn.plot.ly;" // allow plot.ly remote requests
-
-            . " img-src www.google-analytics.com 'self' data:;" // allow Google Analytcs, self, and data: urls for img src
-
-            . " frame-ancestors 'self'"; // accomplishes the same as the X-Frame-Options header above
-
-        $response->headers->set('Content-Security-Policy', $contentSecurityPolicy);
-
-        // prevent browsers from sending unencrypted requests
-        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
-
-        // "low" security finding: prevent MIME type sniffing
-        $response->headers->set('X-Content-Type-Options', 'nosniff');
-
-        // "low" security finding: enable XSS Protection
-        // http://blog.innerht.ml/the-misunderstood-x-xss-protection/
-        $response->headers->set('X-XSS-Protection', '1; mode=block');
-
-        // Default cache control header in ResponseHeaderBag::computeCacheControlValue returns "no-cache, private"
-        // Recommendation from security team is to add no-store as well.
-        $response->headers->addCacheControlDirective('no-cache, no-store');
     }
 
     public function switchSite($email)
@@ -462,7 +428,7 @@ class HpoApplication extends AbstractApplication
 
     protected function afterCallback(Request $request, Response $response)
     {
-        $this->setHeaders($response);
+        $this->addSecurityHeaders($response);
         if ($this->isLoggedIn()) {
             // only the first route handled is considered a login
             $this['session']->set('isLogin', false);

--- a/src/Pmi/Security/GoogleGroupsAuthenticator.php
+++ b/src/Pmi/Security/GoogleGroupsAuthenticator.php
@@ -1,6 +1,7 @@
 <?php
 namespace Pmi\Security;
 
+use App\EventListener\ResponseSecurityHeadersTrait;
 use Pmi\Application\AbstractApplication;
 use Pmi\Audit\Log;
 use Pmi\HttpClient;
@@ -19,6 +20,8 @@ use Symfony\Component\Security\Core\Exception\AuthenticationCredentialsNotFoundE
  */
 class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
 {
+    use ResponseSecurityHeadersTrait;
+
     const OAUTH_FAILURE_MESSAGE = 'OAuth Failure';
 
     private $app;
@@ -179,7 +182,7 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
         // clear session in case Google user and our user are out of sync
         $this->app->logout();
         $response = new Response($this->app['twig']->render($template, $params), $code);
-        $this->app->setHeaders($response);
+        $this->addSecurityHeaders($response);
         return $response;
     }
     

--- a/symfony/config/services.yaml
+++ b/symfony/config/services.yaml
@@ -27,3 +27,7 @@ services:
     # please note that last definitions always *replace* previous ones
 
     Pmi\Datastore\DatastoreSessionHandler:
+
+    App\EventListener\ResponseListener:
+        tags:
+            - { name: kernel.event_listener, event: kernel.response }

--- a/symfony/src/EventListener/ResponseListener.php
+++ b/symfony/src/EventListener/ResponseListener.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResponseListener
+{
+    use ResponseSecurityHeadersTrait;
+
+    public function onKernelResponse(ResponseEvent $event)
+    {
+        $response = $event->getResponse();
+        $this->addSecurityHeaders($response);
+    }
+}

--- a/symfony/src/EventListener/ResponseSecurityHeadersTrait.php
+++ b/symfony/src/EventListener/ResponseSecurityHeadersTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\HttpFoundation\Response;
+
+trait ResponseSecurityHeadersTrait
+{
+    public function addSecurityHeaders(Response $response)
+    {
+        $response->headers->set('header-source', 'ResponseSecurityHeadersTrait');
+        // prevent clickjacking attacks
+        $response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+
+        // define content security policy
+        $contentSecurityPolicy = "default-src"
+            . " 'self'" // allow all local content
+            . " 'unsafe-eval'" // required for setTimeout and setInterval
+            . " 'unsafe-inline'" // for the places we are using inline JS
+            . " www.google-analytics.com www.googletagmanager.com" // Google Analytics
+            . " storage.googleapis.com" // for SOP PDFs stored in a Google Storage bucket
+            . " www.youtube.com" // for training videos hosted on YouTube
+            . " *.kaltura.com" // for training videos hosted on Kaltura
+            . " cdn.plot.ly;" // allow plot.ly remote requests
+
+            . " img-src www.google-analytics.com 'self' data:;" // allow Google Analytcs, self, and data: urls for img src
+
+            . " frame-ancestors 'self'"; // accomplishes the same as the X-Frame-Options header above
+
+        $response->headers->set('Content-Security-Policy', $contentSecurityPolicy);
+
+        // prevent browsers from sending unencrypted requests
+        $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains; preload');
+
+        // "low" security finding: prevent MIME type sniffing
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+
+        // "low" security finding: enable XSS Protection
+        // http://blog.innerht.ml/the-misunderstood-x-xss-protection/
+        $response->headers->set('X-XSS-Protection', '1; mode=block');
+
+        // Default cache control header in ResponseHeaderBag::computeCacheControlValue returns "no-cache, private"
+        // Recommendation from security team is to add no-store as well.
+        $response->headers->addCacheControlDirective('no-cache, no-store');
+    }
+}


### PR DESCRIPTION
[HPRO-625]

The main change in this PR is to simply add the `frame-ancestors 'self'` directive to our Content-Security-Policy header.

In the process, I also refactored the way we set all of these security-related headers in order to make it available in one place for both Silex and Symfony. It might be easier to review this PR by looking at each commit in order.

[HPRO-625]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-625