### PR TITLE
[HPRO-706] OAuth Caching for RdrApiService

### DIFF
--- a/symfony/src/Service/RdrApiService.php
+++ b/symfony/src/Service/RdrApiService.php
@@ -4,6 +4,8 @@ namespace App\Service;
 
 use Google_Client as GoogleClient;
 use Google_Service_Oauth2 as GoogleServiceOauth2;
+use Psr\Log\LoggerInterface;
+use Pmi\Cache\DatastoreAdapter;
 use Pmi\HttpClient;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
@@ -14,8 +16,9 @@ class RdrApiService
     protected $endpoint = 'https://pmi-drc-api-test.appspot.com/';
     protected $config = [];
     protected $cache;
+    protected $logger;
 
-    public function __construct(EnvironmentService $environment, KernelInterface $appKernel, GoogleClient $googleClient, ParameterBagInterface $params)
+    public function __construct(EnvironmentService $environment, KernelInterface $appKernel, GoogleClient $googleClient, ParameterBagInterface $params, LoggerInterface $logger)
     {
         $this->googleClient = $googleClient;
         $basePath = $appKernel->getProjectDir();
@@ -23,10 +26,17 @@ class RdrApiService
         if ($environment->isLocal() && file_exists($basePath . '/../dev_config/rdr_key.json')) {
             $this->config['key_file'] = $basePath . '/../dev_config/rdr_key.json';
         }
+        if ($params->has('rdr_auth_json')) {
+            $this->config['rdr_auth_json'] = $params->get('rdr_auth_json');
+        }
         // Load endpoint from configuration
         if ($params->has('rdr_endpoint')) {
             $this->endpoint = $params->get('rdr_endpoint');
         }
+        // Set up OAuth Cache
+        $this->logger = $logger;
+        $this->cache = new DatastoreAdapter($params->get('ds_clean_up_limit'));
+        $this->cache->setLogger($this->logger);
     }
 
     public function get($path, $params = [])
@@ -44,10 +54,14 @@ class RdrApiService
 
     private function getClient($resourceEndpoint = null)
     {
-        if (isset($this->config['key_file']) && !empty($this->config['key_file'])) {
-            putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $this->config['key_file']);
+        if (!empty($this->config['rdr_auth_json'])) {
+            $this->googleClient->setAuthConfig(json_decode($this->config['rdr_auth_json'], true));
+        } else {
+            if (!empty($this->config['key_file'])) {
+                putenv('GOOGLE_APPLICATION_CREDENTIALS=' . $this->config['key_file']);
+            }
+            $this->googleClient->useApplicationDefaultCredentials();
         }
-        $this->googleClient->useApplicationDefaultCredentials();
 
         $this->googleClient->addScope(GoogleServiceOauth2::USERINFO_EMAIL);
 
@@ -57,14 +71,11 @@ class RdrApiService
             $endpoint = $this->endpoint;
         }
 
-        if ($this->cache) {
-            $this->googleClient->setCache($this->cache);
-        }
+        $this->googleClient->setCache($this->cache);
 
         return $this->googleClient->authorize(new HttpClient([
             'base_uri' => $endpoint,
             'timeout' => 50
         ]));
     }
-
 }

--- a/symfony/src/Service/RdrApiService.php
+++ b/symfony/src/Service/RdrApiService.php
@@ -26,7 +26,7 @@ class RdrApiService
         if ($environment->isLocal() && file_exists($basePath . '/../dev_config/rdr_key.json')) {
             $this->config['key_file'] = $basePath . '/../dev_config/rdr_key.json';
         }
-        if ($params->has('rdr_auth_json')) {
+        if ($params->has('rdr_auth_json') && !$params->has('rdr_auth_json_disabled')) {
             $this->config['rdr_auth_json'] = $params->get('rdr_auth_json');
         }
         // Load endpoint from configuration

--- a/symfony/src/Service/RdrApiService.php
+++ b/symfony/src/Service/RdrApiService.php
@@ -26,7 +26,7 @@ class RdrApiService
         if ($environment->isLocal() && file_exists($basePath . '/../dev_config/rdr_key.json')) {
             $this->config['key_file'] = $basePath . '/../dev_config/rdr_key.json';
         }
-        if ($params->has('rdr_auth_json') && !$params->has('rdr_auth_json_disabled')) {
+        if ($params->has('rdr_auth_json')) {
             $this->config['rdr_auth_json'] = $params->get('rdr_auth_json');
         }
         // Load endpoint from configuration
@@ -34,9 +34,11 @@ class RdrApiService
             $this->endpoint = $params->get('rdr_endpoint');
         }
         // Set up OAuth Cache
-        $this->logger = $logger;
-        $this->cache = new DatastoreAdapter($params->get('ds_clean_up_limit'));
-        $this->cache->setLogger($this->logger);
+        if (!$params->has('rdr_auth_cache_disabled')) {
+            $this->logger = $logger;
+            $this->cache = new DatastoreAdapter($params->get('ds_clean_up_limit'));
+            $this->cache->setLogger($this->logger);
+        }
     }
 
     public function get($path, $params = [])
@@ -71,7 +73,9 @@ class RdrApiService
             $endpoint = $this->endpoint;
         }
 
-        $this->googleClient->setCache($this->cache);
+        if ($this->cache) {
+            $this->googleClient->setCache($this->cache);
+        }
 
         return $this->googleClient->authorize(new HttpClient([
             'base_uri' => $endpoint,


### PR DESCRIPTION
Ran into some trouble with the last roll-out of this. This PR aims to address those issues.

- Use the `rdr_auth_json` if present
- Do not useApplicationDefaultCredentials in that scenario
- Streamline cache usage in `DeceasedReportsController`

[HPRO-706]

[HPRO-706]: https://precisionmedicineinitiative.atlassian.net/browse/HPRO-706