### PR TITLE
[HPRO-671] Fix unintended extra spacing between logo and text link when navbar is collapsed

### DIFF
--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -15,10 +15,8 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand navbar-brand-logo" href="{{ path('home') }}">
-                <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo">
-            </a>
             <a class="navbar-brand" href="{{ path('home') }}">
+                <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
                 HealthPro
                 {% if isTraining %}
                     <div class="navbar-brand-subtitle">training</div>

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -15,10 +15,8 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand navbar-brand-logo" href="{{ path('home') }}">
-                    <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
-                </a>
                 <a class="navbar-brand" href="{{ path('home') }}">
+                    <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
                     HealthPro
                     {% if isTraining %}
                         <div class="navbar-brand-subtitle">training</div>

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -88,14 +88,15 @@ label.label-normal {
 /* Nav bar customization */
 .navbar-brand-subtitle {
     font-size: 11px;
-    margin-top: -7px;
+    margin-top: -17px;
     text-align: right;
 }
-.navbar-brand-logo {
-    padding: 5px 15px
-}
-.navbar-brand-logo img {
+.navbar-brand img {
+    margin-top: -10px;
+    margin-right: 5px;
     height: 40px;
+    vertical-align: top;
+    display: inline-block;
 }
 .navbar-inverse {
     border: 0;


### PR DESCRIPTION
HPRO-671

Previously, we had the logo image (and before the logo image, the star icon) in it's own `a.nav-brand` element and the word link in another `a.nav-brand`. The Bootstrap navbar was not intended to have multiple `.nav-brand` elements, which led to the extra left padding/margin when the navbar was collapsed.

I fixed this by combining the logo image and the "HealthPro" text into the same `a.nav-brand` element. I then adjusted the image alignment and margin to display correctly.

Note that the resulting space between the logo and word is now slightly less than the previous non-collapsed spacing. This is intentional, as I decided this looked better.

**Before**:  
![before](https://user-images.githubusercontent.com/860499/94023280-ab99a780-fd7b-11ea-811b-3c1e9376c4ad.gif)

**After**:  
![after](https://user-images.githubusercontent.com/860499/94023320-b7856980-fd7b-11ea-8870-4ca8e9889970.gif)
