### PR TITLE
[HPRO-762] Always display date for survey fields if exists

### DIFF
--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -404,7 +404,7 @@ class WorkQueue
             }
             $row['ppiSurveys'] = $e($participant->numCompletedPPIModules);
             foreach (array_keys(self::$surveys) as $field) {
-                $row["ppi{$field}"] = $this->displayStatus($participant->{'questionnaireOn' . $field}, 'SUBMITTED', $participant->{'questionnaireOn' . $field . 'Authored'});
+                $row["ppi{$field}"] = $this->displaySurveyStatus($participant->{'questionnaireOn' . $field}, $participant->{'questionnaireOn' . $field . 'Authored'});
             }
 
             //In-Person Enrollment
@@ -524,6 +524,18 @@ class WorkQueue
             return self::HTML_WARNING . ' ' . self::dateFromString($time, $this->app->getUserTimezone(), $displayTime);
         }
         return self::HTML_DANGER;
+    }
+
+    public function displaySurveyStatus($value, $time, $displayTime = true)
+    {
+        if ($value === 'SUBMITTED') {
+            $status = self::HTML_SUCCESS;
+        } elseif ($value === 'SUBMITTED_NOT_SURE') {
+            $status = self::HTML_WARNING;
+        } else {
+            $status = self::HTML_DANGER;
+        }
+        return $status . ' ' . self::dateFromString($time, $this->app->getUserTimezone(), $displayTime);
     }
 
     public function displayConsentStatus($value, $time, $displayTime = true)


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.4.0.2 <!-- which milestone is this for? -->
| Bug fix?            | ✅<!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-762<!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-762 -->

### Instructions for testing  <!-- if applicable -->
I am unable to find a participant who's questionnaire survey status is `UNSET` OR `SUBMITTED_NO_CONSENT`. So, for testing add `$rdrParticipant->questionnaireOnCopeDecAuthored = '2020-12-17T11:50:52';` in line [62](https://github.com/all-of-us/healthpro/blob/develop/src/Pmi/Entities/Participant.php#L62) and remove when done.

### Screenshots <!-- if applicable -->
![Screen Shot 2021-01-26 at 5 06 12 PM](https://user-images.githubusercontent.com/6041980/105918425-85219c80-5ff9-11eb-884f-536d7a1d3610.png)
