### PR TITLE
[HPRO-630] Allow viewing of prior PM&B for deceased participants

### DIFF
--- a/src/Pmi/Controller/DefaultController.php
+++ b/src/Pmi/Controller/DefaultController.php
@@ -396,7 +396,7 @@ class DefaultController extends AbstractController
         }
 
         $isCrossOrg = $participant->hpoId !== $app->getSiteOrganization();
-        $canViewDetails = !$isCrossOrg && ($participant->status || in_array($participant->statusReason, ['test-participant', 'basics', 'genomics', 'ehr-consent', 'program-update', 'primary-consent-update', 'deceased-pending', 'deceased-approved']));
+        $canViewDetails = !$isCrossOrg && ($participant->status || in_array($participant->statusReason, ['test-participant', 'basics', 'genomics', 'ehr-consent', 'program-update', 'primary-consent-update']));
         $hasNoParticipantAccess = $isCrossOrg && empty($app['session']->get('agreeCrossOrg_'.$id));
         if ($hasNoParticipantAccess) {
             $app->log(Log::CROSS_ORG_PARTICIPANT_ATTEMPT, [

--- a/src/Pmi/Controller/DefaultController.php
+++ b/src/Pmi/Controller/DefaultController.php
@@ -396,7 +396,7 @@ class DefaultController extends AbstractController
         }
 
         $isCrossOrg = $participant->hpoId !== $app->getSiteOrganization();
-        $canViewDetails = !$isCrossOrg && ($participant->status || in_array($participant->statusReason, ['test-participant', 'basics', 'genomics', 'ehr-consent', 'program-update', 'primary-consent-update']));
+        $canViewDetails = !$isCrossOrg && ($participant->status || in_array($participant->statusReason, ['test-participant', 'basics', 'genomics', 'ehr-consent', 'program-update', 'primary-consent-update', 'deceased-pending', 'deceased-approved']));
         $hasNoParticipantAccess = $isCrossOrg && empty($app['session']->get('agreeCrossOrg_'.$id));
         if ($hasNoParticipantAccess) {
             $app->log(Log::CROSS_ORG_PARTICIPANT_ATTEMPT, [

--- a/src/Pmi/Entities/Participant.php
+++ b/src/Pmi/Entities/Participant.php
@@ -131,10 +131,12 @@ class Participant
             if ($participant->deceasedStatus === 'PENDING') {
                 $this->status = false;
                 $this->statusReason = 'deceased-pending';
+                $this->editExistingOnly = true;
             }
             if ($participant->deceasedStatus === 'APPROVED') {
                 $this->status = false;
                 $this->statusReason = 'deceased-approved';
+                $this->editExistingOnly = true;
             }
         }
 


### PR DESCRIPTION
Leverages our `editExistingOnly` calculated field to prevent new submissions while allowing the viewing of old ones.

[HPRO-630]

[HPRO-630]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-630