### PR TITLE
[HPRO-865] Restrict EHR PM date selector to prior six months

### DIFF
--- a/symfony/src/Form/MeasurementType.php
+++ b/symfony/src/Form/MeasurementType.php
@@ -94,9 +94,11 @@ class MeasurementType extends AbstractType
             } elseif ($type === 'date') {
                 unset($fieldOptions['scale']);
                 $class = Type\DateType::class;
-                $constraints[] = new Constraints\LessThanOrEqual([
-                    'value' => new \DateTime('today'),
-                    'message' => 'Date cannot be in the future'
+                $constraints[] = new Constraints\Range([
+                    'min' => new \DateTime('-6 months'),
+                    'max' => new \DateTime('today'),
+                    'minMessage' => 'Date cannot greater than six months in the past',
+                    'maxMessage' => 'Date cannot be in the future'
                 ]);
                 $dateOptions = [
                     'widget' => 'single_text',

--- a/symfony/src/Form/MeasurementType.php
+++ b/symfony/src/Form/MeasurementType.php
@@ -97,7 +97,7 @@ class MeasurementType extends AbstractType
                 $constraints[] = new Constraints\Range([
                     'min' => new \DateTime('-6 months'),
                     'max' => new \DateTime('today'),
-                    'minMessage' => 'Date cannot greater than six months in the past',
+                    'minMessage' => 'Date cannot be greater than six months in the past',
                     'maxMessage' => 'Date cannot be in the future'
                 ]);
                 $dateOptions = [

--- a/web/assets/js/views/PhysicalEvaluation-0.3-ehr.js
+++ b/web/assets/js/views/PhysicalEvaluation-0.3-ehr.js
@@ -728,8 +728,12 @@ PMI.views['PhysicalEvaluation-0.3-ehr'] = Backbone.View.extend({
         this.finalized = obj.finalized;
         this.rendered = false;
         this.render();
+        var today = new Date();
+        var sixMonthsAgo = (new Date()).setMonth(today.getMonth() - 6);
         $('.ehr-date').pmiDateTimePicker({
             'format': 'MM/DD/YYYY',
+            'maxDate': today,
+            'minDate': sixMonthsAgo,
             'useCurrent': false
         });
     },


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-865 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Limits the user's ability to select a date in the future or more than six months in the past when completing a physical measurement that relies on EHR data rather than one collected at the point of service.

### Instructions for testing  <!-- if applicable -->

The test participant must be one that can 1) accept new physical measurements and 2) be paired to a site where the `ehr_modification_protocol` flag is set to `1`.

### Screenshots <!-- if applicable -->

In the screenshots below, invalid dates are greyed out and are unable to be selected nor manually entered.

![Screen Shot 2021-08-02 at 9 18 14 PM](https://user-images.githubusercontent.com/80459/127947251-1ad5671b-8248-4910-8651-4484a9b70516.png)
![Screen Shot 2021-08-02 at 9 17 57 PM](https://user-images.githubusercontent.com/80459/127947253-cdba8a56-0bf8-408a-bb95-dfd9ecbd9a50.png)
