### PR TITLE
[HPRO-811] Adjust flash messages on Sites admin

### DIFF
--- a/symfony/src/Controller/SitesController.php
+++ b/symfony/src/Controller/SitesController.php
@@ -55,7 +55,7 @@ class SitesController extends AbstractController
         } else {
             if ($syncEnabled) {
                 // can't create new sites if syncing from rdr
-                throw $this->createNotFoundException('Site not found.');
+                throw $this->createNotFoundException('Sites cannot be created when the RDR Awardee API is enabled.');
             }
             $site = null;
         }
@@ -70,7 +70,7 @@ class SitesController extends AbstractController
                     $duplicateGoogleGroup = $siteRepository->getDuplicateGoogleGroup($form['google_group']->getData());
                 }
                 if ($duplicateGoogleGroup) {
-                    $form['google_group']->addError(new FormError('This google group has already been used for another site.'));
+                    $form['google_group']->addError(new FormError('This Google Group has already been used for another Site.'));
                 }
             }
             if ($form->isValid()) {
@@ -78,7 +78,7 @@ class SitesController extends AbstractController
                     $em->persist($site);
                     $em->flush();
                     $loggerService->log(Log::SITE_EDIT, $site->getId());
-                    $this->addFlash('success', 'Site added.');
+                    $this->addFlash('success', 'Site updated.');
                 } else {
                     $site = $form->getData();
                     $em->persist($site);
@@ -89,7 +89,7 @@ class SitesController extends AbstractController
                 return $this->redirectToRoute('admin_sites');
             } else {
                 if (count($form->getErrors()) == 0) {
-                    $form->addError(new FormError('Please correct the errors below'));
+                    $form->addError(new FormError('Please correct the errors below.'));
                 }
             }
         }

--- a/symfony/src/Controller/SitesController.php
+++ b/symfony/src/Controller/SitesController.php
@@ -42,20 +42,20 @@ class SitesController extends AbstractController
         if ($id) {
             $site = $siteRepository->find($id);
             if (!$site) {
-                throw $this->createNotFoundException('Page notice not found.');
+                throw $this->createNotFoundException('Site not found.');
             }
 
             if ($request->request->has('delete')) {
                 $em->remove($site);
                 $em->flush();
                 $loggerService->log(Log::SITE_DELETE, $site->getId());
-                $this->addFlash('success', 'Site removed');
+                $this->addFlash('success', 'Site removed.');
                 return $this->redirectToRoute('admin_sites');
             }
         } else {
             if ($syncEnabled) {
                 // can't create new sites if syncing from rdr
-                throw $this->createNotFoundException('Page notice not found.');
+                throw $this->createNotFoundException('Site not found.');
             }
             $site = null;
         }
@@ -78,13 +78,13 @@ class SitesController extends AbstractController
                     $em->persist($site);
                     $em->flush();
                     $loggerService->log(Log::SITE_EDIT, $site->getId());
-                    $this->addFlash('success', 'Notice added');
+                    $this->addFlash('success', 'Site added.');
                 } else {
                     $site = $form->getData();
                     $em->persist($site);
                     $em->flush();
                     $loggerService->log(Log::SITE_ADD, $site->getId());
-                    $this->addFlash('success', 'Notice added');
+                    $this->addFlash('success', 'Site added.');
                 }
                 return $this->redirectToRoute('admin_sites');
             } else {

--- a/symfony/templates/admin/sites/sync.html.twig
+++ b/symfony/templates/admin/sites/sync.html.twig
@@ -28,7 +28,7 @@
         </p>
         {{ form_end(form) }}
     {% else %}
-        <p>Preview is available but sites cannot be synced because <code>sites_use_rdr</code> is disabled.</p>
+        <p>Preview is available but sites cannot be synced because the RDR Awardee API is disabled.</p>
     {% endif %}
     <hr />
 


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-811 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Trivial fix to align the flash messages for the Sites management tool (were inadvertently left as the ones for Page Notices).
