### PR TITLE
Release 2.4.6 Bug Fixes - 2

### DIFF
--- a/src/Pmi/Evaluation/Evaluation.php
+++ b/src/Pmi/Evaluation/Evaluation.php
@@ -253,7 +253,7 @@ class Evaluation
 
     public function getForm(FormFactory $formFactory)
     {
-        $formBuilder = $formFactory->createBuilder(FormType::class, $this->data);
+        $formBuilder = $formFactory->createBuilder(FormType::class, $this->data, ['attr' => ['data-locked' => $this->locked ? 1 : 0]]);
         foreach ($this->schema->fields as $field) {
             if (isset($field->formField) && !$field->formField) {
                 continue;

--- a/web/assets/js/views/PhysicalEvaluation-0.3-ehr.js
+++ b/web/assets/js/views/PhysicalEvaluation-0.3-ehr.js
@@ -89,10 +89,12 @@ PMI.views['PhysicalEvaluation-0.3-ehr'] = Backbone.View.extend({
         } else {
             firstReading.find('select').val('');
         }
-        // Enable first reading fields except protocol modification field and EHR date field
-        firstReading.find('input, input:checkbox').not('#form_' + field + '-ehr-date').each(function () {
-            $(this).attr('disabled', false);
-        });
+        // If the form is not locked enable first reading fields except protocol modification field and EHR date field
+        if (!parseInt($('form').attr('data-locked'))) {
+            firstReading.find('input, input:checkbox').not('#form_' + field + '-ehr-date').each(function () {
+                $(this).attr('disabled', false);
+            });
+        }
         $('.' + field + '-' + reading).find('input, select, input:checkbox').each(function () {
             $(this).attr('disabled', disabled);
             $(this).val('');

--- a/web/assets/js/views/PhysicalEvaluation-0.3-ehr.js
+++ b/web/assets/js/views/PhysicalEvaluation-0.3-ehr.js
@@ -90,7 +90,7 @@ PMI.views['PhysicalEvaluation-0.3-ehr'] = Backbone.View.extend({
             firstReading.find('select').val('');
         }
         // If the form is not locked enable first reading fields except protocol modification field and EHR date field
-        if (!parseInt($('form').attr('data-locked'))) {
+        if (!parseInt(this.$('form').data('locked'))) {
             firstReading.find('input, input:checkbox').not('#form_' + field + '-ehr-date').each(function () {
                 $(this).attr('disabled', false);
             });


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.4.6 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | PD-6302<!-- https://precisionmedicineinitiative.atlassian.net/browse/PD-6032 -->

### Summary
1. This PR prevents enabling first reading fields when the form is locked (finalized)