### PR TITLE
[HPRO-768] Add user management role based on Google Group role

### DIFF
--- a/dev_config/config.yml.dist
+++ b/dev_config/config.yml.dist
@@ -102,3 +102,11 @@ reportKitUrl:
 
 # Set diversion pouch site name
 diversion_pouch_site: ECDC DV Diversion Pouch
+
+
+#
+# Feature flags
+#
+
+# Enables Google Groups role check for ROLE_MANAGE_USERS role
+# feature.manageusers: true

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -202,18 +202,11 @@ class HpoApplication extends AbstractApplication
 
     protected function setNewRoles($user)
     {
-        $userRoles = UserService::getRoles($user->getAllRoles(), $this['session']->get('site'), $this['session']->get('awardee'));
+        $userRoles = UserService::getRoles($user->getAllRoles(), $this['session']->get('site'), $this['session']->get('awardee'), $this['session']->get('managegroups'));
         if ($user->getAllRoles() != $userRoles) {
             $token = new PostAuthenticationGuardToken($user, 'main', $userRoles);
             $this['security.token_storage']->setToken($token);
         }
-    }
-
-    protected function canManageUsers($userEmail, $groupEmail)
-    {
-        $role = $this['pmi.drc.appsclient']->getRole($userEmail, $groupEmail);
-
-        return in_array($role, ['OWNER', 'MANAGER']);
     }
 
     /** Returns the user's currently selected HPO site. */

--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -200,13 +200,20 @@ class HpoApplication extends AbstractApplication
         }
     }
 
-    public function setNewRoles($user)
+    protected function setNewRoles($user)
     {
         $userRoles = UserService::getRoles($user->getAllRoles(), $this['session']->get('site'), $this['session']->get('awardee'));
         if ($user->getAllRoles() != $userRoles) {
             $token = new PostAuthenticationGuardToken($user, 'main', $userRoles);
             $this['security.token_storage']->setToken($token);
         }
+    }
+
+    protected function canManageUsers($userEmail, $groupEmail)
+    {
+        $role = $this['pmi.drc.appsclient']->getRole($userEmail, $groupEmail);
+
+        return in_array($role, ['OWNER', 'MANAGER']);
     }
 
     /** Returns the user's currently selected HPO site. */

--- a/src/Pmi/Drc/AppsClient.php
+++ b/src/Pmi/Drc/AppsClient.php
@@ -124,29 +124,21 @@ class AppsClient
     }
 
     /**
-     * Checks if the given user is subscribed to the given group.
-     * @param string $groupEmail the email address of the group.
-     * @param string $userEmail the potential subscriber.
-     * @return boolean true if the user is subscribed, false if not.
+     * Returns the user's role in a group or null if not subscribed
      */
-    public function isSubscribed($groupEmail, $userEmail)
+    public function getRole(string $userEmail, string $groupEmail): ?string
     {
         $subscribed = true;
-        // we'll have an exception with a 404 if user isn't in the group
+        // Will throw a 4xx exception if the user is not in the group
         try {
-            $this->callApi($this->directory, 'members', 'get', array($groupEmail, $userEmail));
-        }
-        catch (\Google_Service_Exception $e) {
-            if ($e->getCode() == 404) {
-                $subscribed = false;
-            } elseif ($e->getCode() == 400) {
-                // also seeing "(400) Missing required field: memberKey" when
-                // trying this on members who are not part of the group
-                $subscribed = false;
+            $result = $this->callApi($this->directory, 'members', 'get', [$groupEmail, $userEmail]);
+            if ($result) {
+                return $result->getRole();
             } else {
-                throw $e;
+                return null;
             }
+        } catch (\Google_Service_Exception $e) {
+            return null;
         }
-        return $subscribed;
     }
 }

--- a/src/Pmi/Drc/MockAppsClient.php
+++ b/src/Pmi/Drc/MockAppsClient.php
@@ -46,6 +46,11 @@ class MockAppsClient
         
         return isset(self::$groups[$userEmail]) ? self::$groups[$userEmail] : [];
     }
