### PR TITLE
[HPRO-714] Remove object-path dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1418,50 +1418,13 @@
             "dev": true
         },
         "adjust-sourcemap-loader": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-2.0.0.tgz",
-            "integrity": "sha512-4hFsTsn58+YjrU9qKzML2JSSDqKvN8mUGQ0nNIrfPi8hmIONT4L3uUaT6MKdMsZ9AjsU6D2xDkZxCkbQPxChrA==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/adjust-sourcemap-loader/-/adjust-sourcemap-loader-3.0.0.tgz",
+            "integrity": "sha512-YBrGyT2/uVQ/c6Rr+t6ZJXniY03YtHGMJQYal368burRGYKqhx9qGTWqcBU5s1CwYY9E/ri63RYyG1IacMZtqw==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "camelcase": "5.0.0",
-                "loader-utils": "1.2.3",
-                "object-path": "0.11.4",
-                "regex-parser": "2.2.10"
-            },
-            "dependencies": {
-                "camelcase": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-                    "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
-                    "dev": true
-                },
-                "emojis-list": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-                    "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-                    "dev": true
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.2.3",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-                    "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-                    "dev": true,
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^2.0.0",
-                        "json5": "^1.0.1"
-                    }
-                }
+                "loader-utils": "^2.0.0",
+                "regex-parser": "^2.2.11"
             }
         },
         "ajv": {
@@ -5872,12 +5835,6 @@
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "dev": true
         },
-        "object-path": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-            "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=",
-            "dev": true
-        },
         "object-visit": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -7163,9 +7120,9 @@
             }
         },
         "regex-parser": {
-            "version": "2.2.10",
-            "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.10.tgz",
-            "integrity": "sha512-8t6074A68gHfU8Neftl0Le6KTDwfGAj7IyjPIMSfikI2wJUTHDMaIq42bUsfVnj8mhx0R+45rdUXHGpN164avA==",
+            "version": "2.2.11",
+            "resolved": "https://registry.npmjs.org/regex-parser/-/regex-parser-2.2.11.tgz",
+            "integrity": "sha512-jbD/FT0+9MBU2XAZluI7w2OBs1RBi6p9M83nkoZayQXXU9e8Robt69FcZc7wU4eJD/YFTjn1JdCk3rbMJajz8Q==",
             "dev": true
         },
         "regexp.prototype.flags": {
@@ -7384,12 +7341,12 @@
             "dev": true
         },
         "resolve-url-loader": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.1.tgz",
-            "integrity": "sha512-K1N5xUjj7v0l2j/3Sgs5b8CjrrgtC70SmdCuZiJ8tSyb5J+uk3FoeZ4b7yTnH6j7ngI+Bc5bldHJIa8hYdu2gQ==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-3.1.2.tgz",
+            "integrity": "sha512-QEb4A76c8Mi7I3xNKXlRKQSlLBwjUV/ULFMP+G7n3/7tJZ8MG5wsZ3ucxP1Jz8Vevn6fnJsxDx9cIls+utGzPQ==",
             "dev": true,
             "requires": {
-                "adjust-sourcemap-loader": "2.0.0",
+                "adjust-sourcemap-loader": "3.0.0",
                 "camelcase": "5.3.1",
                 "compose-function": "3.0.3",
                 "convert-source-map": "1.7.0",


### PR DESCRIPTION
HPRO-714

Ran `npm audit fix` which updated `adjust-sourcemap-loader` to a version that no longer uses `object-path`.