### PR TITLE
[HPRO-917] Adjust routing rules for `/s/cron` endpoints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         "symfony/webpack-encore-bundle": "^1.7",
         "beberlei/doctrineextensions": "^1.2",
         "symfony/proxy-manager-bridge": "4.4.*",
-        "symfony/serializer": "4.4.*"
+        "symfony/serializer": "4.4.*",
+        "symfony/expression-language": "4.4.*"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b3b424f2ef9400e5aba0cf59785a3e1",
+    "content-hash": "8d1b5a34cdac1a073c6b277c77a83ecc",
     "packages": [
         {
             "name": "beberlei/doctrineextensions",
@@ -4269,6 +4269,69 @@
                 "standards"
             ],
             "time": "2020-07-06T13:19:58+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v4.4.30",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "78a014771042079cca30716c8471e7a0b985bd22"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/78a014771042079cca30716c8471e7a0b985bd22",
+                "reference": "78a014771042079cca30716c8471e7a0b985bd22",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3",
+                "symfony/cache": "^3.4|^4.0|^5.0",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an engine that can compile and evaluate expressions",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/expression-language/tree/v4.4.30"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-08-19T09:02:22+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -9777,5 +9840,5 @@
     "platform-overrides": {
         "php": "7.4.14"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -378,6 +378,9 @@
     "symfony/event-dispatcher-contracts": {
         "version": "v1.1.7"
     },
+    "symfony/expression-language": {
+        "version": "v4.4.30"
+    },
     "symfony/filesystem": {
         "version": "v4.4.7"
     },

--- a/symfony/src/Controller/CronController.php
+++ b/symfony/src/Controller/CronController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/s/cron", condition="request.headers.get('X-Appengine-Cron') matches '/true/'")
+ * @Route("/s/cron", condition="request.headers.get('X-Appengine-Cron') === 'true'")
  */
 class CronController extends AbstractController
 {

--- a/symfony/src/Controller/CronController.php
+++ b/symfony/src/Controller/CronController.php
@@ -20,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
- * @Route("/s/cron")
+ * @Route("/s/cron", condition="request.headers.get('X-Appengine-Cron') matches '/true/'")
  */
 class CronController extends AbstractController
 {

--- a/symfony/tests/Controller/CronControllerTest.php
+++ b/symfony/tests/Controller/CronControllerTest.php
@@ -11,7 +11,7 @@ class CronControllerTest extends WebTestCase
         $client = static::createClient();
         $crawler = $client->request('GET', '/s/cron/ping-test');
 
-        $this->assertResponseStatusCodeSame('404', 'Returns a 404 without header set.');
+        $this->assertResponseStatusCodeSame(404, 'Returns a 404 without header set.');
     }
 
     public function testWitHeader()

--- a/symfony/tests/Controller/CronControllerTest.php
+++ b/symfony/tests/Controller/CronControllerTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class CronControllerTest extends WebTestCase
+{
+    public function testWithoutHeader()
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/s/cron/ping-test');
+
+        $this->assertResponseStatusCodeSame('404', 'Returns a 404 without header set.');
+    }
+
+    public function testWitHeader()
+    {
+        $client = static::createClient();
+        $crawler = $client->request('GET', '/s/cron/ping-test', [], [], [
+            'HTTP_X_APPENGINE_CRON' => 'true'
+        ]);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertEquals('{"success":true}', $client->getResponse()->getContent());
+    }
+}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ✅ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-917 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Adjusts routing rules around `/s/cron` endpoints.

### Testing

Provide the `X-Appengine-Cron: true` header when interacting with the endpoints. Omitting it will return a 404 error.

Example:

```
$ curl -H 'X-Appengine-Cron: true' http://localhost:8080/s/cron/ping-test
```