### PR TITLE
[HPRO-709] Fix basic status field in the participant lookup results page

### DIFF
--- a/views/participants-list.html.twig
+++ b/views/participants-list.html.twig
@@ -50,10 +50,10 @@
                             <td>{{ participant.participantOrigin }}</td>
                         {% endif %}
                         <td>
-                            {% if not participant.status and participant.statusReason == 'basics' %}
-                                <i class="fa fa-times-circle text-danger" aria-hidden="true"></i>
-                            {% else %}
+                            {% if participant.questionnaireOnTheBasics == 'SUBMITTED' %}
                                 <i class="fa fa-check-circle text-success" aria-hidden="true"></i>
+                            {% else %}
+                                <i class="fa fa-times-circle text-danger" aria-hidden="true"></i>
                             {% endif %}
                         </td>
                         <td class="text-right">


### PR DESCRIPTION
Basic status column in the participant search results page when searched using last name and dob is displaying a green check mark for participants who's basic status in not submitted. This PR fixes basic status column.

Old:
![Screen Shot 2020-10-21 at 10 51 58 AM](https://user-images.githubusercontent.com/6041980/96746529-e4ce3300-138c-11eb-87a4-891f630bca54.png)

New:
![Screen Shot 2020-10-21 at 10 52 22 AM](https://user-images.githubusercontent.com/6041980/96746584-f1eb2200-138c-11eb-90c0-c5fb466250b7.png)

