### PR TITLE
[HPRO-79] Fix redirect by including forward slash

### DIFF
--- a/src/Pmi/Controller/SymfonyMigrationController.php
+++ b/src/Pmi/Controller/SymfonyMigrationController.php
@@ -89,7 +89,7 @@ class SymfonyMigrationController extends AbstractController
      */
     public function review_todayAction(Application $app)
     {
-       return $app->redirect('/s/review');
+       return $app->redirect('/s/review/');
     }
 
     /**


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.4.2 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-749 <!-- Tag which ticket(s) this PR relates to -->

### Summary

This PR fixes a bug where the interplay between Silex and Symfony requires a trailing slash.