### PR TITLE
[HPRO-878] Add Feedback Links

### DIFF
--- a/src/Pmi/Application/HpoApplication.php
+++ b/src/Pmi/Application/HpoApplication.php
@@ -380,6 +380,7 @@ class HpoApplication extends AbstractApplication
     protected function beforeCallback(Request $request, AbstractApplication $app)
     {
         $app['twig']->addGlobal('confluenceResources', HelpService::$confluenceResources);
+        $app['twig']->addGlobal('feedback_url', HelpService::getFeedbackUrl());
 
         $app->log(Log::REQUEST);
 

--- a/symfony/config/packages/twig.php
+++ b/symfony/config/packages/twig.php
@@ -15,6 +15,7 @@ $container->loadFromExtension('twig', [
         'sessionTimeout' => $env->values['sessionTimeOut'],
         'sessionWarning' => $env->values['sessionWarning'],
         'timeZones' => $env->getTimeZones(),
-        'confluenceResources' => HelpService::$confluenceResources
+        'confluenceResources' => HelpService::$confluenceResources,
+        'feedback_url' => HelpService::getFeedbackUrl()
     ],
 ]);

--- a/symfony/src/Service/HelpService.php
+++ b/symfony/src/Service/HelpService.php
@@ -189,4 +189,9 @@ class HelpService
         }
         return false;
     }
+
+    public static function getFeedbackUrl(): string
+    {
+        return 'https://redcap.pmi-ops.org/surveys/?s=JN33K7PKWC';
+    }
 }

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -161,7 +161,7 @@
                             <li><a href="{{ confluenceResources.ops_data_api }}" target="_blank"><i class="fa fa-files-o" aria-hidden="true"></i> OpsData API Resources</a></li>
                             <li><a href="{{ confluenceResources.data_dictionaries }}" target="_blank"><i class="fa fa-table" aria-hidden="true"></i> HealthPro Data Dictionaries</a></li>
                             <li><a href="{{ confluenceResources.release_notes }}" target="_blank"><i class="fa fa-sticky-note" aria-hidden="true"></i> HealthPro Release Notes</a></li>
-                            <li><a data-href="{{ feedback_url }}" class="external-link"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a></li>
+                            <li><a href="{{ feedback_url }}" target="_blank"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a></li>
                         </ul>
                     </li>
                     <li class="dropdown">

--- a/symfony/templates/base.html.twig
+++ b/symfony/templates/base.html.twig
@@ -161,6 +161,7 @@
                             <li><a href="{{ confluenceResources.ops_data_api }}" target="_blank"><i class="fa fa-files-o" aria-hidden="true"></i> OpsData API Resources</a></li>
                             <li><a href="{{ confluenceResources.data_dictionaries }}" target="_blank"><i class="fa fa-table" aria-hidden="true"></i> HealthPro Data Dictionaries</a></li>
                             <li><a href="{{ confluenceResources.release_notes }}" target="_blank"><i class="fa fa-sticky-note" aria-hidden="true"></i> HealthPro Release Notes</a></li>
+                            <li><a data-href="{{ feedback_url }}" class="external-link"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a></li>
                         </ul>
                     </li>
                     <li class="dropdown">

--- a/symfony/templates/help/index.html.twig
+++ b/symfony/templates/help/index.html.twig
@@ -10,7 +10,7 @@
         <h2><i class="fa fa-question-circle" aria-hidden="true"></i> Help and Training Resources</h2>
     </div>
     <div class="pull-right">
-      <button data-href="{{ feedback_url }}" class="btn btn-sm btn-info external-link"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</button>
+      <a href="{{ feedback_url }}" target="_blank" class="btn btn-sm btn-info"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a>
     </div>
     <p class="lead">What would you like to do today?</p>
     <div class="row home-menu">

--- a/symfony/templates/help/index.html.twig
+++ b/symfony/templates/help/index.html.twig
@@ -9,6 +9,9 @@
     <div class="page-header">
         <h2><i class="fa fa-question-circle" aria-hidden="true"></i> Help and Training Resources</h2>
     </div>
+    <div class="pull-right">
+      <button data-href="{{ feedback_url }}" class="btn btn-sm btn-info external-link"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</button>
+    </div>
     <p class="lead">What would you like to do today?</p>
     <div class="row home-menu">
         <div class="col-sm-6 col-md-4">
@@ -32,4 +35,3 @@
     </div>
     {% include 'help/footer.html.twig' %}
 {% endblock %}
-

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -159,6 +159,7 @@
                                 <li><a href="{{ confluenceResources.ops_data_api }}" target="_blank"><i class="fa fa-files-o" aria-hidden="true"></i> OpsData API Resources</a></li>
                                 <li><a href="{{ confluenceResources.data_dictionaries }}" target="_blank"><i class="fa fa-table" aria-hidden="true"></i> HealthPro Data Dictionaries</a></li>
                                 <li><a href="{{ confluenceResources.release_notes }}" target="_blank"><i class="fa fa-sticky-note" aria-hidden="true"></i> HealthPro Release Notes</a></li>
+                                <li><a data-href="{{ feedback_url }}" class="external-link"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a></li>
                             </ul>
                         </li>
 

--- a/views/base.html.twig
+++ b/views/base.html.twig
@@ -159,7 +159,7 @@
                                 <li><a href="{{ confluenceResources.ops_data_api }}" target="_blank"><i class="fa fa-files-o" aria-hidden="true"></i> OpsData API Resources</a></li>
                                 <li><a href="{{ confluenceResources.data_dictionaries }}" target="_blank"><i class="fa fa-table" aria-hidden="true"></i> HealthPro Data Dictionaries</a></li>
                                 <li><a href="{{ confluenceResources.release_notes }}" target="_blank"><i class="fa fa-sticky-note" aria-hidden="true"></i> HealthPro Release Notes</a></li>
-                                <li><a data-href="{{ feedback_url }}" class="external-link"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a></li>
+                                <li><a href="{{ feedback_url }}" target="_blank"><i class="fa fa-comment-dots" aria-hidden="true"></i> Submit Feedback</a></li>
                             </ul>
                         </li>
 


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-8788 <!-- Tag which ticket(s) this PR relates to -->

### Summary

This PR links the REDCap form for collecting user feedback for the HealthPro application in two places:

- Drop down menu in upper right
- As a button on the Help and Training Resources page

### Instructions for testing  <!-- if applicable -->

Notable is the requirement that the link display the External Site warning pop-up before continuing on in a new tab.

### Screenshots <!-- if applicable -->

![Screen Shot 2021-08-06 at 11 09 33 AM](https://user-images.githubusercontent.com/80459/128540478-66a7f56f-6795-4988-a20d-186fb6ad30b2.png)

![Screen Shot 2021-08-06 at 11 09 51 AM](https://user-images.githubusercontent.com/80459/128540487-341af1a6-5b01-4775-854f-f83d62714e1d.png)
