### PR TITLE
[HPRO-695] Javascript asset compile process improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Install front end assets and build tooling via NPM:
 
 Compile assets using [Webpack Encore](https://symfony.com/doc/4.4/frontend.html) and recompile on the fly as assets change:
 
-`npx encore dev --watch`
+`npm run watch`
 
 Run local Datastore emulator
 

--- a/package.json
+++ b/package.json
@@ -27,5 +27,11 @@
     },
     "devDependencies": {
         "@symfony/webpack-encore": "^0.31.0"
+    },
+    "scripts": {
+        "dev-server": "encore dev-server",
+        "dev": "encore dev",
+        "watch": "encore dev --watch",
+        "build": "encore production --progress"
     }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
         "dev-server": "encore dev-server",
         "dev": "encore dev",
         "watch": "encore dev --watch",
-        "build": "encore production --progress"
+        "build": "encore production"
     }
 }

--- a/src/Pmi/Console/Command/DeployCommand.php
+++ b/src/Pmi/Console/Command/DeployCommand.php
@@ -126,7 +126,7 @@ class DeployCommand extends Command {
         $this->generatePhpConfig();
         $this->generateCronConfig();
 
-        // If not local, compile assets. Run `npx encore dev --watch` when developing locally.
+        // If not local, compile assets. Run `npm run watch` when developing locally.
         if (!$this->local) {
             // ensure that we are up-to-date with the latest NPM dependencies
             $output->writeln('');
@@ -136,7 +136,7 @@ class DeployCommand extends Command {
             // compile (concat/minify/copy) assets
             $output->writeln('');
             $output->writeln("Compiling assets...");
-            $this->exec("npx encore prod");
+            $this->exec("npm run build");
         }
 
         // security checks


### PR DESCRIPTION
This brings the project in line with the default recipe from the Webpack Encore project. Has the added benefit of abstracting the command away from the underlying build process should we need to change it in the future.

- Adds `npm-scripts` entries for `build`, `watch`, `dev` and `dev-server`
- Adjusts deploy scripts to leverage `build`

[HPRO-695]

[HPRO-695]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-695