### PR TITLE
[HPRO-699] Update README for credential scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,15 @@ Run local App Engine dev server:
 
 ## Credentials and configuration
 
+### Automated credential scanning
+
+**Important:** Install and use [`git-secrets`](https://github.com/awslabs/git-secrets) to avoid exposing API keys and certificates by screening commits for matched strings. An installation script has been provided.
+
+`./bin/installHooks`
+
 ### config.yml
 
-Configure your local development parameters by copying the `dev_config/config.yml.dist` file to `dev_config/config.yml`.  Edit `config.yml` as needed.  This file is .gitignore'd.  See comments in the dist file for more details.
+Configure your local development parameters by copying the `dev_config/config.yml.dist` file to `dev_config/config.yml`.  Edit `config.yml` as needed.  This file is .gitignore'd.  See comments in the `config.yml.dist` file for more details.
 
 #### MySQL database configuration
 Create a new MySQL for this application.  Configure the MySQL connection in `config.yml`.  Then, import the SQL scripts in `/sql` into the new database.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Run local App Engine dev server:
 
 ### Automated credential scanning
 
-**Important:** Install and use [`git-secrets`](https://github.com/awslabs/git-secrets) to avoid exposing API keys and certificates by screening commits for matched strings. An installation script has been provided.
+**Important:** Install and use [`git-secrets`](https://github.com/awslabs/git-secrets) to avoid exposing API keys and certificates by screening commits for matched strings. After installing that utility, run the script below to configure the hooks for this project.
 
 `./bin/installHooks`
 


### PR DESCRIPTION
During our conversion to the second generation runtime for App Engine, we lost the composer `post-install-cmd` stanzy because it prevented deployments (doesn't mesh well with their Cloud Deploy tool). As a result, we no longer have a way of ensuring that a developer has installed the `git-secrets` utiliity that scans for potentially leaked credentials prior to commit. This PR updates the README to include instructions to run the helper script manually.

[HPRO-699]

[HPRO-699]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-699