### PR TITLE
[HPRO-910] Deceased > Check for `ROLE_USER` before making AJAX request

### DIFF
--- a/symfony/templates/index.html.twig
+++ b/symfony/templates/index.html.twig
@@ -86,16 +86,17 @@
     <script>
         $(document).ready(function () {
             // Add badge for count of Deceased Participant Reports for review
-            var deceasedReportCount = 0;
-            $.ajax({
-                url: '/s/deceased-reports/stats'
-            }).done(function (data) {
-                deceasedReportCount = data.pending
-                if (deceasedReportCount > 0) {
-                    $('#deceased_report_block > a').prepend($('<div class="welcome-page-badge">' + deceasedReportCount +'</div>'));
-                }
-            })
+            if ($('deceased_report_block').length) {
+                var deceasedReportCount = 0;
+                $.ajax({
+                    url: '/s/deceased-reports/stats'
+                }).done(function (data) {
+                    deceasedReportCount = data.pending
+                    if (deceasedReportCount > 0) {
+                        $('#deceased_report_block > a').prepend($('<div class="welcome-page-badge">' + deceasedReportCount +'</div>'));
+                    }
+                })
+            }
         })
     </script>
 {% endblock %}
-

--- a/symfony/templates/index.html.twig
+++ b/symfony/templates/index.html.twig
@@ -86,7 +86,7 @@
     <script>
         $(document).ready(function () {
             // Add badge for count of Deceased Participant Reports for review
-            if ($('deceased_report_block').length) {
+            if ($('#deceased_report_block').length) {
                 var deceasedReportCount = 0;
                 $.ajax({
                     url: '/s/deceased-reports/stats'


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-910 <!-- Tag which ticket(s) this PR relates to -->

### Summary

When a user lacks `ROLE_USER`, we were still calling the `/s/deceased-reports/stats` endpoint to get a badge count, resulting in a HTTP 403 error appearing in the logs. This PR wraps the AJAX request in a check of whether the relevant block appears on the page.