### PR TITLE
[HPRO-650] Set phpunit error reporting to E_ALL

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,9 @@
          processIsolation="false"
          stopOnFailure="false"
     >
+    <php>
+      <ini name="error_reporting" value="E_ALL" />
+    </php>
     <testsuites>
         <testsuite name="Silex Unit Tests">
             <directory>tests/Pmi</directory>


### PR DESCRIPTION
As discovered in #706, the phpunit setting for `convertNoticesToExceptions` doesn't do anything if notices aren't included in the error_reporting setting. We set it to E_ALL in our runtime php.ini file, but this isn't included when running our unit tests. This PR sets the error_reporting setting using the [<ini>](https://phpunit.readthedocs.io/en/8.5/configuration.html#the-ini-element) element in our phpunit configuration file.