### PR TITLE
[HPRO-812] Set SameSite Cookie

### DIFF
--- a/php.ini.dist
+++ b/php.ini.dist
@@ -3,5 +3,6 @@ display_errors = 0
 error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
 session.cookie_httponly = 1
 session.cookie_secure = 1
+session.cookie_samesite= "Lax"
 extension=grpc.so
 session.gc_probability = 0


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-812 <!-- Tag which ticket(s) this PR relates to -->

### Summary

In #868, I made the assumption that "Strict" was the best option for the SameSite cookie setting. Upon some additional research, the more important thing is that the flag is both set and that it is consistent. The actual reported issue summary reads:

>- Cookie without SameSite attribute.When cookies lack the SameSite attribute, Web browsers may apply different and sometimes unexpected defaults. It is thereforerecommended to add a SameSite attribute with an appropriate value of either "Strict", "Lax", or "None".

As we are already using "Lax" in the Symfony configuration, makes sense to me to set it the same here.
