### PR TITLE
[HPRO-784] Fix undefined getMayoId method call

### DIFF
--- a/symfony/src/Service/OrderService.php
+++ b/symfony/src/Service/OrderService.php
@@ -463,10 +463,10 @@ class OrderService
         if (!$rdrId) {
             // Check for rdr id conflict error code
             if ($this->rdrApiService->getLastErrorCode() === 409) {
-                $rdrOrder = $this->getOrder($this->order->getParticipantId(), $this->getMayoId());
+                $rdrOrder = $this->getOrder($this->order->getParticipantId(), $this->order->getMayoId());
                 // Check if order exists in RDR
-                if (!empty($rdrOrder) && $rdrOrder->id === $this->order['mayo_id']) {
-                    $rdrId = $this->getMayoId();
+                if (!empty($rdrOrder) && $rdrOrder->id === $this->order->getMayoId()) {
+                    $rdrId = $this->order->getMayoId();
                 }
             }
         }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅<!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-784 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-784 -->

### Summary
This fixes updating `rdr_id` field in the orders table when we get 409 response from RDR
