### PR TITLE
[HPRO-519] Add role selector to navbar

### DIFF
--- a/symfony/templates/admin/base.html.twig
+++ b/symfony/templates/admin/base.html.twig
@@ -1,0 +1,2 @@
+{% set currentRoleNav = 'admin' %}
+{% extends 'base.html.twig' %}

--- a/symfony/templates/admin/debug/missing-measurements.html.twig
+++ b/symfony/templates/admin/debug/missing-measurements.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Physical Measurements - Missing RDR Data - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/admin/debug/missing-orders.html.twig
+++ b/symfony/templates/admin/debug/missing-orders.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Biobank Orders - Missing RDR Data - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/admin/debug/participant.html.twig
+++ b/symfony/templates/admin/debug/participant.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Participants - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/admin/debug/participants.html.twig
+++ b/symfony/templates/admin/debug/participants.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Participants - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/admin/index.html.twig
+++ b/symfony/templates/admin/index.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Admin - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/admin/notifications.html.twig
+++ b/symfony/templates/admin/notifications.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Notifications - {% endblock %}
 {% macro displayNotifications(notifications, type) %}
     <table class="table table-striped table-hover">

--- a/symfony/templates/admin/sites/edit.html.twig
+++ b/symfony/templates/admin/sites/edit.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Edit Site - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/admin/sites/index.html.twig
+++ b/symfony/templates/admin/sites/index.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Sites - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}
 {% block body %}

--- a/symfony/templates/admin/sites/sync.html.twig
+++ b/symfony/templates/admin/sites/sync.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'admin/base.html.twig' %}
 {% block title %}Sites - {% endblock %}
 {% block body %}
     <ol class="breadcrumb">

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -62,7 +62,7 @@
                         {% endif %}
                     </a>
                     <ul class="dropdown-menu dropdown-menu-role">
-                        <li><a href="{{ path('symfony_home') }}"><i class="fas fa-arrow-circle-right"></i> HealthPro</a></li>
+                        <li><a href="{{ path('home') }}"><i class="fas fa-arrow-circle-right"></i> HealthPro</a></li>
                         {% for key, roleNav in roleNavs %}
                             {% if is_granted(roleNav.role) %}
                                 <li>

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -74,19 +74,21 @@
                                 </a>
                             </li>
                         {% endif %}
