### PR TITLE
[HPRO-650] Migrate 'Page Notices' to Symfony

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,8 +9,11 @@
          stopOnFailure="false"
     >
     <testsuites>
-        <testsuite name="unit">
+        <testsuite name="Silex Unit Tests">
             <directory>tests/Pmi</directory>
+        </testsuite>
+        <testsuite name="Symfony Test Suite">
+            <directory>symfony/tests</directory>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/src/Pmi/Security/User.php
+++ b/src/Pmi/Security/User.php
@@ -17,6 +17,8 @@ class User implements UserInterface
     const SCRIPPS_GROUP = 'scripps-non-pii';
     const AWARDEE_SCRIPPS = 'stsi';
 
+    const DEFAULT_TIMEZONE = 'America/New_York';
+
     private $googleUser;
     private $groups;
     private $sites;
@@ -36,7 +38,7 @@ class User implements UserInterface
         $this->googleUser = $googleUser;
         $this->groups = $groups;
         $this->info = $info;
-        $this->timezone = null;
+        $this->timezone = (!is_null($timezone)) ? $timezone : $info['timezone'];
         $this->sessionInfo = $sessionInfo;
         $this->sites = $this->computeSites();
         $this->awardees = $this->computeAwardees();
@@ -46,12 +48,12 @@ class User implements UserInterface
         $this->biobankAccess = $this->computeBiobankAccess();
         $this->scrippsAccess = $this->computeScrippsAccess();
     }
-    
+
     public function getGroups()
     {
         return $this->groups;
     }
-    
+
     public function getInfo()
     {
         return $this->info;
@@ -153,7 +155,7 @@ class User implements UserInterface
     }
 
 
-    
+
     public function hasTwoFactorAuth()
     {
         // Google doesn't expose the user's current 2FA setting via API so
@@ -179,7 +181,7 @@ class User implements UserInterface
     {
         return $this->awardees;
     }
-    
+
     public function getSite($email)
     {
         $site = null;
@@ -203,7 +205,7 @@ class User implements UserInterface
         }
         return $awardee;
     }
-    
+
     public function belongsToSite($email)
     {
         $belongs = false;
@@ -227,7 +229,7 @@ class User implements UserInterface
         }
         return $belongs;
     }
-    
+
     public function getGoogleUser()
     {
         return $this->googleUser;
@@ -267,27 +269,27 @@ class User implements UserInterface
     {
         return UserService::getRoles($this->getAllRoles(), $this->sessionInfo['site'], $this->sessionInfo['awardee']);
     }
-    
+
     public function getPassword()
     {
         return null;
     }
-    
+
     public function getSalt()
     {
         return null;
     }
-    
+
     public function getUsername()
     {
         return $this->googleUser->getEmail();
     }
-    
+
     public function getEmail()
     {
         return $this->googleUser->getEmail();
     }
-    
+
     public function eraseCredentials()
     {
         // we don't actually store any credentials
@@ -295,6 +297,9 @@ class User implements UserInterface
 
     public function getTimezone()
     {
+        if (!$this->timezone) {
+            return self::DEFAULT_TIMEZONE;
+        }
         return $this->timezone;
     }
 

--- a/symfony/config/packages/security.yaml
+++ b/symfony/config/packages/security.yaml
@@ -24,4 +24,5 @@ security:
     # Easy way to control access for large sections of your site
     # Note: Only the *first* access control that matches will be used
     access_control:
+     - { path: ^/s/admin/.*, roles: ROLE_ADMIN }
      - { path: ^/.*$, roles: ROLE_USER }

--- a/symfony/config/routes.yaml
+++ b/symfony/config/routes.yaml
@@ -1,3 +1,50 @@
 index:
     path: /
     controller: App\Controller\DefaultController::index
+
+# Legacy Silex Routes
+
+settings:
+    path: /settings
+
+logout:
+    path: /logout
+
+help_home:
+    path: /help
+
+help_videos:
+    path: /help/videos
+
+help_faq:
+    path: /help/faq
+
+help_sop:
+    path: /help/sop
+
+selectSite:
+    path: /site/select
+
+participants:
+    path: /participants
+
+orders:
+    path: /orders
+
+review_today:
+    path: /review
+
+workqueue_index:
+    path: /workqueue
+
+problem_reports:
+    path: /problem/reports
+
+admin_home:
+    path: /admin
+
+dashboard_home:
+    path: /dashboard
+
+biobank_home:
+    path: /biobank

--- a/symfony/config/routes/dev/framework.yaml
+++ b/symfony/config/routes/dev/framework.yaml
@@ -1,3 +1,3 @@
 _errors:
     resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
-    prefix: /_error
+    prefix: /s/_error

--- a/symfony/src/Controller/NoticeController.php
+++ b/symfony/src/Controller/NoticeController.php
@@ -36,7 +36,7 @@ class NoticeController extends AbstractController
         if ($id) {
             $notice = $noticeRepository->find($id);
             if (!$notice) {
-                $this->createNotFoundException('Page notice not found.');
+                throw $this->createNotFoundException('Page notice not found.');
             }
         } else {
             $notice = null;

--- a/symfony/src/Controller/NoticeController.php
+++ b/symfony/src/Controller/NoticeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\Notice;
 use App\Form\NoticeType;
 use App\Repository\NoticeRepository;
 use App\Service\LoggerService;
@@ -39,7 +40,8 @@ class NoticeController extends AbstractController
                 throw $this->createNotFoundException('Page notice not found.');
             }
         } else {
-            $notice = null;
+            $notice = new Notice();
+            $notice->setStatus(true);
         }
 
         $form = $this->createForm(NoticeType::class, $notice, ['timezone' => $this->getUser()->getTimezone()]);

--- a/symfony/src/Form/NoticeType.php
+++ b/symfony/src/Form/NoticeType.php
@@ -1,6 +1,7 @@
 <?php
-namespace Pmi\Form;
+namespace App\Form;
 
+use App\Entity\Notice;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type;
@@ -96,6 +97,7 @@ class NoticeType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
+            'data_class' => Notice::class,
             'timezone' => 'UTC',
         ]);
     }

