### PR TITLE
[HPRO-687] Disable deceased reporting for withdrawn/deactivated participants

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -74,7 +74,6 @@ class WorkQueueController extends AbstractController
         if (!empty($params['activityStatus'])) {
             if ($params['activityStatus'] === 'withdrawn') {
                 $rdrParams['withdrawalStatus'] = 'NO_USE';
-                $rdrParams['deceasedStatus'] = 'UNSET';
             } else {
                 $rdrParams['withdrawalStatus'] = 'NOT_WITHDRAWN';
                 if ($params['activityStatus'] === 'active') {

--- a/symfony/src/Controller/DeceasedReportsController.php
+++ b/symfony/src/Controller/DeceasedReportsController.php
@@ -85,6 +85,14 @@ class DeceasedReportsController extends AbstractController
         if (!$participant) {
             throw $this->createNotFoundException('Participant not found.');
         }
+        if ($participant->withdrawalStatus !== 'NOT_WITHDRAWN') {
+            $this->addFlash('error', 'Cannot create Deceased Report on withdrawn participant.');
+            return $this->redirectToRoute('participant', ['id' => $participantId]);
+        }
+        if ($participant->suspensionStatus !== 'NOT_SUSPENDED') {
+            $this->addFlash('error', 'Cannot create Deceased Report on deactivated participant.');
+            return $this->redirectToRoute('participant', ['id' => $participantId]);
+        }
         $reports = $deceasedReportsService->getDeceasedReportsByParticipant($participantId);
         $report = new DeceasedReport();
         foreach ($reports as $record) {

--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -58,6 +58,7 @@
         {% include 'partials/deceased-participant-notice.html.twig' %}
     {% endif %}
 
+    {% if participant.activityStatus != 'deactivated' and participant.activityStatus != 'withdrawn' %}
     <div class="btn-group pull-right">
       <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
         <i class="fas fa-cog"></i><span class="sr-only">Additional Options</span>
@@ -66,6 +67,7 @@
         <li><a class="dropdown-item" href="{{ path('deceased_report_new', {participantId: participant.participantId}) }}"><i class="fa fa-hourglass-o"></i> Report Deceased Participant</a></li>
       </ul>
     </div>
+    {% endif %}
 
     <div role="tabpanel">
         <ul class="nav nav-tabs" role="tablist">


### PR DESCRIPTION
This PR removes the cog icon on the Participant Summary page for deactivated and withdrawn participants. It also adds logic that prevents new Deceased Reports from being created for those participants.

Additionally, it fixes a bug where the Deactivated filter would not work in the Work Queue because of a restriction on combining it with Deceased Status.

[HPRO-687]

[HPRO-687]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-687