-                        {% for key, roleNav in roleNavs %}
-                            {% if is_granted(roleNav.role) %}
-                                <li>
-                                    <a href="{{ path(roleNav.path) }}">
-                                        <i class="fas fa-arrow-circle-right"></i>
-                                        {% if key == currentRoleNav %}
-                                            <strong>{{ roleNav.title }}</strong>
-                                        {% else %}
-                                            {{ roleNav.title }}
-                                        {% endif %}
-                                    </a>
-                                </li>
-                            {% endif %}
+                        {% for key, roleNav in roleNavs|filter((roleNav, key) =>
+                            is_granted(roleNav.role) and
+                            not (key == 'biobank' and is_granted('ROLE_SCRIPPS'))
+                        ) %}
+                        {# Scripps and biobank roles point to the same route, so only display one if user has both roles #}
+                            <li>
+                                <a href="{{ path(roleNav.path) }}">
+                                    <i class="fas fa-arrow-circle-right"></i>
+                                    {% if key == currentRoleNav %}
+                                        <strong>{{ roleNav.title }}</strong>
+                                    {% else %}
+                                        {{ roleNav.title }}
+                                    {% endif %}
+                                </a>
+                            </li>
                         {% endfor %}
                     </ul>
                 </li>

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -1,4 +1,36 @@
 {% set isTraining = isStable %}
+{% set roleNavs = {
+    admin: {
+        role: 'ROLE_ADMIN',
+        title: 'Admin',
+        path: 'admin_home'
+    },
+    problem_reports: {
+        role: 'ROLE_DV_ADMIN',
+        title: 'Problem Reports',
+        path: 'problem_reports'
+    },
+    scripps: {
+        role: 'ROLE_SCRIPPS',
+        title: 'Scripps',
+        path: 'biobank_home'
+    },
+    biobank: {
+        role: 'ROLE_BIOBANK',
+        title: 'Biobank',
+        path: 'biobank_home'
+    },
+    dashboard: {
+        role: 'ROLE_DASHBOARD',
+        title: 'Dashboard',
+        path: 'dashboard_home'
+    }
+} %}
+{% set showRoleDropdown = false %}
+{% for roleNav in roleNavs %}
+    {% set showRoleDropdown = showRoleDropdown or is_granted(roleNav.role) %}
+{% endfor %}
+{% set currentRoleNav = currentRoleNav|default(false) %}
 <!doctype html>
 <html lang="en">
 <head>
@@ -15,74 +47,98 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
             </button>
-            <a class="navbar-brand" href="{{ path('home') }}">
-                <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
-                HealthPro
-                {% if isTraining %}
-                    <div class="navbar-brand-subtitle">training</div>
-                {% endif %}
-            </a>
+            {% if showRoleDropdown %}
+            <ul class="nav navbar-nav navbar-nav-role">
+                <li class="dropdown">
+                    <a class="navbar-brand dropdown-toggle" href="{{ path('home') }}" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                        <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
+                        HealthPro
+                        {% if currentRoleNav and roleNavs[currentRoleNav] is defined %}
+                            <span class="navbar-brand-role">{{ roleNavs[currentRoleNav].title }}</span>
+                        {% endif %}
+                        <span class="caret"></span>
+                        {% if isTraining %}
+                            <div class="navbar-brand-subtitle">training</div>
+                        {% endif %}
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-role">
+                        <li><a href="{{ path('symfony_home') }}"><i class="fas fa-arrow-circle-right"></i> HealthPro</a></li>
+                        {% for key, roleNav in roleNavs %}
+                            {% if is_granted(roleNav.role) %}
+                                <li>
+                                    <a href="{{ path(roleNav.path) }}">
+                                        <i class="fas fa-arrow-circle-right"></i>
+                                        {% if key == currentRoleNav %}
+                                            <strong>{{ roleNav.title }}</strong>
+                                        {% else %}
+                                            {{ roleNav.title }}
+                                        {% endif %}
+                                    </a>
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                </li>
+            </ul>
+            {% else %}
+                <a class="navbar-brand" href="{{ path('home') }}">
+                    <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
+                    HealthPro
+                    {% if isTraining %}
+                        <div class="navbar-brand-subtitle">training</div>
+                    {% endif %}
+                </a>
+            {% endif %}
         </div>
         <div class="collapse navbar-collapse" id="pmi-navbar-collapse">
             <ul class="nav navbar-nav">
-                {% if is_granted('ROLE_USER') and app.session.get('site') %}
-                    <li class="dropdown">
-                        <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lookup <span class="caret"></span></a>
-                        <ul class="dropdown-menu">
-                            <li><a href="{{ path('participants') }}"><i class="fa fa-user" aria-hidden="true"></i> Participant Lookup</a></li>
-                            <li><a href="{{ path('orders') }}"><i class="fa fa-medkit" aria-hidden="true"></i> Biobank Order Lookup</a></li>
-                        </ul>
-                    </li>
-                    <li class="dropdown">
-                        <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Review <span class="caret"></span></a>
-                        <ul class="dropdown-menu">
-                            <li><a href="{{ path('review_today') }}"><i class="fa fa-list" aria-hidden="true"></i> Participant Review</a></li>
-                            <li><a href="{{ path('deceased_reports_index') }}"><i class="fa fa-hourglass-o" aria-hidden="true"></i> Deceased Participants</a></li>
-                        </ul>
-                    </li>
-                    {% if app.session.get('siteOrganization') %}
+                {% if not currentRoleNav %}
+                    {% if is_granted('ROLE_USER') and app.session.get('site') %}
+                        <li class="dropdown">
+                            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lookup <span class="caret"></span></a>
+                            <ul class="dropdown-menu">
+                                <li><a href="{{ path('participants') }}"><i class="fa fa-user" aria-hidden="true"></i> Participant Lookup</a></li>
+                                <li><a href="{{ path('orders') }}"><i class="fa fa-medkit" aria-hidden="true"></i> Biobank Order Lookup</a></li>
+                            </ul>
+                        </li>
+                        <li class="dropdown">
+                            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Review <span class="caret"></span></a>
+                            <ul class="dropdown-menu">
+                                <li><a href="{{ path('review_today') }}"><i class="fa fa-list" aria-hidden="true"></i> Participant Review</a></li>
+                                <li><a href="{{ path('deceased_reports_index') }}"><i class="fa fa-hourglass-o" aria-hidden="true"></i> Deceased Participants</a></li>
+                            </ul>
+                        </li>
+                        {% if app.session.get('siteOrganization') %}
+                            <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
+                        {% endif %}
+                    {% endif %}
+                    {% if is_granted('ROLE_AWARDEE') and app.session.get('awardee') and siteInfo.superUserAwardees %}
                         <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
                     {% endif %}
-                {% endif %}
-                {% if is_granted('ROLE_AWARDEE') and app.session.get('awardee') and siteInfo.superUserAwardees %}
-                    <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
-                {% endif %}
-                {% if is_granted('ROLE_DV_ADMIN') %}
-                    <li><a href="{{ path('problem_reports') }}">Problem Reports</a></li>
-                {% endif %}
-                {% if is_granted('ROLE_USER') and app.session.get('site') and app.session.get('orderType') == 'dv' and reportKitUrl %}
-                    <li><a data-href="{{ reportKitUrl }}" class="external-link">Report Kit Problem</a></li>
-                {% endif %}
-                {% if is_granted('ROLE_ADMIN') %}
-                    <li><a href="{{ path('admin_home') }}">Admin</a></li>
-                {% endif %}
-                {% if is_granted('ROLE_DASHBOARD') %}
-                    <li><a href="{{ path('dashboard_home') }}">Dashboard</a></li>
-                {% endif %}
-                {% if is_granted('ROLE_SCRIPPS') %}
-                    <li><a href="{{ path('biobank_home') }}">Scripps</a></li>
-                {% elseif is_granted('ROLE_BIOBANK')  %}
-                    <li><a href="{{ path('biobank_home') }}">Biobank</a></li>
+                    {% if is_granted('ROLE_USER') and app.session.get('site') and app.session.get('orderType') == 'dv' and reportKitUrl %}
+                        <li><a data-href="{{ reportKitUrl }}" class="external-link">Report Kit Problem</a></li>
+                    {% endif %}
                 {% endif %}
             </ul>
             <ul class="nav navbar-nav navbar-right">
                 {% if is_granted('IS_AUTHENTICATED_FULLY') %}
-                    {% if app.session.get('site') %}
-                        <li>
-                            <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
-                                <i class="fa fa-hospital-o" aria-hidden="true"></i>
-                                {{ app.session.get('currentSiteDisplayName')|default(app.session.get('site').name) }}
-                            </a>
-                        </li>
-                    {% endif %}
-
-                    {% if app.session.get('awardee') %}
-                        <li>
-                            <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
-                                <i class="fa fa-hospital-o" aria-hidden="true"></i>
-                                {{ app.session.get('awardee').name }}
-                            </a>
-                        </li>
+                    {% if not currentRoleNav %}
+                        {% if app.session.get('site') %}
+                            <li>
+                                <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
+                                    <i class="fa fa-hospital-o" aria-hidden="true"></i>
+                                    {{ app.session.get('currentSiteDisplayName')|default(app.session.get('site').name) }}
+                                </a>
+                            </li>
+                        {% endif %}
+                        {% if app.session.get('awardee') %}
+                            <li>
+                                <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
+                                    <i class="fa fa-hospital-o" aria-hidden="true"></i>
+                                    {{ app.session.get('awardee').name }}
+                                </a>
+                            </li>
+                        {% endif %}
                     {% endif %}
 
                     <li class="dropdown">

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -62,7 +62,18 @@
                         {% endif %}
                     </a>
                     <ul class="dropdown-menu dropdown-menu-role">
-                        <li><a href="{{ path('home') }}"><i class="fas fa-arrow-circle-right"></i> HealthPro</a></li>
+                        {% if is_granted(['ROLE_USER', 'ROLE_AWARDEE']) %}
+                            <li>
+                                <a href="{{ path('home') }}">
+                                    <i class="fas fa-arrow-circle-right"></i>
+                                    {% if not currentRoleNav %}
+                                        <strong>HealthPro</strong>
+                                    {% else %}
+                                        HealthPro
+                                    {% endif %}
+                                </a>
+                            </li>
+                        {% endif %}
                         {% for key, roleNav in roleNavs %}
                             {% if is_granted(roleNav.role) %}
                                 <li>

--- a/symfony/templates/biobank/base.html.twig
+++ b/symfony/templates/biobank/base.html.twig
@@ -1,0 +1,6 @@
+{% if is_granted('ROLE_SCRIPPS') %}
+    {% set currentRoleNav = 'scripps' %}
+{% elseif is_granted('ROLE_BIOBANK') %}
+    {% set currentRoleNav = 'biobank' %}
+{% endif %}
+{% extends 'base.html.twig' %}

--- a/symfony/templates/biobank/index.html.twig
+++ b/symfony/templates/biobank/index.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block body %}
     <div class="page-header">
         <h2>Welcome!</h2>

