### PR TITLE
[HPRO-721] Refactor Participant::getActivityStatus

### DIFF
--- a/src/Pmi/Entities/Participant.php
+++ b/src/Pmi/Entities/Participant.php
@@ -383,20 +383,28 @@ class Participant
 
     private function getActivityStatus($participant)
     {
+        // Withdrawn
         if (in_array($participant->withdrawalStatus, self::$withdrawalStatusValues, true)) {
             return 'withdrawn';
-        } elseif (in_array($participant->deceasedStatus, self::$deceasedStatusValues, true)) {
-            return 'deceased';
-        } else {
-            switch (isset($participant->suspensionStatus) ? $participant->suspensionStatus : null) {
+        }
+
+        // Deactivated
+        if (isset($participant->suspensionStatus)) {
+            switch ($participant->suspensionStatus) {
                 case 'NOT_SUSPENDED':
                     return 'active';
                 case 'NO_CONTACT':
                     return 'deactivated';
-                default:
-                    return '';
             }
         }
+
+        // Deceased Status
+        if (in_array($participant->deceasedStatus, self::$deceasedStatusValues, true)) {
+            return 'deceased';
+        }
+
+        // Default
+        return '';
     }
 
     private function getConsentCohortText($participant)

--- a/src/Pmi/Entities/Participant.php
+++ b/src/Pmi/Entities/Participant.php
@@ -389,13 +389,8 @@ class Participant
         }
 
         // Deactivated
-        if (isset($participant->suspensionStatus)) {
-            switch ($participant->suspensionStatus) {
-                case 'NOT_SUSPENDED':
-                    return 'active';
-                case 'NO_CONTACT':
-                    return 'deactivated';
-            }
+        if (isset($participant->suspensionStatus) && $participant->suspensionStatus === 'NO_CONTACT') {
+            return 'deactivated';
         }
 
         // Deceased Status
@@ -404,7 +399,7 @@ class Participant
         }
 
         // Default
-        return '';
+        return 'active';
     }
 
     private function getConsentCohortText($participant)

--- a/tests/Pmi/Participant/ParticipantTest.php
+++ b/tests/Pmi/Participant/ParticipantTest.php
@@ -393,4 +393,50 @@ class ParticipantTest extends PHPUnit\Framework\TestCase
         ]);
         $this->assertSame(true, $participant->status);
     }
+
+    public function testActivityStatus()
+    {
+        // Withdrawn
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'NO_USE'
+        ]);
+        $this->assertSame('withdrawn', $participant->activityStatus);
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'EARLY_OUT'
+        ]);
+        $this->assertSame('withdrawn', $participant->activityStatus);
+
+        // Deactivated
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'NOT_WITHDRAWN',
+            'suspensionStatus' => 'NO_CONTACT'
+        ]);
+        $this->assertSame('deactivated', $participant->activityStatus);
+
+        // Deceased
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'NOT_WITHDRAWN',
+            'deceasedStatus' => 'PENDING'
+        ]);
+        $this->assertSame('deceased', $participant->activityStatus);
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'NOT_WITHDRAWN',
+            'deceasedStatus' => 'APPROVED'
+        ]);
+        $this->assertSame('deceased', $participant->activityStatus);
+
+        // Priority
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'NO_USE',
+            'deceasedStatus' => 'APPROVED'
+        ]);
+        $this->assertSame('withdrawn', $participant->activityStatus);
+
+        $participant = new Participant((object)[
+            'withdrawalStatus' => 'NOT_WITHDRAWN',
+            'suspensionStatus' => 'NO_CONTACT',
+            'deceasedStatus' => 'APPROVED'
+        ]);
+        $this->assertSame('deactivated', $participant->activityStatus);
+    }
 }

--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -1,9 +1,6 @@
 {% extends 'base.html.twig' %}
 {% block title %}Participant {{ participant.id }} - {% endblock %}
 {% block body %}
-
-<tt>{{ participant.withdrawalStatus }}</tt>
-
 {% import 'macros/display-text.html.twig' as macros %}
 {% if hasNoParticipantAccess %}
     <div class="row">

--- a/views/participant.html.twig
+++ b/views/participant.html.twig
@@ -1,6 +1,9 @@
 {% extends 'base.html.twig' %}
 {% block title %}Participant {{ participant.id }} - {% endblock %}
 {% block body %}
+
+<tt>{{ participant.withdrawalStatus }}</tt>
+
 {% import 'macros/display-text.html.twig' as macros %}
 {% if hasNoParticipantAccess %}
     <div class="row">


### PR DESCRIPTION
The hierarchy for activity status has been reorganized, and as a result this PR refactors the logic for returning the correct string.

The priority for these should be:

1. Withdrawn
1. Deactivated
1. Deceased

[HPRO-721]

[HPRO-721]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-721