### PR TITLE
[HPRO-833] Fix digital health sharing status field parse error

### DIFF
--- a/src/Pmi/Drc/CodeBook.php
+++ b/src/Pmi/Drc/CodeBook.php
@@ -133,7 +133,7 @@ class CodeBook
 
     public static function display($code)
     {
-        if (is_bool($code)) {
+        if (is_bool($code) || is_object($code)) {
             return $code;
         }
         if (array_key_exists($code, self::$map)) {

--- a/symfony/src/Helper/Participant.php
+++ b/symfony/src/Helper/Participant.php
@@ -222,16 +222,6 @@ class Participant
         if (isset($participant->consentCohort)) {
             $this->consentCohortText = $this->getConsentCohortText($participant);
         }
-
-        // Json decode digital health sharing status
-        if (isset($participant->digitalHealthSharingStatus) && !empty($participant->digitalHealthSharingStatus)) {
-            $digitalHealthSharingStatus = json_decode($participant->digitalHealthSharingStatus, true);
-            if (is_array($digitalHealthSharingStatus)) {
-                $this->digitalHealthSharingStatus = $digitalHealthSharingStatus;
-            } else {
-                $this->digitalHealthSharingStatus = [];
-            }
-        }
     }
 
     public function getShortId()

--- a/symfony/src/Helper/WorkQueue.php
+++ b/symfony/src/Helper/WorkQueue.php
@@ -661,9 +661,9 @@ class WorkQueue
     public static function getDigitalHealthSharingStatus($digitalHealthSharingStatus, $type, $userTimezone)
     {
         if ($digitalHealthSharingStatus) {
-            if (isset($digitalHealthSharingStatus[$type]['status'])) {
-                $authoredDate = $digitalHealthSharingStatus[$type]['history'][0]['authoredTime'] ?? '';
-                if ($digitalHealthSharingStatus[$type]['status'] === 'YES') {
+            if (isset($digitalHealthSharingStatus->{$type}->status)) {
+                $authoredDate = $digitalHealthSharingStatus->{$type}->history[0]->authoredTime ?? '';
+                if ($digitalHealthSharingStatus->{$type}->status === 'YES') {
                     return self::HTML_SUCCESS . ' ' . self::dateFromString($authoredDate, $userTimezone);
                 }
                 return self::HTML_DANGER . ' ' . self::dateFromString($authoredDate, $userTimezone);
@@ -676,9 +676,9 @@ class WorkQueue
     {
         if ($digitalHealthSharingStatus) {
             if (!$displayDate) {
-                return isset($digitalHealthSharingStatus[$type]['status']) && $digitalHealthSharingStatus[$type]['status'] === 'YES' ? 1 : 0;
+                return isset($digitalHealthSharingStatus->{$type}->status) && $digitalHealthSharingStatus->{$type}->status === 'YES' ? 1 : 0;
             }
-            $authoredDate = $digitalHealthSharingStatus[$type]['history'][0]['authoredTime'] ?? '';
+            $authoredDate = $digitalHealthSharingStatus->{$type}->history[0]->authoredTime ?? '';
             return self::dateFromString($authoredDate, $userTimezone);
         }
         return 0;


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅<!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-833 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-833-->

### Instructions for testing  <!-- if applicable -->
Looks like `digitalHealthSharingStatus` field values are returned as an stdClass object instead of json string.

Below is the participant which is tied to awardee `AZ_TUCSON` for testing in WQ
Participant Id: P741896610