--- a/symfony/templates/biobank/order-quanum.html.twig
+++ b/symfony/templates/biobank/order-quanum.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Biobank {{ participant.biobankId }} - {% endblock %}
 
 {% import 'macros/display-text.html.twig' as macros %}

--- a/symfony/templates/biobank/order.html.twig
+++ b/symfony/templates/biobank/order.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Participant {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">
@@ -54,7 +54,7 @@
             {% endif %}
         </div>
     {% endif %}
-    
+
     <div role="tabpanel">
         <ul class="nav nav-tabs" role="tablist">
             <li role="presentation">

--- a/symfony/templates/biobank/orders-quanum-today.html.twig
+++ b/symfony/templates/biobank/orders-quanum-today.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Today - Participant Review - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}
 
@@ -76,7 +76,7 @@
         {% endfor %}
         </tbody>
     </table>
-{% endblock %} 
+{% endblock %}
 
 {% block pagejs %}
     <script>

--- a/symfony/templates/biobank/orders-recent-modify.html.twig
+++ b/symfony/templates/biobank/orders-recent-modify.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Orders Recent Modify - Participant Review - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}
 

--- a/symfony/templates/biobank/orders-today.html.twig
+++ b/symfony/templates/biobank/orders-today.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Today - Participant Review - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}
 {% set missingName = '' %}