--- a/symfony/src/Service/TimezoneService.php
+++ b/symfony/src/Service/TimezoneService.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Service;
+
+class TimezoneService {
+    public static $timezoneOptions = [
+        'America/New_York' => 'Eastern Time',
+        'America/Chicago' => 'Central Time',
+        'America/Denver' => 'Mountain Time',
+        'America/Phoenix' => 'Mountain Time - Arizona',
+        'America/Los_Angeles' => 'Pacific Time',
+        'America/Anchorage' => 'Alaska Time',
+        'Pacific/Honolulu' => 'Hawaii Time'
+    ];
+
+    /**
+     * Get Timezone Display Value
+     *
+     * Returns human-friendly timezone from given string. If no match found,
+     * return the given value.
+     */
+    public function getTimezoneDisplay(string $timezone): ?string
+    {
+        if (array_key_exists($timezone, static::$timezoneOptions)) {
+            return static::$timezoneOptions[$timezone];
+        } else {
+            return $timezone;
+        }
+    }
+}

--- a/symfony/src/Twig/AppExtension.php
+++ b/symfony/src/Twig/AppExtension.php
@@ -2,6 +2,7 @@
 
 namespace App\Twig;
 
+use App\Service\TimezoneService;
 use Psr\Container\ContainerInterface;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
@@ -20,7 +21,8 @@ class AppExtension extends AbstractExtension
         return [
             new TwigFunction('path_exists', [$this, 'checkPath']),
             new TwigFunction('asset', [$this, 'asset']),
-            new TwigFunction('slugify', [$this, 'slugify'])
+            new TwigFunction('slugify', [$this, 'slugify']),
+            new TwigFunction('timezone_display', [$this, 'timezoneDisplay'])
         ];
     }
 
@@ -48,5 +50,11 @@ class AppExtension extends AbstractExtension
         $output = trim(strtolower($text));
         $output = preg_replace('/[^a-z0-9]/', '-', $output);
         return $output;
+    }
+
+    public function timezoneDisplay(?string $timezone): string
+    {
+        $tsService = new TimezoneService();
+        return $tsService->getTimezoneDisplay($timezone);
     }
 }

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -15,7 +15,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="/">
+            <a class="navbar-brand" href="{{ path('home') }}">
                 <i class="fa fa-star" aria-hidden="true"></i> HealthPro
                 {% if isTraining %}
                     <div class="navbar-brand-subtitle">training</div>
