### PR TITLE
[HPRO-681] Deceased Reports > Participant Summary Updates

### DIFF
--- a/src/Pmi/Controller/DefaultController.php
+++ b/src/Pmi/Controller/DefaultController.php
@@ -396,7 +396,7 @@ class DefaultController extends AbstractController
         }
 
         $isCrossOrg = $participant->hpoId !== $app->getSiteOrganization();
-        $canViewDetails = !$isCrossOrg && ($participant->status || in_array($participant->statusReason, ['test-participant', 'basics', 'genomics', 'ehr-consent', 'program-update', 'primary-consent-update']));
+        $canViewDetails = !$isCrossOrg && ($participant->status || in_array($participant->statusReason, ['test-participant', 'basics', 'genomics', 'ehr-consent', 'program-update', 'primary-consent-update', 'deceased-pending', 'deceased-approved']));
         $hasNoParticipantAccess = $isCrossOrg && empty($app['session']->get('agreeCrossOrg_'.$id));
         if ($hasNoParticipantAccess) {
             $app->log(Log::CROSS_ORG_PARTICIPANT_ATTEMPT, [

--- a/src/Pmi/Controller/SymfonyMigrationController.php
+++ b/src/Pmi/Controller/SymfonyMigrationController.php
@@ -9,7 +9,8 @@ class SymfonyMigrationController extends AbstractController
     protected static $routes = [
         ['settings', '/settings', ['method' => 'GET|POST']],
         ['deceased_reports_index', '/deceased-participant'],
-        ['deceased_report_new', '/deceased-participant/{participantId}/new']
+        ['deceased_report_new', '/deceased-participant/{participantId}/new'],
+        ['deceased_report_history', '/deceased-participant/{participantId}/history']
     ];
 
     public function deceased_reports_indexAction(Application $app)
@@ -20,6 +21,11 @@ class SymfonyMigrationController extends AbstractController
     public function deceased_report_newAction(Application $app, $participantId)
     {
         return $app->redirect('/s/deceased-reports/' . $participantId . '/new');
+    }
+
+    public function deceased_report_historyAction(Application $app, $participantId)
+    {
+        return $app->redirect('/s/deceased-reports/' . $participantId . '/history');
     }
 
     /**

--- a/src/Pmi/Entities/Participant.php
+++ b/src/Pmi/Entities/Participant.php
@@ -120,17 +120,6 @@ class Participant
                 }
             }
         }
-        if (!empty($participant->withdrawalStatus) && in_array($participant->withdrawalStatus, self::$withdrawalStatusValues, true)) {
-            $this->status = false;
-            $this->statusReason = 'withdrawal';
-            $this->isWithdrawn = true;
-        }
-        // RDR should not be returning participant data for unconsented participants, but adding this check to be safe
-        // Participant details tab is disabled for the below two status reasons
-        if (empty($participant->consentForStudyEnrollment) || $participant->consentForStudyEnrollment !== 'SUBMITTED') {
-            $this->status = false;
-            $this->statusReason = 'consent';
-        }
 
         // Deceased Participant
         if (isset($participant->deceasedStatus)) {
@@ -142,6 +131,18 @@ class Participant
                 $this->status = false;
                 $this->statusReason = 'deceased-approved';
             }
+        }
+
+        if (!empty($participant->withdrawalStatus) && in_array($participant->withdrawalStatus, self::$withdrawalStatusValues, true)) {
+            $this->status = false;
+            $this->statusReason = 'withdrawal';
+            $this->isWithdrawn = true;
+        }
+        // RDR should not be returning participant data for unconsented participants, but adding this check to be safe
+        // Participant details tab is disabled for the below two status reasons
+        if (empty($participant->consentForStudyEnrollment) || $participant->consentForStudyEnrollment !== 'SUBMITTED') {
+            $this->status = false;
+            $this->statusReason = 'consent';
         }
 
         // Map gender identity to gender options for MayoLINK.

--- a/src/Pmi/Entities/Participant.php
+++ b/src/Pmi/Entities/Participant.php
@@ -132,6 +132,18 @@ class Participant
             $this->statusReason = 'consent';
         }
 
+        // Deceased Participant
+        if (isset($participant->deceasedStatus)) {
+            if ($participant->deceasedStatus === 'PENDING') {
+                $this->status = false;
+                $this->statusReason = 'deceased-pending';
+            }
+            if ($participant->deceasedStatus === 'APPROVED') {
+                $this->status = false;
+                $this->statusReason = 'deceased-approved';
+            }
+        }
+
         // Map gender identity to gender options for MayoLINK.
         switch (isset($participant->genderIdentity) ? $participant->genderIdentity : null) {
             case 'GenderIdentity_Woman':

--- a/symfony/src/Controller/DeceasedReportsController.php
+++ b/symfony/src/Controller/DeceasedReportsController.php
@@ -119,6 +119,23 @@ class DeceasedReportsController extends AbstractController
     }
 
     /**
+     * @Route("/{participantId}/history", name="deceased_report_history", requirements={"participantId"="P\d+"})
+     */
+    public function deceasedReporthHistory(Request $request, ParticipantSummaryService $participantSummaryService, DeceasedReportsService $deceasedReportsService, $participantId) {
+        $participant = $participantSummaryService->getParticipantById($participantId);
+        if (!$participant) {
+            throw $this->createNotFoundException('Participant not found.');
+        }
+        $reports = $deceasedReportsService->getDeceasedReportsByParticipant($participantId);
+        $reports = $this->formatReportTableRows($reports);
+
+        return $this->render('deceasedreports/history.html.twig', [
+            'participant' => $participant,
+            'reports' => $reports
+        ]);
+    }
+
+    /**
      * @Route("/stats", name="deceased_report_stats")
      */
     public function getStats(SessionInterface $session, DeceasedReportsService $deceasedReportsService)

--- a/symfony/templates/deceasedreports/history.html.twig
+++ b/symfony/templates/deceasedreports/history.html.twig
@@ -26,9 +26,9 @@
             <td>{{ report.dateOfDeath ? report.dateOfDeath|date('n/j/Y') : '' }}</td>
             <td>{{ report.reportMechanismDisplay }}{% if report.reportMechanism == 'Other' %} - {{ report.reportMechanismOtherDescription }}{% endif %}</td>
             <td><a href="{{ path('deceased_report_review', {participantId: report.participantId, reportId: report.id}) }}"><span class="label label-default">{{ report.reportStatusDisplay }}</span></a></td>
-            <td>{{ report.submittedBy|default('Unknown') }}</td>
+            <td>{{ report.submittedBy|default('--') }}</td>
             <td>{{ report.submittedOn|date('n/j/Y g:ia', app.user.timezone) }}</td>
-            <td>{% if report.reviewedBy %}{{ report.reviewedBy|default('Unknown') }}{% else %}--{% endif %}</td>
+            <td>{{ report.reviewedBy|default('--') }}</td>
             <td>{% if report.reviewedOn %}{{ report.reviewedOn|date('n/j/Y g:ia', app.user.timezone) }}{% else %}--{% endif %}</td>
           </tr>
           {% else %}

--- a/symfony/templates/deceasedreports/history.html.twig
+++ b/symfony/templates/deceasedreports/history.html.twig
@@ -1,0 +1,46 @@
+{% extends 'base.html.twig' %}
+{% block title %}Deceased Participant {{ participant.participantId }} - {% endblock %}
+{% block body %}
+    <div class="page-header">
+      <h2><i class="fa fa-hourglass-o" aria-hidden="true"></i> Deceased Participant <small><a href="{{ path('participant', {id: participant.participantId} )}}">{{ participant.lastName }}, {{ participant.firstName }}</a></small></h2>
+    </div>
+    {% include 'deceasedreports/_review-details.html.twig' %}
+    <div class="container">
+      <table class="table table-striped table-bordered">
+        <thead>
+          <tr>
+            <th>Report ID</th>
+            <th>Date of Death</th>
+            <th>Notification Mechanism</th>
+            <th>Status</th>
+            <th>Submitted By</th>
+            <th>Submitted On</th>
+            <th>Reviewed By</th>
+            <th>Reviewed On</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for report in reports %}
+          <tr>
+            <td><a href="{{ path('deceased_report_review', {participantId: report.participantId, reportId: report.id}) }}">{{ report.id }}</a></td>
+            <td>{{ report.dateOfDeath ? report.dateOfDeath|date('n/j/Y') : '' }}</td>
+            <td>{{ report.reportMechanismDisplay }}{% if report.reportMechanism == 'Other' %} - {{ report.reportMechanismOtherDescription }}{% endif %}</td>
+            <td><a href="{{ path('deceased_report_review', {participantId: report.participantId, reportId: report.id}) }}"><span class="label label-default">{{ report.reportStatusDisplay }}</span></a></td>
+            <td>{{ report.submittedBy|default('Unknown') }}</td>
+            <td>{{ report.submittedOn|date('n/j/Y g:ia', app.user.timezone) }}</td>
+            <td>{% if report.reviewedBy %}{{ report.reviewedBy|default('Unknown') }}{% else %}--{% endif %}</td>
+            <td>{% if report.reviewedOn %}{{ report.reviewedOn|date('n/j/Y g:ia', app.user.timezone) }}{% else %}--{% endif %}</td>
+          </tr>
+          {% else %}
+          <tr>
+            <td colspan="99">No records matched your criteria.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    
+{% endblock %}
+
+{% block pagejs %}
+{% endblock %}

--- a/symfony/templates/deceasedreports/new.html.twig
+++ b/symfony/templates/deceasedreports/new.html.twig
@@ -10,7 +10,7 @@
     {% if report.id %}
     <div class="alert alert-info">
       <div class="pull-right">
-        <a class="btn btn-sm btn-primary" href="{{ path('deceased_report_history', {participantId: participant.participantId}) }}">View Submission(s)</a>
+        <a class="btn btn-sm btn-primary" href="{{ path('deceased_report_history', {participantId: participant.participantId}) }}">View Report(s)</a>
       </div>
       <div style="line-height:2em;">
         <i class="fas fa-info-circle"></i> There is already one or more Deceased Report for this Participant.

--- a/symfony/templates/deceasedreports/new.html.twig
+++ b/symfony/templates/deceasedreports/new.html.twig
@@ -8,7 +8,14 @@
     {% include 'deceasedreports/_review-details.html.twig' %}
 
     {% if report.id %}
-    <div class="alert alert-info"><i class="fas fas-info-circle"></i> There is already one or more Deceased Report for this Participant.</div>
+    <div class="alert alert-info">
+      <div class="pull-right">
+        <a class="btn btn-sm btn-primary" href="{{ path('deceased_report_history', {participantId: participant.participantId}) }}">View Submission(s)</a>
+      </div>
+      <div style="line-height:2em;">
+        <i class="fas fa-info-circle"></i> There is already one or more Deceased Report for this Participant.
+      </div>
+    </div>
     <dl class="dl-horizontal">
       <dt>Status</dt>
       <dd><span class="label label-default">{{ report.reportStatusDisplay }}</span></dd>

--- a/tests/Pmi/Participant/ParticipantTest.php
+++ b/tests/Pmi/Participant/ParticipantTest.php
@@ -18,6 +18,26 @@ class ParticipantTest extends PHPUnit\Framework\TestCase
         $this->assertSame('1933-03-03', $participant->getMayolinkDob()->format('Y-m-d'));
     }
 
+    public function testDeceasedParticipantPendingAccessStatus()
+    {
+        $participant = new Participant((object)[
+            'deceasedStatus' => 'PENDING'
+        ]);
+        $this->assertSame(false, $participant->status);
+        $this->assertSame('deceased-pending', $participant->statusReason);
+        $this->assertSame(false, $participant->isWithdrawn);
+    }
+
+    public function testDeceasedParticipantApprovedAccessStatus()
+    {
+        $participant = new Participant((object)[
+            'deceasedStatus' => 'APPROVED'
+        ]);
+        $this->assertSame(false, $participant->status);
+        $this->assertSame('deceased-approved', $participant->statusReason);
+        $this->assertSame(false, $participant->isWithdrawn);
+    }
+
     public function testParticipantDisableTestAccessStatus()
     {
         $options = [

--- a/tests/Pmi/Participant/ParticipantTest.php
+++ b/tests/Pmi/Participant/ParticipantTest.php
@@ -21,6 +21,7 @@ class ParticipantTest extends PHPUnit\Framework\TestCase
     public function testDeceasedParticipantPendingAccessStatus()
     {
         $participant = new Participant((object)[
+            'consentForStudyEnrollment' => 'SUBMITTED',
             'deceasedStatus' => 'PENDING'
         ]);
         $this->assertSame(false, $participant->status);
@@ -31,6 +32,7 @@ class ParticipantTest extends PHPUnit\Framework\TestCase
     public function testDeceasedParticipantApprovedAccessStatus()
     {
         $participant = new Participant((object)[
+            'consentForStudyEnrollment' => 'SUBMITTED',
             'deceasedStatus' => 'APPROVED'
         ]);
         $this->assertSame(false, $participant->status);

--- a/views/partials/deceased-participant-notice.html.twig
+++ b/views/partials/deceased-participant-notice.html.twig
@@ -1,0 +1,21 @@
+<div class="alert alert-warning">
+  <div class="row">
+    <div class="col-sm-9">
+      {% if participant.deceasedStatus == 'PENDING' %}
+      <strong>Deceased Participant:</strong> This participant was reported as deceased on <strong>{{ participant.deceasedAuthored|date('n/j/Y g:ia', app.userTimezone) }}</strong>. This status still needs to be approved. Data can continue to be sent for this participant, but no new data should be collected. If entered in error, please review the submission under the "Review > Deceased Participants" tab and deny it to proceed with PM&B order creation.
+      {% endif %}
+      {% if participant.deceasedStatus == 'APPROVED' %}
+      <strong>Deceased Participant:</strong> This participant was approved as deceased. Data can continue to be sent for this participant, but no new data should be collected.
+      <ul>
+        <li><strong>Date of death:</strong> {{ participant.dateOfDeath ? participant.dateOfDeath|date('n/j/Y', app.userTimezone) : 'Date not available.' }}</li>
+        <li><strong>Approved on:</strong> {{ participant.deceasedAuthored|date('n/j/Y g:ia', app.userTimezone) }}</li>
+      </ul>
+      {% endif %}
+    </div>
+    <div class="col-sm-3">
+      <div style="margin-top: 1em; margin-bottom: 1em;">
+        <a class="btn btn-sm btn-block btn-primary" href="{{ path('deceased_report_history', {participantId: participant.participantId}) }}">View Submission(s)</a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/partials/deceased-participant-notice.html.twig
+++ b/views/partials/deceased-participant-notice.html.twig
@@ -14,7 +14,7 @@
     </div>
     <div class="col-sm-3">
       <div style="margin-top: 1em; margin-bottom: 1em;">
-        <a class="btn btn-sm btn-block btn-primary" href="{{ path('deceased_report_history', {participantId: participant.participantId}) }}">View Submission(s)</a>
+        <a class="btn btn-sm btn-block btn-primary" href="{{ path('deceased_report_history', {participantId: participant.participantId}) }}">View Report(s)</a>
       </div>
     </div>
   </div>

--- a/views/partials/participant-notice.html.twig
+++ b/views/partials/participant-notice.html.twig
@@ -1,4 +1,10 @@
-{% if app.isTestSite %}
+{% if participant.statusReason == 'deceased-pending' %}
+    {% set errorTitle = 'Deceased Participant' %}
+    {% set errorMessage = 'This participant has a pending Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
+{% elseif participant.statusReason == 'deceased-approved' %}
+    {% set errorTitle = 'Deceased Participant' %}
+    {% set errorMessage = 'This participant has an approved Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
+{% elseif app.isTestSite %}
     {% set errorTitle = 'Test user' %}
     {% set errorMessage = 'Data collection and entry for test users are prohibited in this environment.' %}
 {% elseif participant.statusReason == 'test-participant' %}

--- a/views/partials/participant-notice.html.twig
+++ b/views/partials/participant-notice.html.twig
@@ -15,7 +15,7 @@
     {% set errorMessage = 'This participant has a pending Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
 {% elseif participant.statusReason == 'deceased-approved' %}
     {% set errorTitle = 'Deceased Participant' %}
-    {% set errorMessage = 'This participant has an approved Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
+    {% set errorMessage = 'This participant has been reported and approved as deceased. You may not create a biobank order or collect physical measurements for this participant.' %}
 {% elseif participant.statusReason == 'genomics' %}
     {% set errorTitle = 'Genomic Return of Results Consent not complete' %}
     {% set errorMessage = 'This participant has provided primary consent but has not completed Genomic Return of Results consent in the Participant Portal and is therefore ineligible to be scheduled for or complete physical measurements and biospecimen collection. Please direct the participant to complete the Genomic Return of Results consent in the Participant Portal to enable in-person enrollment or contact the Help Desk, if needed.' %}

--- a/views/partials/participant-notice.html.twig
+++ b/views/partials/participant-notice.html.twig
@@ -1,10 +1,4 @@
-{% if participant.statusReason == 'deceased-pending' %}
-    {% set errorTitle = 'Deceased Participant' %}
-    {% set errorMessage = 'This participant has a pending Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
-{% elseif participant.statusReason == 'deceased-approved' %}
-    {% set errorTitle = 'Deceased Participant' %}
-    {% set errorMessage = 'This participant has an approved Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
-{% elseif app.isTestSite %}
+{% if app.isTestSite %}
     {% set errorTitle = 'Test user' %}
     {% set errorMessage = 'Data collection and entry for test users are prohibited in this environment.' %}
 {% elseif participant.statusReason == 'test-participant' %}
@@ -16,6 +10,12 @@
 {% elseif participant.statusReason == 'withdrawal' %}
     {% set errorTitle = 'Withdrawn participant' %}
     {% set errorMessage = 'This participant has withdrawn from the All of Us Research Program. No new data can be collected or sent for this participant. Staff must also follow all site-specific SOPs to ensure all All of Us Research Program data are removed from all local systems for this participant.' %}
+{% elseif participant.statusReason == 'deceased-pending' %}
+    {% set errorTitle = 'Deceased Participant' %}
+    {% set errorMessage = 'This participant has a pending Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
+{% elseif participant.statusReason == 'deceased-approved' %}
+    {% set errorTitle = 'Deceased Participant' %}
+    {% set errorMessage = 'This participant has an approved Deceased Participant report. You may not create a biobank order or collect physical measurements for this participant.' %}
 {% elseif participant.statusReason == 'genomics' %}
     {% set errorTitle = 'Genomic Return of Results Consent not complete' %}
     {% set errorMessage = 'This participant has provided primary consent but has not completed Genomic Return of Results consent in the Participant Portal and is therefore ineligible to be scheduled for or complete physical measurements and biospecimen collection. Please direct the participant to complete the Genomic Return of Results consent in the Participant Portal to enable in-person enrollment or contact the Help Desk, if needed.' %}

--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -54,12 +54,16 @@
         {% include 'partials/participant-deactivated-status-notice.html.twig' %}
     {% endif %}
 
+    {% if participant.deceasedStatus == 'PENDING' or participant.deceasedStatus == 'APPROVED' %}
+        {% include 'partials/deceased-participant-notice.html.twig' %}
+    {% endif %}
+
     <div class="btn-group pull-right">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fas fa-cog"></i><span class="sr-only">Additional Options</span>
       </button>
       <ul class="dropdown-menu">
-        <li><a class="dropdown-item" href="{{ path('deceased_report_new', {participantId: participant.participantId}) }}">Report Deceased</a></li>
+        <li><a class="dropdown-item" href="{{ path('deceased_report_new', {participantId: participant.participantId}) }}"><i class="fa fa-hourglass-o"></i> Report Deceased Participant</a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Adds page alerts when a Participant has been flagged as deceased. Adds a history view that allows the user to see a log of Deceased Participant Report submissions.

TODO:

- [x] Disable PM&B submissions if Participant reported as deceased

[HPRO-681]

[HPRO-681]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-681