@@ -92,7 +92,7 @@
         {% endfor %}
         </tbody>
     </table>
-{% endblock %} 
+{% endblock %}
 
 {% block pagejs %}
     <script>

--- a/symfony/templates/biobank/orders-unfinalized.html.twig
+++ b/symfony/templates/biobank/orders-unfinalized.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Orders - Participant Review - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}
 

--- a/symfony/templates/biobank/orders-unlocked.html.twig
+++ b/symfony/templates/biobank/orders-unlocked.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Orders - Participant Review - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}
 

--- a/symfony/templates/biobank/orders.html.twig
+++ b/symfony/templates/biobank/orders.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Orders - {% endblock %}
 {% block body %}
     <div class="page-header">

--- a/symfony/templates/biobank/participant.html.twig
+++ b/symfony/templates/biobank/participant.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Participant {{ participant.biobankId }} - {% endblock %}
 {% block body %}
     <div class="page-header">

--- a/symfony/templates/biobank/participants.html.twig
+++ b/symfony/templates/biobank/participants.html.twig
@@ -1,4 +1,4 @@
-{% extends 'base.html.twig' %}
+{% extends 'biobank/base.html.twig' %}
 {% block title %}Participants - {% endblock %}
 {% block body %}
     <div class="page-header">

--- a/symfony/templates/macros/display-text.html.twig
+++ b/symfony/templates/macros/display-text.html.twig
@@ -128,7 +128,7 @@
 {% endmacro %}
 
 {% macro displayQuestSiteAddress(address) %}
