### PR TITLE
[HPRO-829] Persist MySQL data between Docker runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
             - "53306:3306"
         volumes:
             - ./sql/healthpro:/docker-entrypoint-initdb.d
+            - healthpro-mysql-data:/var/lib/mysql
 
     web:
         environment:
@@ -28,3 +29,6 @@ services:
             - "8080:8080"
         volumes:
             - .:/app:delegated
+
+volumes:
+    healthpro-mysql-data:


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-829 <!-- Tag which ticket(s) this PR relates to -->

### Summary

In some circumstances, stopping our development Docker containers or running `docker compose down` will destroy the existing database data, prompting it to be rebuilt on a subsequent run. This PR attaches a volume to persist the database.

### Instructions for testing  <!-- if applicable -->

1. Back up any specific test cases you would like to keep
1. Run `docker compose down` to clean up existing containers
1. Run `docker compose up` or `docker compose up -d` to create the volume
1. Use Docker as usual

Note: If you do not do these steps, there will be a warning that the volume declaration has no effect.
