### PR TITLE
[HPRO-801] Record last login for user

### DIFF
--- a/sql/healthpro/users.sql
+++ b/sql/healthpro/users.sql
@@ -3,5 +3,6 @@ CREATE TABLE `users` (
   `email` varchar(255) NOT NULL,
   `google_id` varchar(255) NOT NULL,
   `timezone` varchar(100) DEFAULT NULL,
+  `last_login` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) DEFAULT CHARSET=utf8mb4;

--- a/sql/migrations/043-alter-user-table-add-last-login.sql
+++ b/sql/migrations/043-alter-user-table-add-last-login.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+ADD COLUMN `last_login` datetime DEFAULT NULL AFTER `timezone`;

--- a/src/Pmi/Security/User.php
+++ b/src/Pmi/Security/User.php
@@ -27,6 +27,7 @@ class User implements UserInterface
     private $adminAccess;
     private $info;
     private $timezone;
+    private $lastLogin;
     private $sessionInfo;
     private $adminDvAccess;
     private $biobankAccess;
@@ -306,6 +307,16 @@ class User implements UserInterface
     public function setTimezone($timezone)
     {
         $this->timezone = $timezone;
+    }
+
+    public function getLastlogin(): ?\DateTimeInterface
+    {
+        return $this->lastLogin;
+    }
+
+    public function setLastLogin(?\DateTimeInterface $lastLogin)
+    {
+        $this->lastLogin = $lastLogin;
     }
 
     public function getId()

--- a/src/Pmi/Service/UserService.php
+++ b/src/Pmi/Service/UserService.php
@@ -6,7 +6,6 @@ use Pmi\Security\User;
 
 class UserService
 {
-
     public static function getRoles($roles, $site, $awardee, $managegroups)
     {
         if (!empty($site)) {
@@ -36,5 +35,17 @@ class UserService
             }
         }
         return $roles;
+    }
+
+    public static function updateLastLogin($app): void
+    {
+        $user = $app->getUser();
+        if (!$user) {
+            return;
+        }
+        $app['em']->getRepository('users')->update(
+            $user->getId(),
+            ['last_login' => new \DateTime()]
+        );
     }
 }

--- a/symfony/src/Entity/User.php
+++ b/symfony/src/Entity/User.php
@@ -32,6 +32,11 @@ class User
      */
     private $timezone;
 
+    /**
+     * @ORM\Column(type="datetime", nullable=true)
+     */
+    private $lastLogin;
+
     public function getId(): ?int
     {
         return $this->id;
@@ -69,6 +74,18 @@ class User
     public function setTimezone(?string $timezone): self
     {
         $this->timezone = $timezone;
+
+        return $this;
+    }
+
+    public function getLastlogin(): ?\DateTimeInterface
+    {
+        return $this->lastLogin;
+    }
+
+    public function setLastLogin(?\DateTimeInterface $lastLogin): self
+    {
+        $this->lastLogin = $lastLogin;
 
         return $this;
     }

--- a/symfony/src/EventListener/RequestListener.php
+++ b/symfony/src/EventListener/RequestListener.php
@@ -16,6 +16,7 @@ class RequestListener
     private $logger;
     private $em;
     private $twig;
+    private $session;
 
     private $request;
 

--- a/symfony/src/Security/GoogleGroupsAuthenticator.php
+++ b/symfony/src/Security/GoogleGroupsAuthenticator.php
@@ -79,7 +79,7 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
 
     public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
     {
-        // todo
+        $this->userService->updateLastLogin();
     }
 
     public function start(Request $request, AuthenticationException $authException = null)

--- a/symfony/src/Service/UserService.php
+++ b/symfony/src/Service/UserService.php
@@ -82,4 +82,14 @@ class UserService
         }
         return null;
     }
+
+    public function updateLastLogin(): void
+    {
+        $user = $this->getUser();
+        if ($user) {
+            $user->setLastLogin(new \DateTime());
+            $this->em->persist($user);
+            $this->em->flush();
+        }
+    }
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ✅ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-801 <!-- Tag which ticket(s) this PR relates to -->

### Summary

We would like to record when a user last logged in to the platform. This data is already available in logs, but this would put it a bit more in reach for easier reporting. I updated on both the Silex and Symfony side, though I don't think we've got a pathway to run it on the Symfony side yet.

### Instructions for testing  <!-- if applicable -->

- Be sure to run the migrations
- Log in as a test user
- Observe that the `last_login` column has been updated in MySQL