-    {% if (address.line) %}
+    {% if address.line is defined %}
         {% for line in address.line %}
             {{ line }}<br />
         {% endfor %}

--- a/symfony/templates/problem/problem-details.html.twig
+++ b/symfony/templates/problem/problem-details.html.twig
@@ -1,3 +1,4 @@
+{% set currentRoleNav = 'problem_reports' %}
 {% extends 'base.html.twig' %}
 {% block title %}Unanticipated Problem Details - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}

--- a/symfony/templates/problem/problem-reports.html.twig
+++ b/symfony/templates/problem/problem-reports.html.twig
@@ -1,3 +1,4 @@
+{% set currentRoleNav = 'problem_reports' %}
 {% extends 'base.html.twig' %}
 {% block title %}Unanticipated Problem Reports - {% endblock %}
 {% block bodycontainer %}container-fluid{% endblock %}

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -1,4 +1,36 @@
 {% set isTraining = app.stable %}
+{% set roleNavs = {
+    admin: {
+        role: 'ROLE_ADMIN',
+        title: 'Admin',
+        path: 'admin_home'
+    },
+    problem_reports: {
+        role: 'ROLE_DV_ADMIN',
+        title: 'Problem Reports',
+        path: 'problem_reports'
+    },
+    scripps: {
+        role: 'ROLE_SCRIPPS',
+        title: 'Scripps',
+        path: 'biobank_home'
+    },
+    biobank: {
+        role: 'ROLE_BIOBANK',
+        title: 'Biobank',
+        path: 'biobank_home'
+    },
+    dashboard: {
+        role: 'ROLE_DASHBOARD',
+        title: 'Dashboard',
+        path: 'dashboard_home'
+    }
+} %}
+{% set showRoleDropdown = false %}
+{% for roleNav in roleNavs %}
+    {% set showRoleDropdown = showRoleDropdown or is_granted(roleNav.role) %}
+{% endfor %}
+{% set currentRoleNav = currentRoleNav|default(false) %}
 <!doctype html>
 <html lang="en">
 <head>
@@ -15,74 +47,108 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                <a class="navbar-brand" href="{{ path('home') }}">
-                    <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
-                    HealthPro
-                    {% if isTraining %}
-                        <div class="navbar-brand-subtitle">training</div>
-                    {% endif %}
-                </a>
+
+                {% if showRoleDropdown %}
+                <ul class="nav navbar-nav navbar-nav-role">
+                    <li class="dropdown">
+                        <a class="navbar-brand dropdown-toggle" href="{{ path('home') }}" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+                            <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
+                            HealthPro
+                            {% if currentRoleNav and roleNavs[currentRoleNav] is defined %}
+                                <span class="navbar-brand-role">{{ roleNavs[currentRoleNav].title }}</span>
+                            {% endif %}
+                            <span class="caret"></span>
+                            {% if isTraining %}
+                                <div class="navbar-brand-subtitle">training</div>
+                            {% endif %}
+                        </a>
+                        <ul class="dropdown-menu dropdown-menu-role">
+                            <li>
+                                <a href="{{ path('home') }}">
+                                    <i class="fas fa-arrow-circle-right"></i>
+                                    {% if not currentRoleNav %}
+                                        <strong>HealthPro</strong>
+                                    {% else %}
+                                        HealthPro
+                                    {% endif %}
+                                </a>
+                            </li>
+                            {% for key, roleNav in roleNavs %}
+                                {% if is_granted(roleNav.role) %}
+                                    <li>
+                                        <a href="{{ path(roleNav.path) }}">
+                                            <i class="fas fa-arrow-circle-right"></i>
+                                            {% if key == currentRoleNav %}
+                                                <strong>{{ roleNav.title }}</strong>
+                                            {% else %}
+                                                {{ roleNav.title }}
+                                            {% endif %}
+                                        </a>
+                                    </li>
+                                {% endif %}
+                            {% endfor %}
+                        </ul>
+                    </li>
+                </ul>
+                {% else %}
+                    <a class="navbar-brand" href="{{ path('home') }}">
+                        <img src="{{ asset('img/all-of-us-logo-stacked-inverted.svg') }}" alt="All of Us logo"/>
+                        HealthPro
+                        {% if isTraining %}
+                            <div class="navbar-brand-subtitle">training</div>
+                        {% endif %}
+                    </a>
+                {% endif %}
             </div>
             <div class="collapse navbar-collapse" id="pmi-navbar-collapse">
                 <ul class="nav navbar-nav">
