### PR TITLE
[BUG][HPRO-630] Ensure '0' appears in column for non-deceased participants

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -529,7 +529,7 @@ class WorkQueueController extends AbstractController
                             case 'APPROVED':
                                 $row[] = 2;
                                 break;
-                            defeault:
+                            default:
                                 $row[] = 0;
                         }
                         $row[] = $participant->dateOfDeath ? date('n/j/Y', strtotime($participant->dateOfDeath)) : '';


### PR DESCRIPTION
Typo led to the ~defeault~ default case not being activated.

[HPRO-630]

[HPRO-630]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-630