### PR TITLE
[HPRO-779] Enable PMs and Orders JSON endpoint

### DIFF
--- a/src/Pmi/Controller/EvaluationController.php
+++ b/src/Pmi/Controller/EvaluationController.php
@@ -21,12 +21,12 @@ class EvaluationController extends AbstractController
         ['evaluationRevert', '/participant/{participantId}/evaluation/{evalId}/revert', ['method' => 'POST']]
     ];
 
-    /* For debugging generated FHIR bundle - only allowed in dev */
+    /* For debugging generated FHIR bundle - only allowed for admins or in local dev */
     public function evaluationFhirAction($participantId, $evalId, Application $app, Request $request)
     {
         $isTest = $request->query->has('test');
-        if (!$app->isLocal()) {
-            $app->abort(404);
+        if (!$app->hasRole('ROLE_ADMIN') && !$app->isLocal()) {
+            $app->abort(403);
         }
         $participant = $app['pmi.drc.participants']->getById($participantId);
         if (!$participant) {
@@ -71,11 +71,11 @@ class EvaluationController extends AbstractController
         }
     }
 
-    /* For debugging evaluation object pushed to RDR - only allowed in dev */
+    /* For debugging evaluation object pushed to RDR - only allowed for admins or in local dev */
     public function evaluationRdrAction($participantId, $evalId, Application $app)
     {
-        if (!$app->isLocal()) {
-            $app->abort(404);
+        if (!$app->hasRole('ROLE_ADMIN') && !$app->isLocal()) {
+            $app->abort(403);
         }
         $participant = $app['pmi.drc.participants']->getById($participantId);
         if (!$participant) {
@@ -105,7 +105,7 @@ class EvaluationController extends AbstractController
         if (!$evaluationService->canEdit($evalId, $participant) || $app->isTestSite()) {
             $app->abort(403);
         }
-        
+
         $evaluation = $app['em']->getRepository('evaluations')->fetchOneBy([
             'id' => $evalId,
             'participant_id' => $participantId

--- a/symfony/src/Controller/OrderController.php
+++ b/symfony/src/Controller/OrderController.php
@@ -673,12 +673,12 @@ class OrderController extends AbstractController
 
     /**
      * @Route("/participant/{participantId}/order/{orderId}/json-response", name="order_json")
-     * For debugging generated JSON representation - only allowed in local dev
+     * For debugging generated JSON representation - only allowed for admins or in local dev
      */
     public function orderJsonAction($participantId, $orderId, Request $request, EnvironmentService $env)
     {
-        if (!$env->isLocal()) {
-            throw $this->createNotFoundException();
+        if (!$this->isGranted('ROLE_ADMIN') && !$env->isLocal()) {
+            throw $this->createAccessDeniedException();
         }
         $order = $this->loadOrder($participantId, $orderId);
         if ($request->query->has('rdr')) {


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-779 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Allows a user to access specific debug tools that were previously only available in the local development enviroment. It checks whether the user has admin access.