-                    {% if is_granted('ROLE_USER') and app.session.get('site') %}
-                        <li class="dropdown">
-                            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lookup <span class="caret"></span></a>
-                            <ul class="dropdown-menu">
-                                <li><a href="{{ path('participants') }}"><i class="fa fa-user" aria-hidden="true"></i> Participant Lookup</a></li>
-                                <li><a href="{{ path('orders') }}"><i class="fa fa-medkit" aria-hidden="true"></i> Biobank Order Lookup</a></li>
-                            </ul>
-                        </li>
-                        <li class="dropdown">
-                            <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Review <span class="caret"></span></a>
-                            <ul class="dropdown-menu">
-                                <li><a href="{{ path('review_today') }}"><i class="fa fa-list" aria-hidden="true"></i> Participant Review</a></li>
-                                <li><a href="{{ path('deceased_reports_index') }}"><i class="fa fa-hourglass-o" aria-hidden="true"></i> Deceased Participants</a></li>
-                            </ul>
-                        </li>
-                        {% if app.siteOrganization %}
+                    {% if not currentRoleNav %}
+                        {% if is_granted('ROLE_USER') and app.session.get('site') %}
+                            <li class="dropdown">
+                                <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Lookup <span class="caret"></span></a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="{{ path('participants') }}"><i class="fa fa-user" aria-hidden="true"></i> Participant Lookup</a></li>
+                                    <li><a href="{{ path('orders') }}"><i class="fa fa-medkit" aria-hidden="true"></i> Biobank Order Lookup</a></li>
+                                </ul>
+                            </li>
+                            <li class="dropdown">
+                                <a class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Review <span class="caret"></span></a>
+                                <ul class="dropdown-menu">
+                                    <li><a href="{{ path('review_today') }}"><i class="fa fa-list" aria-hidden="true"></i> Participant Review</a></li>
+                                    <li><a href="{{ path('deceased_reports_index') }}"><i class="fa fa-hourglass-o" aria-hidden="true"></i> Deceased Participants</a></li>
+                                </ul>
+                            </li>
+                            {% if app.siteOrganization %}
+                                <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
+                            {% endif %}
+                        {% endif %}
+                        {% if is_granted('ROLE_AWARDEE') and app.session.get('awardee') and app.awardeeOrganization %}
                             <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
                         {% endif %}
