### PR TITLE
[HPRO-717] Fix mayo account sync issue in stable

### DIFF
--- a/symfony/src/Service/SiteSyncService.php
+++ b/symfony/src/Service/SiteSyncService.php
@@ -114,16 +114,19 @@ class SiteSyncService
                         if (strtolower($awardee->type) === 'dv') {
                             // For diversion pouch site set hpo mayo account number
                             if (isset($site->siteType) && $site->siteType === 'ECDC DV Diversion Pouch') {
-                                $mayoAccountType = 'ml_account_hpo';
+                                $checkMayoAccountType = 'dv';
+                                $setMayoAccountType = 'hpo';
                             } else {
-                                $mayoAccountType = 'ml_account_dv';
+                                $checkMayoAccountType = 'hpo';
+                                $setMayoAccountType = 'dv';
                             }
                         } else {
-                            $mayoAccountType = 'ml_account_hpo';
+                            $checkMayoAccountType = 'dv';
+                            $setMayoAccountType = 'hpo';
                         }
-                        // Set to default hpo/dv account number if existing mayo account number is empty or equal to default hpo/dv account number
-                        if (empty($existing) || (empty($existing->getMayolinkAccount()) || ($existing->getMayolinkAccount() === $this->params->get($mayoAccountType)))) {
-                            $siteData->setMayolinkAccount($this->params->get($mayoAccountType));
+                        // Set to default hpo/dv account number if existing mayo account number is empty or equal to default dv/hpo account number
+                        if (empty($existing) || (empty($existing->getMayolinkAccount()) || ($existing->getMayolinkAccount() === $this->params->get('ml_account_' . $checkMayoAccountType)))) {
+                            $siteData->setMayolinkAccount($this->params->get('ml_account_' . $setMayoAccountType));
                         }
                     }
                     $siteData->setTimezone(isset($site->timeZoneId) ? $site->timeZoneId : null);


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.3.8
| Bug fix?            | ❌ 
| New feature?        | ✅
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-717 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-717 -->

### Summary
- This fixes mayo account number sync in stable

### Instructions for testing  <!-- if applicable -->

- Set `emsicentralregion` site mayo account number to 7035500.

- Change `isStable` to `isLocal` to allow mayo account number sync in local env

- The new column in the site sync preview should display hpo account number 7037059

![Screen Shot 2020-12-08 at 10 28 41 AM](https://user-images.githubusercontent.com/6041980/101511080-2e281100-3940-11eb-91fe-eb7b77a653c0.png)

