### PR TITLE
[HPRO-634] Add collection site address to Quest orders

### DIFF
--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1431,6 +1431,7 @@ class Order
         $this->order['collected_user_id'] = !empty($object->collectedInfo) ? $object->collectedInfo->author->value : false;
         $this->order['collected_site'] = null;
         $this->order['collected_site_name'] = 'A Quest Site';
+        $this->order['collected_site_address'] = !empty($object->collectedInfo->address) ? $object->collectedInfo->address : null;
         $this->order['processed_user_id'] = !empty($object->processedInfo) ? $object->processedInfo->author->value : false;
         $this->order['processed_site'] = null;
         $this->order['processed_site_name'] = 'A Quest Site';

--- a/src/Pmi/Order/Order.php
+++ b/src/Pmi/Order/Order.php
@@ -1440,6 +1440,7 @@ class Order
         $this->order['failedToReachRDR'] = false;
         $this->order['orderStatus'] = 'Finalized';
         $this->order['status'] = 'finalized';
+        $this->order['biobank_finalized'] = false;
 
         $this->order['origin'] = $object->origin;
 

--- a/views/biobank/order-quanum.html.twig
+++ b/views/biobank/order-quanum.html.twig
@@ -8,7 +8,7 @@
         <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>
     </div>
     <div class="row">
-        <div class="col-sm-4">
+        <div class="col-sm-6">
             <dl class="dl-horizontal">
                 {% if is_granted('ROLE_SCRIPPS') or is_granted('ROLE_AWARDEE') %}
                     <dt>Participant ID</dt>
@@ -32,7 +32,7 @@
                 {% endif %}
             </dl>
         </div>
-        <div class="col-sm-4">
+        <div class="col-sm-6">
             <p class="lead">
                 Order ID: <strong>{{ order.order_id }}</strong>
             </p>

--- a/views/biobank/order-quanum.html.twig
+++ b/views/biobank/order-quanum.html.twig
@@ -1,5 +1,8 @@
 {% extends 'base.html.twig' %}
 {% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
+
+{% import 'macros/display-text.html.twig' as macros %}
+
 {% block body %}
     <div class="page-header">
         <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>
@@ -23,6 +26,10 @@
                 <dd>{{ participant.awardee ? app.getAwardeeDisplayName(participant.awardee) : '(not paired)' }}</dd>
                 <dt>Paired Site</dt>
                 <dd>{{ participant.site ? app.getSiteDisplayName(participant.siteSuffix) : '(not paired)' }}</dd>
+                {% if order.collected_site_address %}
+                    <dt>Quest Collection Site<dt>
+                    <dd>{{ macros.displayQuestSiteAddress(order.collected_site_address) }}</dd>
+                {% endif %}
             </dl>
         </div>
         <div class="col-sm-4">

--- a/views/biobank/order.html.twig
+++ b/views/biobank/order.html.twig
@@ -5,7 +5,7 @@
         <h2><i class="fa fa-medkit" aria-hidden="true"></i> Order Details</h2>
     </div>
     <div class="row">
-        <div class="col-sm-4">
+        <div class="col-sm-6">
             <dl class="dl-horizontal">
                 {% if is_granted('ROLE_SCRIPPS') or is_granted('ROLE_AWARDEE') %}
                     <dt>Participant ID</dt>
@@ -25,7 +25,7 @@
                 <dd>{{ participant.site ? app.getSiteDisplayName(participant.siteSuffix) : '(not paired)' }}</dd>
             </dl>
         </div>
-        <div class="col-sm-4">
+        <div class="col-sm-6">
             <p class="lead">
                 Order ID: <strong>{{ order.order_id }}</strong>
             </p>

--- a/views/macros/display-text.html.twig
+++ b/views/macros/display-text.html.twig
@@ -114,3 +114,14 @@
         (--)
     {% endif %}
 {% endmacro %}
+
+{% macro displayQuestSiteAddress(address) %}
+    {% if (address.line) %}
+        {% for line in address.line %}
+            {{ line }}<br />
+        {% endfor %}
+    {% endif %}
+    {% if address.city|default(false) %}{{ address.city }},{% endif %}
+    {{ address.state|default('') }}
+    {{ address.postalCode|default('') }}
+{% endmacro %}


### PR DESCRIPTION
HPRO-634

Adds the address and adjusts the column layout.

Also adds the missing `biobank_finalized` field in the method that maps the RDR order response to mimic our local order object (this was throwing a warning).

![Screen Shot 2020-11-09 at 4 54 11 PM](https://user-images.githubusercontent.com/860499/98606291-9b4a7700-22ac-11eb-93cd-df00cf62df53.png)
