### PR TITLE
[HPRO-912] Return null for digital health sharing date fields when status is not set

### DIFF
--- a/symfony/src/Helper/WorkQueue.php
+++ b/symfony/src/Helper/WorkQueue.php
@@ -686,6 +686,6 @@ class WorkQueue
             $authoredDate = $digitalHealthSharingStatus->{$type}->history[0]->authoredTime ?? '';
             return self::dateFromString($authoredDate, $userTimezone);
         }
-        return !$displayDate ? 0 : null;
+        return !$displayDate ? 0 : '';
     }
 }

--- a/symfony/src/Helper/WorkQueue.php
+++ b/symfony/src/Helper/WorkQueue.php
@@ -686,6 +686,6 @@ class WorkQueue
             $authoredDate = $digitalHealthSharingStatus->{$type}->history[0]->authoredTime ?? '';
             return self::dateFromString($authoredDate, $userTimezone);
         }
-        return 0;
+        return !$displayDate ? 0 : null;
     }
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-912 <!-- https://precisionmedicineinitiative.atlassian.net/browse/HPRO-912-->

### Screenshots <!-- if applicable -->
![Screen Shot 2021-09-15 at 3 07 14 PM](https://user-images.githubusercontent.com/6041980/133501659-c1f4b422-7b4b-4840-a079-39e29ecd698a.png)


