### PR TITLE
[HPRO-653] Prevent required asterisk from displaying on radio button labels

### DIFF
--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -43,7 +43,7 @@ iframe.pdf {
         font-size: 20px;
     }
 }
-label.required::after {
+label.control-label.required::after {
     content: "*";
     color: #a94442;
     margin-left: 2px;


### PR DESCRIPTION
HPRO-653

Fixed the problem by making the CSS selector more specific.