### PR TITLE
[HPRO-599] Adjust Symfony logging

### DIFF
--- a/symfony/config/packages/dev/monolog.yaml
+++ b/symfony/config/packages/dev/monolog.yaml
@@ -12,6 +12,3 @@ monolog:
             level: info
             bubble: true
             logopts: !php/const LOG_PERROR
-        service:
-            type: service
-            id: App\Service\StackdriverHandler

--- a/symfony/config/packages/dev/monolog.yaml
+++ b/symfony/config/packages/dev/monolog.yaml
@@ -10,5 +10,4 @@ monolog:
             ident: false
             facility: !php/const LOG_USER
             level: info
-            bubble: true
             logopts: !php/const LOG_PERROR

--- a/symfony/config/packages/prod/monolog.yaml
+++ b/symfony/config/packages/prod/monolog.yaml
@@ -5,8 +5,6 @@ monolog:
             ident: false
             facility: !php/const LOG_USER
             level: info
-            bubble: true
-            logopts: !php/const LOG_PERROR
         service:
             type: service
             id: App\Service\StackdriverHandler

--- a/symfony/config/packages/prod/monolog.yaml
+++ b/symfony/config/packages/prod/monolog.yaml
@@ -1,10 +1,5 @@
 monolog:
     handlers:
-        main:
-            type: stream
-            path: "%kernel.logs_dir%/%kernel.environment%.log"
-            level: debug
-            channels: ["!event"]
         syslog_handler:
             type: syslog
             ident: false

--- a/symfony/config/services.yaml
+++ b/symfony/config/services.yaml
@@ -28,6 +28,10 @@ services:
 
     Pmi\Datastore\DatastoreSessionHandler:
 
+    App\EventListener\RequestListener:
+        tags:
+            - { name: kernel.event_listener, event: kernel.request }
+
     App\EventListener\ResponseListener:
         tags:
             - { name: kernel.event_listener, event: kernel.response }

--- a/symfony/src/EventListener/RequestListener.php
+++ b/symfony/src/EventListener/RequestListener.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\EventListener;
+
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use App\Service\LoggerService;
+
+class RequestListener
+{
+    private $logger;
+
+    public function __construct(LoggerService $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $this->logRequest();
+    }
+
+    private function logRequest()
+    {
+        $this->logger->log(LoggerService::REQUEST);
+    }
+}

--- a/symfony/src/EventListener/ResponseListener.php
+++ b/symfony/src/EventListener/ResponseListener.php
@@ -3,7 +3,6 @@
 namespace App\EventListener;
 
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
-use Symfony\Component\HttpFoundation\Response;
 
 class ResponseListener
 {


### PR DESCRIPTION
HPRO-599

This PR adjusts the logging in Symfony a bit. It still doesn't match our Silex implementation exactly, but it is closer.

I'm taking the shortcut of just using Symfony's dev vs. prod environment and not worrying about the differences between our environments. For now, we can assume that when running locally we will be using Symfony's dev environment and when running in App Engine, it will be using the prod environment.

To that end, I'm removing the default prod.log file and relying on syslog and Stackdriver only in production. In dev, I have removed the Stackdriver handler, as we don't want this on by default. In Silex we have a local configuration option that can be used to test. To test locally in the Symfony, just add the handler temporarily back to the dev monolog configuration.

This PR also adds a request listener to add our custom log entry on every request, which adds an info-level Stackdriver log with the user information and context.