@@ -25,32 +25,32 @@
         <div class="collapse navbar-collapse" id="pmi-navbar-collapse">
             <ul class="nav navbar-nav">
                 {% if is_granted('ROLE_USER') and app.session.get('site') %}
-                    <li><a href="/participants">Participant Lookup</a></li>
-                    <li><a href="/orders">Biobank Order Lookup</a></li>
-                    <li><a href="/review">Participant Review</a></li>
+                    <li><a href="{{ path('participants') }}">Participant Lookup</a></li>
+                    <li><a href="{{ path('orders') }}">Biobank Order Lookup</a></li>
+                    <li><a href="{{ path('review_today') }}">Participant Review</a></li>
                     {% if app.session.get('siteOrganization') %}
-                        <li><a href="/workqueue">Work Queue</a></li>
+                        <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
                     {% endif %}
                 {% endif %}
                 {% if is_granted('ROLE_AWARDEE') and app.session.get('awardee') and awardeeOrganization %}
-                    <li><a href="/workqueue">Work Queue</a></li>
+                    <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
                 {% endif %}
                 {% if is_granted('ROLE_DV_ADMIN') %}
-                    <li><a href="/problem/reports">Problem Reports</a></li>
+                    <li><a href="{{ path('problem_reports') }}">Problem Reports</a></li>
                 {% endif %}
                 {% if is_granted('ROLE_USER') and app.session.get('site') and isDvType and reportKitUrl %}
                     <li><a data-href="{{ app.reportKitUrl }}" class="external-link">Report Kit Problem</a></li>
                 {% endif %}
                 {% if is_granted('ROLE_ADMIN') %}
-                    <li><a href="/admin">Admin</a></li>
+                    <li><a href="{{ path('admin_home') }}">Admin</a></li>
                 {% endif %}
                 {% if is_granted('ROLE_DASHBOARD') %}
-                    <li><a href="/dashboard">Dashboard</a></li>
+                    <li><a href="{{ path('dashboard_home') }}">Dashboard</a></li>
                 {% endif %}
                 {% if is_granted('ROLE_SCRIPPS') %}
-                    <li><a href="/biobank">Scripps</a></li>
+                    <li><a href="{{ path('biobank_home') }}">Scripps</a></li>
                 {% elseif is_granted('ROLE_BIOBANK')  %}
