### PR TITLE
[HPRO-644] Suppress router listener logs in Symfony

### DIFF
--- a/bin/dx
+++ b/bin/dx
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Wrapper for docker exec to run a command inside of the web container
+#
+# Example:
+# bin/dx bin/phpunit
+# bin/dx bin/symfony cache:clear
+#
+
+docker exec -it healthpro-web "$@"

--- a/bin/symfony
+++ b/bin/symfony
@@ -1,0 +1,10 @@
+#!/bin/bash
+#
+# Executes the Symfony console which is currently inside the symfony directory
+# while we run Silex and Symfony side-by-side
+#
+
+APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+SYMFONY_DIR="${APP_DIR}/symfony"
+
+$SYMFONY_DIR/bin/console "$@"

--- a/symfony/config/services.yaml
+++ b/symfony/config/services.yaml
@@ -35,3 +35,15 @@ services:
     App\EventListener\ResponseListener:
         tags:
             - { name: kernel.event_listener, event: kernel.response }
+
+    # Override router_listener service defined in vendor/symfony/framework-bundle/Resources/config/routing.xml
+    # to suppress logger (definition below is identical except for passing in null for the logger)
+    router_listener:
+        class: Symfony\Component\HttpKernel\EventListener\RouterListener
+        arguments:
+            - '@router'
+            - '@request_stack'
+            - '@?router.request_context'
+            - null
+            - '%kernel.project_dir%'
+            - '%kernel.debug%'


### PR DESCRIPTION
HPRO-644

Accomplished this by overriding the router_listener service definition and passing in `null` for the logger.

Also added a few helper scripts into the `bin` directory.