### PR TITLE
[HPRO-777] Add Core Minus PM Enrollment Status

### DIFF
--- a/src/Pmi/Controller/WorkQueueController.php
+++ b/src/Pmi/Controller/WorkQueueController.php
@@ -406,6 +406,7 @@ class WorkQueueController extends AbstractController
             $headers[] = 'Education';
             $headers[] = 'COPE Feb PPI Survey Complete';
             $headers[] = 'COPE Feb PPI Survey Completion Date';
+            $headers[] = 'Core Participant Minus PM Date';
 
             fputcsv($output, $headers);
 
@@ -502,6 +503,7 @@ class WorkQueueController extends AbstractController
                     $row[] = $participant->education;
                     $row[] = WorkQueue::csvStatusFromSubmitted($participant->questionnaireOnCopeFeb);
                     $row[] = WorkQueue::dateFromString($participant->questionnaireOnCopeFebAuthored, $app->getUserTimezone());
+                    $row[] = WorkQueue::dateFromString($participant->enrollmentStatusCoreMinusPMTime, $app->getUserTimeZone());
                     fputcsv($output, $row);
                 }
                 unset($participants);

--- a/src/Pmi/Drc/CodeBook.php
+++ b/src/Pmi/Drc/CodeBook.php
@@ -122,6 +122,7 @@ class CodeBook
         'INTERESTED' => 'Participant',
         'MEMBER' => 'Participant + EHR Consent',
         'FULL_PARTICIPANT' => 'Core Participant',
+        'CORE_MINUS_PM' => 'Core Participant Minus PM',
         'en' => 'English',
         'es' => 'Spanish',
         'vibrent' => 'PTSC Portal',

--- a/src/Pmi/Entities/Participant.php
+++ b/src/Pmi/Entities/Participant.php
@@ -18,6 +18,7 @@ class Participant
     public $age;
     public $patientStatus;
     public $isCoreParticipant = false;
+    public $isCoreMinusPMParticipant = false;
     public $activityStatus;
     public $isSuspended = false;
     public $isWithdrawn = false;
@@ -197,6 +198,11 @@ class Participant
         // Determine core participant
         if (!empty($participant->enrollmentStatus) && $participant->enrollmentStatus === 'FULL_PARTICIPANT') {
             $this->isCoreParticipant = true;
+        }
+
+        // Determine core minus pm participant
+        if (!empty($participant->enrollmentStatus) && $participant->enrollmentStatus === 'CORE_MINUS_PM') {
+            $this->isCoreMinusPMParticipant = true;
         }
 
         // Set activity status

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -365,8 +365,7 @@ class WorkQueue
             $row['participantId'] = $e($participant->id);
             $row['biobankId'] = $e($participant->biobankId);
             $row['participantOrigin'] = $e($participant->participantOrigin);
-            $enrollmentStatusCoreSampleTime = $participant->isCoreParticipant ? '<br/>' . self::dateFromString($participant->enrollmentStatusCoreStoredSampleTime, $app->getUserTimezone()) : '';
-            $row['participantStatus'] = $e($participant->enrollmentStatus) . $enrollmentStatusCoreSampleTime;
+            $row['participantStatus'] = $e($participant->enrollmentStatus) . $this->getEnrollementStatusTime($participant);
             $row['activityStatus'] = $this->getActivityStatus($participant);
             $row['withdrawalReason'] = $e($participant->withdrawalReason);
             $row['consentCohort'] = $e($participant->consentCohortText);
@@ -684,5 +683,18 @@ class WorkQueue
             return self::HTML_SUCCESS . ' Yes';
         }
         return self::HTML_DANGER . ' No';
+    }
+
+    public function getEnrollementStatusTime($participant)
+    {
+        if ($participant->isCoreParticipant) {
+            $time = $participant->enrollmentStatusCoreStoredSampleTime;
+        } elseif ($participant->isCoreMinusPMParticipant) {
+            $time = $participant->enrollmentStatusCoreMinusPMTime;
+        }
+        if (!empty($time)) {
+            return '<br>' . self::dateFromString($time, $this->app->getUserTimezone());
+        }
+        return '';
     }
 }

