### PR TITLE
[HPRO-651] Ensure barcode container exists before generating

### DIFF
--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -600,11 +600,13 @@ $(document).ready(function() {
         $('#problem-overflow').show();
         e.preventDefault();
     });
-    JsBarcode("#participant-barcode", {{ participant.id|json_encode|raw }}, {
-        width: 2,
-        height: 50,
-        displayValue: true
-    });
+    if ($("#participant-barcode").length === 1) {
+        JsBarcode("#participant-barcode", {{ participant.id|json_encode|raw }}, {
+            width: 2,
+            height: 50,
+            displayValue: true
+        });
+    }
 });
 </script>
 {# Paient status tab #}

--- a/views/workqueue/participant.html.twig
+++ b/views/workqueue/participant.html.twig
@@ -51,11 +51,13 @@
 {% block pagejs %}
 <script>
     $(document).ready(function() {
-        JsBarcode("#participant-barcode", {{ participant.id|json_encode|raw }}, {
-            width: 2,
-            height: 50,
-            displayValue: true
-        });
+        if ($("#participant-barcode").length === 1) {
+            JsBarcode("#participant-barcode", {{ participant.id|json_encode|raw }}, {
+                width: 2,
+                height: 50,
+                displayValue: true
+            });
+        }
         $('#order-overflow-show').on('click', function (e) {
             $(this).hide();
             $('#order-overflow').show();


### PR DESCRIPTION
Prior to this PR, we would execute the JsBarCode generation script on the participant view without ensuring that the barcode was actually to be displayed. This caused a console error, but did not affect site operation. This PR adds a sanity check before generating the barcode.

[HPRO-651]

[HPRO-651]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-651