-                    {% endif %}
-                    {% if is_granted('ROLE_AWARDEE') and app.session.get('awardee') and app.awardeeOrganization %}
-                        <li><a href="{{ path('workqueue_index') }}">Work Queue</a></li>
-                    {% endif %}
-                    {% if is_granted('ROLE_DV_ADMIN') %}
-                        <li><a href="{{ path('problem_reports') }}">Problem Reports</a></li>
-                    {% endif %}
-                    {% if is_granted('ROLE_USER') and app.session.get('site') and app.getOrderType == 'dv' and app.reportKitUrl %}
-                        <li><a data-href="{{ app.reportKitUrl }}" class="external-link">Report Kit Problem</a></li>
-                    {% endif %}
-                    {% if is_granted('ROLE_ADMIN') %}
-                        <li><a href="{{ path('admin_home') }}">Admin</a></li>
-                    {% endif %}
-                    {% if is_granted('ROLE_DASHBOARD') %}
-                        <li><a href="{{ path('dashboard_home') }}">Dashboard</a></li>
-                    {% endif %}
-                    {% if is_granted('ROLE_SCRIPPS') %}
-                        <li><a href="{{ path('biobank_home') }}">Scripps</a></li>
-                    {% elseif is_granted('ROLE_BIOBANK')  %}
-                        <li><a href="{{ path('biobank_home') }}">Biobank</a></li>
+                        {% if is_granted('ROLE_USER') and app.session.get('site') and app.getOrderType == 'dv' and app.reportKitUrl %}
+                            <li><a data-href="{{ app.reportKitUrl }}" class="external-link">Report Kit Problem</a></li>
+                        {% endif %}
                     {% endif %}
                 </ul>
                 <ul class="nav navbar-nav navbar-right">
                     {% if is_granted('IS_AUTHENTICATED_FULLY') %}
-                        {% if app.session.get('site') %}
-                            <li>
-                                <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
-                                    <i class="fa fa-hospital-o" aria-hidden="true"></i>
-                                    {{ app.getCurrentSiteDisplayName()|default(app.session.get('site').name) }}
-                                </a>
-                            </li>
-                        {% endif %}
-
-                        {% if app.session.get('awardee') %}
-                            <li>
-                                <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
-                                    <i class="fa fa-hospital-o" aria-hidden="true"></i>
-                                    {{ app.session.get('awardee').name }}
-                                </a>
-                            </li>
+                        {% if not currentRoleNav %}
+                            {% if app.session.get('site') %}
+                                <li>
+                                    <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
+                                        <i class="fa fa-hospital-o" aria-hidden="true"></i>
+                                        {{ app.getCurrentSiteDisplayName()|default(app.session.get('site').name) }}
+                                    </a>
+                                </li>
+                            {% endif %}
+                            {% if app.session.get('awardee') %}
+                                <li>
+                                    <a href="#" data-toggle="modal" data-target="#siteModal" title="Current site">
+                                        <i class="fa fa-hospital-o" aria-hidden="true"></i>
+                                        {{ app.session.get('awardee').name }}
+                                    </a>
+                                </li>
+                            {% endif %}
                         {% endif %}
 
                         <li class="dropdown">

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -63,16 +63,18 @@
                             {% endif %}
                         </a>
                         <ul class="dropdown-menu dropdown-menu-role">
-                            <li>
-                                <a href="{{ path('home') }}">
-                                    <i class="fas fa-arrow-circle-right"></i>
-                                    {% if not currentRoleNav %}
-                                        <strong>HealthPro</strong>
-                                    {% else %}
-                                        HealthPro
-                                    {% endif %}
-                                </a>
-                            </li>
+                            {% if is_granted(['ROLE_USER', 'ROLE_AWARDEE']) %}
+                                <li>
+                                    <a href="{{ path('home') }}">
+                                        <i class="fas fa-arrow-circle-right"></i>
+                                        {% if not currentRoleNav %}
+                                            <strong>HealthPro</strong>
+                                        {% else %}
+                                            HealthPro
+                                        {% endif %}
+                                    </a>
+                                </li>
+                            {% endif %}
                             {% for key, roleNav in roleNavs %}
                                 {% if is_granted(roleNav.role) %}
                                     <li>

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -75,19 +75,21 @@
                                     </a>
                                 </li>
                             {% endif %}
