### PR TITLE
[HPRO-812] Adjust cookie settings for SameSite attribute

### DIFF
--- a/symfony/config/packages/dev/framework.yaml
+++ b/symfony/config/packages/dev/framework.yaml
@@ -8,7 +8,7 @@ framework:
   session:
     handler_id: null
     cookie_secure: auto
-    cookie_samesite: lax
+    cookie_samesite: 'strict'
 
   #esi: true
   #fragments: true

--- a/symfony/config/packages/prod/framework.yaml
+++ b/symfony/config/packages/prod/framework.yaml
@@ -8,7 +8,7 @@ framework:
   session:
     handler_id: Pmi\Datastore\DatastoreSessionHandler
     cookie_secure: auto
-    cookie_samesite: lax
+    cookie_samesite: 'strict'
 
   #esi: true
   #fragments: true


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-812, PD-6062 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Back in #654, we added the Symfony framework with the `SameSite` session cookie attribute to `lax`. We can adjust this to `strict`.

Reference: https://symfony.com/blog/new-in-symfony-4-2-samesite-cookie-configuration