### PR TITLE
[HPRO-729]  Warning is thrown in Work Queue when reading patient status that is not iterable

### DIFF
--- a/symfony/src/Service/WorkQueueService.php
+++ b/symfony/src/Service/WorkQueueService.php
@@ -431,16 +431,19 @@ class WorkQueueService
             return '';
         }
         $organizations = [];
-        foreach ($participant->patientStatus as $patientStatus) {
-            if ($patientStatus->status === $value) {
-                if ($type === 'export') {
-                    $organizations[] = $patientStatus->organization;
-                } else {
-                    $organizations[] = $this->siteService->getOrganizationDisplayName($patientStatus->organization);
+        if (is_array($participant->patientStatus)) {
+            foreach ($participant->patientStatus as $patientStatus) {
+                if ($patientStatus->status === $value) {
+                    if ($type === 'export') {
+                        $organizations[] = $patientStatus->organization;
+                    } else {
+                        $organizations[] = $this->siteService->getOrganizationDisplayName($patientStatus->organization);
+                    }
                 }
             }
+            return implode('; ', $organizations);
         }
-        return implode('; ', $organizations);
+        return '';
     }
 
 


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅<!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-729 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-792 -->
