### PR TITLE
Revert "[HPRO-706] Add OAuth caching to new RdrApiService class"

### DIFF
--- a/symfony/src/Service/RdrApiService.php
+++ b/symfony/src/Service/RdrApiService.php
@@ -4,8 +4,6 @@ namespace App\Service;
 
 use Google_Client as GoogleClient;
 use Google_Service_Oauth2 as GoogleServiceOauth2;
-use Psr\Log\LoggerInterface;
-use Pmi\Cache\DatastoreAdapter;
 use Pmi\HttpClient;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -17,7 +15,7 @@ class RdrApiService
     protected $config = [];
     protected $cache;
 
-    public function __construct(EnvironmentService $environment, KernelInterface $appKernel, GoogleClient $googleClient, ParameterBagInterface $params, LoggerInterface $logger)
+    public function __construct(EnvironmentService $environment, KernelInterface $appKernel, GoogleClient $googleClient, ParameterBagInterface $params)
     {
         $this->googleClient = $googleClient;
         $basePath = $appKernel->getProjectDir();
@@ -28,11 +26,6 @@ class RdrApiService
         // Load endpoint from configuration
         if ($params->has('rdr_endpoint')) {
             $this->endpoint = $params->get('rdr_endpoint');
-        }
-        // Set up OAuth Cache
-        if ($params->has('ds_clean_up_limit')) {
-            $this->cache = new DatastoreAdapter($params->get('ds_clean_up_limit'));
-            $this->cache->setLogger($logger);
         }
     }
 


### PR DESCRIPTION
Reverts all-of-us/healthpro#764

We're seeing some interplay between the Symfony and Silex versions of this that may be causing the incorrect token to be cached, resulting in `HTTP/401` errors in certain circumstances on the Symfony side. Until that can be looked into, this should come out as a hotfix.