+
+    public function getRole($userEmail, $groupEmail)
+    {
+        return 'MEMBER';
+    }
     
     public static function setGroups($userEmail, $groups)
     {

--- a/src/Pmi/Security/User.php
+++ b/src/Pmi/Security/User.php
@@ -267,7 +267,7 @@ class User implements UserInterface
 
     public function getRoles()
     {
-        return UserService::getRoles($this->getAllRoles(), $this->sessionInfo['site'], $this->sessionInfo['awardee']);
+        return UserService::getRoles($this->getAllRoles(), $this->sessionInfo['site'], $this->sessionInfo['awardee'], $this->sessionInfo['managegroups']);
     }
 
     public function getPassword()

--- a/src/Pmi/Security/UserProvider.php
+++ b/src/Pmi/Security/UserProvider.php
@@ -29,11 +29,13 @@ class UserProvider implements UserProviderInterface
                 $groups = $this->app['pmi.drc.appsclient'] ? $this->app['pmi.drc.appsclient']->getGroups($googleUser->getEmail()) : [];
                 $this->app['session']->set('googlegroups', $groups);
                 $manageGroups = [];
-                foreach ($groups as $group) {
-                    if (strpos($group->getEmail(), User::SITE_PREFIX) === 0) {
-                        $role = $this->app['pmi.drc.appsclient']->getRole($googleUser->getEmail(), $group->getEmail());
-                        if (in_array($role, ['OWNER', 'MANAGER'])) {
-                            $manageGroups[] = $group->getEmail();
+                if ($this->app->getConfig('feature.manageusers')) {
+                    foreach ($groups as $group) {
+                        if (strpos($group->getEmail(), User::SITE_PREFIX) === 0) {
+                            $role = $this->app['pmi.drc.appsclient']->getRole($googleUser->getEmail(), $group->getEmail());
+                            if (in_array($role, ['OWNER', 'MANAGER'])) {
+                                $manageGroups[] = $group->getEmail();
+                            }
                         }
                     }
                 }

--- a/src/Pmi/Security/UserProvider.php
+++ b/src/Pmi/Security/UserProvider.php
@@ -28,6 +28,16 @@ class UserProvider implements UserProviderInterface
             try {
                 $groups = $this->app['pmi.drc.appsclient'] ? $this->app['pmi.drc.appsclient']->getGroups($googleUser->getEmail()) : [];
                 $this->app['session']->set('googlegroups', $groups);
+                $manageGroups = [];
+                foreach ($groups as $group) {
+                    if (strpos($group->getEmail(), User::SITE_PREFIX) === 0) {
+                        $role = $this->app['pmi.drc.appsclient']->getRole($googleUser->getEmail(), $group->getEmail());
+                        if (in_array($role, ['OWNER', 'MANAGER'])) {
+                            $manageGroups[] = $group->getEmail();
+                        }
+                    }
+                }
+                $this->app['session']->set('managegroups', $manageGroups);
             } catch (\Exception $e) {
                 $this->app->logException($e);
                 throw new AuthenticationException('Failed to retrieve group permissions');
@@ -36,7 +46,8 @@ class UserProvider implements UserProviderInterface
         $userInfo = $this->getUserInfo($googleUser);
         $sessionInfo = [
             'site' => $this->app['session']->get('site'),
-            'awardee' => $this->app['session']->get('awardee')
+            'awardee' => $this->app['session']->get('awardee'),
+            'managegroups' => $this->app['session']->get('managegroups')
         ];
         return new User($googleUser, $groups, $userInfo, null, $sessionInfo);
     }

--- a/src/Pmi/Service/UserService.php
+++ b/src/Pmi/Service/UserService.php
@@ -7,7 +7,7 @@ use Pmi\Security\User;
 class UserService
 {
 
-    public static function getRoles($roles, $site, $awardee)
+    public static function getRoles($roles, $site, $awardee, $managegroups)
     {
         if (!empty($site)) {
             if (($key = array_search('ROLE_AWARDEE', $roles)) !== false) {
@@ -16,12 +16,22 @@ class UserService
             if (($key = array_search('ROLE_AWARDEE_SCRIPPS', $roles)) !== false) {
                 unset($roles[$key]);
             }
+            if (in_array($site->email, $managegroups)) {
+                $roles[] = 'ROLE_MANAGE_USERS';
+            } else {
+                if (($key = array_search('ROLE_MANAGE_USERS', $roles)) !== false) {
+                    unset($roles[$key]);
+                }
+            }
         }
         if (!empty($awardee)) {
             if (($key = array_search('ROLE_USER', $roles)) !== false) {
                 unset($roles[$key]);
             }
             if (isset($awardee->id) && $awardee->id !== User::AWARDEE_SCRIPPS && ($key = array_search('ROLE_AWARDEE_SCRIPPS', $roles)) !== false) {
+                unset($roles[$key]);
+            }
+            if (($key = array_search('ROLE_MANAGE_USERS', $roles)) !== false) {
                 unset($roles[$key]);
             }
         }

--- a/symfony/src/Security/UserProvider.php
+++ b/symfony/src/Security/UserProvider.php
@@ -47,7 +47,8 @@ class UserProvider implements UserProviderInterface, PasswordUpgraderInterface
         $userInfo = $this->userService->getUserInfo($googleUser);
         $sessionInfo = [
             'site' => $this->session->get('site'),
-            'awardee' => $this->session->get('awardee')
+            'awardee' => $this->session->get('awardee'),
+            'managegroups' => $this->session->get('managegroups')
         ];
         return new User($googleUser, $groups, $userInfo, null, $sessionInfo);
     }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ✅ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-768 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Adds new `ROLE_MANAGE_USERS` role based on the user's role in the Google Group for the current site. This role is not yet used, but paves the way for implementing the new user management features.

Currently, this is behind a feature flag to avoid unnecessary API calls in production.

### Instructions for testing

`dev_config/config.yml`:

* Enable `feature.manageusers` feature flag
* Disable `gaBypass`

Log in with an actual @pmi-ops.org account.

From any Symfony route, you can use the dev toolbar to check your user's roles. When you select a site for which the account has the owner or manager in the Google Group, the user roles should include `ROLE_MANAGE_USERS`. Conversely, for a site group where the user does not have owner or manager access, the user roles should not include `ROLE_MANAGE_USERS`.


### Screenshots

<img width="1070" alt="Screen Shot 2021-02-22 at 1 33 36 PM" src="https://user-images.githubusercontent.com/860499/108759928-9e433d80-7512-11eb-9e51-219be0dae457.png">