-                    <li><a href="/biobank">Biobank</a></li>
+                    <li><a href="{{ path('biobank_home') }}">Biobank</a></li>
                 {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-right">
@@ -74,19 +74,19 @@
                     {% endif %}
 
                     <li class="dropdown">
-                        <a href="/help" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-question-circle" aria-hidden="true"></i> <span class="visible-xs-inline">Help</span><span class="caret"></span></a>
+                        <a href="{{ path('help_home') }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-question-circle" aria-hidden="true"></i> <span class="visible-xs-inline">Help</span><span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="/help/videos"><i class="fa fa-film" aria-hidden="true"></i> Training Videos</a></li>
-                            <li><a href="/help/faq"><i class="fa fa-question-circle-o" aria-hidden="true"></i> Technical FAQs</a></li>
-                            <li><a href="/help/sop"><i class="fa fa-file-text-o" aria-hidden="true"></i> All of Us℠ SOPs</a></li>
+                            <li><a href="{{ path('help_videos') }}"><i class="fa fa-film" aria-hidden="true"></i> Training Videos</a></li>
+                            <li><a href="{{ path('help_faq') }}"><i class="fa fa-question-circle-o" aria-hidden="true"></i> Technical FAQs</a></li>
+                            <li><a href="{{ path('help_sop') }}"><i class="fa fa-file-text-o" aria-hidden="true"></i> All of Us℠ SOPs</a></li>
                         </ul>
                     </li>
                     <li class="dropdown">
-                        <a href="/settings" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" aria-hidden="true"></i> {{ app.user.email|default('') }} <span class="caret"></span></a>
+                        <a href="{{ path('settings') }}" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i class="fa fa-user" aria-hidden="true"></i> {{ app.user.email|default('') }} <span class="caret"></span></a>
                         <ul class="dropdown-menu">
-                            <li><a href="/settings"><i class="fa fa-cog" aria-hidden="true"></i> Settings</a></li>
+                            <li><a href="{{ path('settings') }}"><i class="fa fa-cog" aria-hidden="true"></i> Settings</a></li>
                             <li><a data-href="https://docs.google.com/forms/d/e/1FAIpQLScc_wOGZtGeb-qruWztngFm5oarQUlECsMw_7G6siHq9DmIPA/viewform" class="external-link"><i class="fa fa-comment" aria-hidden="true"></i> Feedback</a></li>
-                            <li><a href="/logout"><i class="fa fa-sign-out" aria-hidden="true"></i> Logout</a></li>
+                            <li><a href="{{ path('logout') }}"><i class="fa fa-sign-out" aria-hidden="true"></i> Logout</a></li>
                         </ul>
                     </li>
                 {% endif %}
@@ -127,7 +127,7 @@
     <div class="modal fade" id="siteModal" tabindex="-1" role="dialog" aria-labelledby="siteModalLabel">
         <div class="modal-dialog" role="document">
             <div class="modal-content">
-                <form method="POST" action="/site/select">
+                <form method="POST" action="{{ path('selectSite') }}">
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
                         <h4 class="modal-title" id="siteModalLabel">Current site</h4>

--- a/symfony/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/symfony/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,23 @@
+{% set hideSystemUsage = true %}
+{% if status_code == 404 %}
+    {% set title = 'Not Found' %}
+    {% set description = 'Sorry, the page or resource you have requested could not be found or has been deleted.' %}
+{% elseif status_code == 403 %}
+    {% set title = 'Forbidden' %}
+    {% set description = 'Sorry, access to this page is denied or the request is invalid.' %}
+{% elseif status_code == 405 %}
+    {% set title = 'Method Not Allowed' %}
+    {% set description = 'Sorry, this request is not valid.' %}
+{% else %}
+    {% set title = 'Unexpected Error' %}
+    {% set description = 'Sorry, an error has occurred.' %}
+{% endif %}
+{% extends 'base.html.twig' %}
+{% block title %}{{ title }} - {% endblock %}
+{% block body %}
+    <h2>{{ title }}</h2>
+    <p class="text-muted">Error {{ status_code }}</p>
+    <p class="lead">
+        {{ description }}
+    </p>
+{% endblock %}

--- a/symfony/templates/notice/edit.html.twig
+++ b/symfony/templates/notice/edit.html.twig
@@ -32,7 +32,7 @@
                 </div>
                 <div class="panel-body">
                     {% set return = path('admin_notice', { notice: notice ? notice.id : null }) %}
-                    <p><strong>Your time zone</strong>: {{ app.user.info.timezone|default('Not set!') }} <a href="{{ path('settings', { return: settings_return_url }) }}" class="small">change</a></p>
+                    <p><strong>Your time zone</strong>: {{ timezone_display(app.user.info.timezone)|default('Not set!') }} <a href="{{ path('settings', { return: settings_return_url }) }}" class="small">change</a></p>
                     {{ form_rest(form) }}
                     <div class="alert alert-info">
                         <ul>

--- a/symfony/templates/notice/edit.html.twig
+++ b/symfony/templates/notice/edit.html.twig
@@ -32,7 +32,7 @@
                 </div>
                 <div class="panel-body">
                     {% set return = path('admin_notice', { notice: notice ? notice.id : null }) %}
-                    <p><strong>Your time zone</strong>: {{ app.userTimezoneDisplay }} <a href="{{ path('settings', { return: return}) }}" class="small">change</a></p>
+                    <p><strong>Your time zone</strong>: {{ app.user.info.timezone|default('Not set!') }} <a href="{{ path('settings', { return: settings_return_url }) }}" class="small">change</a></p>
                     {{ form_rest(form) }}
                     <div class="alert alert-info">
                         <ul>
@@ -59,8 +59,8 @@
 {% block pagejs %}
 <script>
 $(document).ready(function() {
-    $('#form_start_ts, #form_end_ts').pmiDateTimePicker();
-    $('#form_url').dropdownOther({
+    $('#notice_start_ts, #notice_end_ts').pmiDateTimePicker();
+    $('#notice_url').dropdownOther({
         'All': '/*',
         'Home Page': '/',
         'Work Queue': '/workqueue/',

--- a/symfony/templates/notice/index.html.twig
+++ b/symfony/templates/notice/index.html.twig
@@ -20,8 +20,8 @@
                 <td><a href="{{ path('admin_notice', { id: notice.id }) }}">{{ notice.url }}</a></td>
                 <td>{{ notice.message|length > 100 ? notice.message|slice(0, 100) ~ '...' : notice.message  }}</td>
                 <td>{{ notice.fullPage ? 'Yes' : 'No' }}</td>
-                <td>{{ notice.startTs ? notice.startTs|date('n/j/Y g:ia', app.userTimezone) }}</td>
-                <td>{{ notice.endTs ? notice.endTs|date('n/j/Y g:ia', app.userTimezone) }}</td>
+                <td>{{ notice.startTs ? notice.startTs|date('n/j/Y g:ia', app.user.timezone) }}</td>
+                <td>{{ notice.endTs ? notice.endTs|date('n/j/Y g:ia', app.user.timezone) }}</td>
                 <td>
                     {% if notice.status %}
                         <span class="label label-success">Enabled</span>

--- a/symfony/templates/notice/index.html.twig
+++ b/symfony/templates/notice/index.html.twig
@@ -19,9 +19,9 @@
             <tr>
                 <td><a href="{{ path('admin_notice', { id: notice.id }) }}">{{ notice.url }}</a></td>
                 <td>{{ notice.message|length > 100 ? notice.message|slice(0, 100) ~ '...' : notice.message  }}</td>
-                <td>{{ notice.full_page ? 'Yes' : 'No' }}</td>
-                <td>{{ notice.start_ts ? notice.start_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
-                <td>{{ notice.end_ts ? notice.end_ts|date('n/j/Y g:ia', app.userTimezone) }}</td>
+                <td>{{ notice.fullPage ? 'Yes' : 'No' }}</td>
+                <td>{{ notice.startTs ? notice.startTs|date('n/j/Y g:ia', app.userTimezone) }}</td>
+                <td>{{ notice.endTs ? notice.endTs|date('n/j/Y g:ia', app.userTimezone) }}</td>
                 <td>
                     {% if notice.status %}
                         <span class="label label-success">Enabled</span>

--- a/symfony/tests/Service/TimezoneServiceTest.php
+++ b/symfony/tests/Service/TimezoneServiceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Test\Service;
+
+use PHPUnit\Framework\TestCase;
+
+use App\Service\TimezoneService;
+
+class TimezoneServiceTest extends TestCase
+{
+    protected $tsService;
+
+    public function setup(): void
+    {
+        $this->tsService = new TimezoneService;
+    }
+
+    public function testTimezoneDisplay()
+    {
+        $this->assertEquals('Central Time', $this->tsService->getTimezoneDisplay('America/Chicago'));
+        $this->assertEquals('Mountain Time', $this->tsService->getTimezoneDisplay('America/Denver'));
+        $this->assertEquals('America/Bogota', $this->tsService->getTimezoneDisplay('America/Bogota'));
+    }
+}

--- a/views/admin/index.html.twig
+++ b/views/admin/index.html.twig
@@ -17,7 +17,7 @@
             <a href="{{ path('admin_withdrawalNotifications') }}" class="btn btn-lg btn-default btn-block"><i class="fa fa-bell" aria-hidden="true"></i> Withdrawal Notifications</a>
         </div>
         <div class="col-sm-6 col-md-4">
-            <a href="{{ path('admin_notices') }}" class="btn btn-lg btn-default btn-block"><i class="fa fa-info-circle" aria-hidden="true"></i> Page Notices</a>
+            <a href="/s/admin/notices" class="btn btn-lg btn-default btn-block"><i class="fa fa-info-circle" aria-hidden="true"></i> Page Notices</a>
         </div>
     </div>
 


### PR DESCRIPTION
This takes a relatively contained piece of functionality of the site (the Page Notices tool) and migrates it into the Symfony framework. Among the things to discuss:

- Maintaining routes between the two frameworks (use static mapping file?)
- Checking for permissions/security (controller vs. firewall route matching)
- Migrating form types backed by Entities
- Maintaining the two `base.html.twig` files
- Route naming conventions
- Twig globals (e.g. `app.userTimezoneDisplay`)

[HPRO-650]

[HPRO-650]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-650