### PR TITLE
[HPRO-733] Adds Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,23 @@
 | Q                   | A
-| ------------------- | -------
-| Target Release?     | <!-- which release milestone is this for? -->
-| Bug fix?            | yes/no <!-- fixes an issue -->
-| New feature?        | yes/no <!-- adds a new feature/behavior change -->
-| Database migration? | yes/no <!-- lets us know to look for migrations -->
-| New configuration?  | yes/no <!-- lets us know if we need new config items -->
-| Jira Tickets        | HPRO-... <!-- Tag which ticket(s) this PR relates to -->
+| ------------------- | --------------
+| Target Release?     | 0.0.0/Next available <!-- which milestone is this for? -->
+| Bug fix?            | ✅/❌ <!-- fixes an issue -->
+| New feature?        | ✅/❌ <!-- adds a new feature/behavior change -->
+| Database migration? | ✅/❌ <!-- lets us know to look for migrations -->
+| New configuration?  | ✅/❌ <!-- lets us know if we need new config items -->
+| Composer updates?   | ✅/❌ <!-- lets us know to run `composer install` -->
+| NPM updates?        | ✅/❌ <!-- lets us know to run `npm install` -->
+| Jira Ticket(s)      | HPRO-... <!-- Tag which ticket(s) this PR relates to -->
+
+### Summary
 
 <!-- Provide notes for the development team that might be needed to review the PR. Some examples:
 
-- Do they need to add a particular `gaBypassGroups` entry?
+- Do they need to add a particular `gaBypassGroups` configuration entry?
 - What Participant IDs in the test environment have relevant data/settings?
 -->
+
+### Instructions for testing  <!-- if applicable -->
+
+
+### Screenshots <!-- if applicable -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+| Q                   | A
+| ------------------- | -------
+| Target Release?     | <!-- which release milestone is this for? -->
+| Bug fix?            | yes/no <!-- fixes an issue -->
+| New feature?        | yes/no <!-- adds a new feature/behavior change -->
+| Database migration? | yes/no <!-- lets us know to look for migrations -->
+| New configuration?  | yes/no <!-- lets us know if we need new config items -->
+| Jira Tickets        | HPRO-... <!-- Tag which ticket(s) this PR relates to -->
+
+<!-- Provide notes for the development team that might be needed to review the PR. Some examples:
+
+- Do they need to add a particular `gaBypassGroups` entry?
+- What Participant IDs in the test environment have relevant data/settings?
+-->


### PR DESCRIPTION
| Q                   | A
| ------------------- | -------
| Target Release?     | Next available
| Bug fix?            | ❌
| New feature?        | ❌
| Database migration? | ❌
| New configuration?  | ❌
| Composer updates?   | ❌
| NPM updates?        | ❌
| Jira Tickets        | HPRO-733

### Summary

This is a non-user facing change that adds a suggested template when opening a PR through the web interface (or when using the official `gh` command line tool). The idea is partially stolen from `symfony/symfony`.

Is there any additional information we might want to capture or share?