-                            {% for key, roleNav in roleNavs %}
-                                {% if is_granted(roleNav.role) %}
-                                    <li>
-                                        <a href="{{ path(roleNav.path) }}">
-                                            <i class="fas fa-arrow-circle-right"></i>
-                                            {% if key == currentRoleNav %}
-                                                <strong>{{ roleNav.title }}</strong>
-                                            {% else %}
-                                                {{ roleNav.title }}
-                                            {% endif %}
-                                        </a>
-                                    </li>
-                                {% endif %}
+                            {% for key, roleNav in roleNavs|filter((roleNav, key) =>
+                                is_granted(roleNav.role) and
+                                not (key == 'biobank' and is_granted('ROLE_SCRIPPS'))
+                            ) %}
+                            {# Scripps and biobank roles point to the same route, so only display one if user has both roles #}
+                                <li>
+                                    <a href="{{ path(roleNav.path) }}">
+                                        <i class="fas fa-arrow-circle-right"></i>
+                                        {% if key == currentRoleNav %}
+                                            <strong>{{ roleNav.title }}</strong>
+                                        {% else %}
+                                            {{ roleNav.title }}
+                                        {% endif %}
+                                    </a>
+                                </li>
                             {% endfor %}
                         </ul>
                     </li>

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -133,6 +133,41 @@ label.label-normal {
     text-transform: uppercase;
 }
 
+/* Nav bar role selector */
+.navbar-brand-role {
+    color: #f48d76;
+    font-weight: bold;
+}
+.navbar .dropdown-menu-role {
+    right: 0;
+    left: -15px;
+    font-size: 17px;
+}
+.navbar .dropdown-menu-role > li > a {
+    padding-left: 10px;
+}
+.navbar .dropdown-menu-role a i {
+    color: #363272;
+}
+.navbar-nav-role {
+    margin: 0;
+}
+@media(max-width:767px) {
+    .navbar-nav-role {
+        margin-top: 5px;
+    }
+    .navbar .dropdown-menu-role a i {
+        color: #FFFFFF;
+    }
+}
+.navbar-allofus .navbar-nav>.open>a.navbar-brand, .navbar-allofus .navbar-nav>.open>a.navbar-brand:focus, .navbar-allofus .navbar-nav>.open>a.navbar-brand:hover {
+    background-color: inherit;
+}
+.dropdown-toggle .navbar-brand-subtitle {
+    text-align: left;
+    margin-left: 50px;
+}
+
 /*
    IE >= 10 hack
    https://philipnewcomer.net/2014/04/target-internet-explorer-10-11-css/

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -135,7 +135,7 @@ label.label-normal {
 
 /* Nav bar role selector */
 .navbar-brand-role {
-    color: #f48d76;
+    color: #FFFFFF;
     font-weight: bold;
 }
 .navbar .dropdown-menu-role {


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-519 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Previously, our navbar has links to specific pages for regular site and awardee users, and then links to home pages for other roles (like admin, dashboard, biobank, etc.)

This PR replaces the main HealthPro home page link with a dropdown when a user has access to more than one role. Note that this frees up space in the navbar so in the future, we could add navbar links for different roles (like sites, page notices, etc. when in the admin context) but that is outside the scope of this PR.

I decided to implement this completely in the view layer since all of this is only affects the rendered navbar. This results in a bit more complexity in the view logic, but I think it's the right organization. Also, since we are still using the Silex homepage, I had to duplicate this across both templates. Looking forward to removing all of the Silex templates soon!

Finally, one unrelated change I made while testing switching roles - there was an error being thrown in dev (strict) mode for quanum orders when the address is empty. I fixed this by adding an `is defined` check.

### Instructions for testing

Try all combination of roles with different `gaBypassGroups` entries.

### Screenshots

![Screen Shot 2021-06-22 at 4 16 52 PM](https://user-images.githubusercontent.com/860499/123000616-68ee1580-d375-11eb-889b-1792462bd34c.png)

![Screen Shot 2021-06-22 at 4 17 19 PM](https://user-images.githubusercontent.com/860499/123000626-6be90600-d375-11eb-9bba-c102bbd03436.png)