--- a/src/Pmi/WorkQueue/WorkQueue.php
+++ b/src/Pmi/WorkQueue/WorkQueue.php
@@ -109,7 +109,8 @@ class WorkQueue
             'options' => [
                 'Participant' => 'INTERESTED',
                 'Participant + EHR Consent' => 'MEMBER',
-                'Core Participant' => 'FULL_PARTICIPANT'
+                'Core Participant' => 'FULL_PARTICIPANT',
+                'Core Participant Minus PM' => 'CORE_MINUS_PM'
             ]
         ],
         'patientStatus' => [

--- a/symfony/src/Helper/Participant.php
+++ b/symfony/src/Helper/Participant.php
@@ -19,6 +19,7 @@ class Participant
     public $age;
     public $patientStatus;
     public $isCoreParticipant = false;
+    public $isCoreMinusPMParticipant = false;
     public $activityStatus;
     public $isSuspended = false;
     public $isWithdrawn = false;
@@ -198,6 +199,11 @@ class Participant
         // Determine core participant
         if (!empty($participant->enrollmentStatus) && $participant->enrollmentStatus === 'FULL_PARTICIPANT') {
             $this->isCoreParticipant = true;
+        }
+
+        // Determine core minus pm participant
+        if (!empty($participant->enrollmentStatus) && $participant->enrollmentStatus === 'CORE_MINUS_PM') {
+            $this->isCoreMinusPMParticipant = true;
         }
 
         // Set activity status

--- a/symfony/templates/partials/participant-dl.html.twig
+++ b/symfony/templates/partials/participant-dl.html.twig
@@ -12,9 +12,9 @@
     <dt>Participant Status</dt>
     <dd>{{ participant.enrollmentStatus|default('--') }}
         {% if participant.isCoreParticipant and  participant.enrollmentStatusCoreStoredSampleTime is not empty %}
-            ({{ participant.enrollmentStatusCoreStoredSampleTime|date('n/j/Y', app.userTimezone) }})
+            ({{ participant.enrollmentStatusCoreStoredSampleTime|date('n/j/Y', app.user.getInfo.timezone) }})
         {% elseif participant.isCoreMinusPMParticipant and  participant.enrollmentStatusCoreMinusPMTime is not empty %}
-            ({{ participant.enrollmentStatusCoreMinusPMTime|date('n/j/Y', app.userTimezone) }})
+            ({{ participant.enrollmentStatusCoreMinusPMTime|date('n/j/Y', app.user.getInfo.timezone) }})
         {% endif %}
     </dd>
     {% if app.session.get('siteType') == 'dv' or is_granted('ROLE_AWARDEE_SCRIPPS') %}

--- a/symfony/templates/partials/participant-dl.html.twig
+++ b/symfony/templates/partials/participant-dl.html.twig
@@ -13,6 +13,8 @@
     <dd>{{ participant.enrollmentStatus|default('--') }}
         {% if participant.isCoreParticipant and  participant.enrollmentStatusCoreStoredSampleTime is not empty %}
             ({{ participant.enrollmentStatusCoreStoredSampleTime|date('n/j/Y', app.userTimezone) }})
+        {% elseif participant.isCoreMinusPMParticipant and  participant.enrollmentStatusCoreMinusPMTime is not empty %}
+            ({{ participant.enrollmentStatusCoreMinusPMTime|date('n/j/Y', app.userTimezone) }})
         {% endif %}
     </dd>
     {% if app.session.get('siteType') == 'dv' or is_granted('ROLE_AWARDEE_SCRIPPS') %}

--- a/views/partials/participant-dl.html.twig
+++ b/views/partials/participant-dl.html.twig
@@ -13,6 +13,8 @@
     <dd>{{ participant.enrollmentStatus|default('--') }}
         {% if participant.isCoreParticipant and  participant.enrollmentStatusCoreStoredSampleTime is not empty %}
             ({{ participant.enrollmentStatusCoreStoredSampleTime|date('n/j/Y', app.userTimezone) }})
+        {% elseif participant.isCoreMinusPMParticipant and  participant.enrollmentStatusCoreMinusPMTime is not empty %}
+            ({{ participant.enrollmentStatusCoreMinusPMTime|date('n/j/Y', app.userTimezone) }})
         {% endif %}
     </dd>
     {% if app.isDvType or is_granted('ROLE_AWARDEE_SCRIPPS') %}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.4.3 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅/<!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-777 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-777 -->


### Instructions for testing  <!-- if applicable -->
I didn't find any participants having `CORE_MINUS_PM` in dev env. For testing, manually add below code in Participant class for both [Silex](https://github.com/all-of-us/healthpro/blob/develop/src/Pmi/Entities/Participant.php#L62) and [Symfony](https://github.com/all-of-us/healthpro/blob/develop/symfony/src/Helper/Participant.php#L63)
`$rdrParticipant->enrollmentStatus = 'CORE_MINUS_PM';`
`$rdrParticipant->enrollmentStatusCoreMinusPMTime = '2020-11-16T18:52:58';`

### Screenshots <!-- if applicable -->
![Screen Shot 2021-03-01 at 11 16 29 AM](https://user-images.githubusercontent.com/6041980/109533270-a73a8e80-7a7f-11eb-9347-5a0bdadae7e0.png)
![Screen Shot 2021-03-01 at 11 16 39 AM](https://user-images.githubusercontent.com/6041980/109533289-ad306f80-7a7f-11eb-8310-cbfbc101d785.png)
![Screen Shot 2021-03-01 at 11 16 51 AM](https://user-images.githubusercontent.com/6041980/109533300-b02b6000-7a7f-11eb-8358-1ab4deda4bb8.png)
