### PR TITLE
[HPRO-814] Fix kit id identifier issue

### DIFF
--- a/symfony/src/Service/OrderService.php
+++ b/symfony/src/Service/OrderService.php
@@ -709,7 +709,9 @@ class OrderService
         $participantId = $subject_matches[1];
 
         $this->order->setParticipantId($participantId);
-        $this->order->setOrderId($kitId);
+        if (!empty($kitId)) {
+            $this->order->setOrderId($kitId);
+        }
         // Can be used as order Id
         $this->order->setRdrId($object->id);
         if (property_exists($object, 'biobankId')) {
@@ -755,6 +757,9 @@ class OrderService
         }
         $this->order->setFinalizedSiteName('A Quest Site');
         $this->order->setQuanumOrderStatus('Finalized');
+        if ($this->params->has('order_samples_version')) {
+            $this->order->setVersion($this->params->get('order_samples_version'));
+        }
         return $this->order;
     }
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-814 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-814 -->

### Summary

This fixes 500 RDR error when the order from the careevolution doesn't have kit id in the identifiers
