### PR TITLE
 [HPRO-914] Use Google Group data as email source of truth

### DIFF
--- a/cron.yaml.dist
+++ b/cron.yaml.dist
@@ -23,6 +23,10 @@ cron:
   url: /s/cron/sites
   schedule: every day 20:00
   timezone: America/Chicago
+- description: "Sync sites admin emails"
+  url: /s/cron/sites-email-sync
+  schedule: every day 21:00
+  timezone: America/Chicago
 - description: "Sync awardees and organizations"
   url: /s/cron/awardees-organizations
   schedule: every day 20:01

--- a/symfony/src/Command/SyncSiteEmailsCommand.php
+++ b/symfony/src/Command/SyncSiteEmailsCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Site;
+use App\Service\EnvironmentService;
+use App\Service\GoogleGroupsService;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Formatter\OutputFormatter;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class SyncSiteEmailsCommand extends Command
+{
+    private $googleGroupsService;
+    private $environmentService;
+    private $em;
+    private $adminEmails = [];
+
+    private const MEMBER_DOMAIN = '@pmi-ops.org';
+
+    public function __construct(EnvironmentService $environmentService, GoogleGroupsService $googleGroupsService, EntityManagerInterface $em)
+    {
+        $this->environmentService = $environmentService;
+        $this->googleGroupsService = $googleGroupsService;
+        $this->em = $em;
+        parent::__construct();
+    }
+
+    public function configure(): void
+    {
+        $this
+            ->setName('pmi:sitesync:emails')
+            ->setDescription('Sync existing site administrator emails.')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // Do not set site emails on staging/stable environments
+        if (!$this->environmentService->isProd() && !$this->environmentService->isLocal()) {
+            $output->writeln('Site email sync not allowed in this environment.', OutputInterface::VERBOSITY_VERBOSE);
+            return 0;
+        }
+
+        // Get site list
+        $sites = $this->em->getRepository(Site::class)->findBy(['status' => 1, 'deleted' => 0]);
+        $progressBar = new ProgressBar($output, count($sites));
+        $progressBar->start();
+        foreach ($sites as $site) {
+            $progressBar->advance();
+            $output->writeln($site->getName(), OutputInterface::VERBOSITY_VERBOSE);
+            $siteAdmins = [];
+            $members = $this->googleGroupsService->getMembers($site->getSiteId() . self::MEMBER_DOMAIN, ['OWNER', 'MANAGER']);
+            if (count($members) === 0) {
+                $output->writeln(' └ No members set for site!', OutputInterface::VERBOSITY_VERBOSE);
+                $site->setEmail(null);
+                continue;
+            }
+            foreach ($members as $member) {
+                if ($member->status === 'ACTIVE') {
+                    $output->writeln(' └ User: ' . $member->email, OutputInterface::VERBOSITY_VERBOSE);
+                    if (isset($this->adminEmails[$member->email])) {
+                        $output->writeln('  └ ' . $this->adminEmails[$member->email] . ' (matched previous lookup)', OutputInterface::VERBOSITY_VERBOSE);
+                        $siteAdmins[] = $this->adminEmails[$member->email];
+                        continue;
+                    }
+                    $user = $this->googleGroupsService->getUser($member->email);
+                    $userEmail = $user->recoveryEmail;
+                    $output->writeln('  └ ' . $userEmail, OutputInterface::VERBOSITY_VERBOSE);
+                    $output->writeln(json_encode($user), OutputInterface::VERBOSITY_DEBUG);
+                    $this->adminEmails[$member->email] = $userEmail;
+                    $siteAdmins[] = $userEmail;
+                }
+            }
+            $statusMessage = ' └ Setting: ' . join(', ', $siteAdmins);
+            $output->writeln($statusMessage, OutputInterface::VERBOSITY_VERBOSE);
+            $site->setEmail(join(', ', $siteAdmins));
+            $this->em->persist($site);
+        }
+        $progressBar->finish();
+        $this->em->flush();
+        $output->writeln('');
+        return 0;
+    }
+}

--- a/symfony/src/Controller/CronController.php
+++ b/symfony/src/Controller/CronController.php
@@ -14,9 +14,13 @@ use App\Service\SiteSyncService;
 use App\Service\WithdrawalNotificationService;
 use Doctrine\ORM\EntityManagerInterface;
 use Pmi\Cache\DatastoreAdapter;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelInterface;
 use Symfony\Component\Routing\Annotation\Route;
 
 /**
@@ -51,6 +55,22 @@ class CronController extends AbstractController
             return $this->json(['error' => 'RDR Awardee API disabled']);
         }
         $siteSyncService->sync();
+        return $this->json(['success' => true]);
+    }
+
+    /**
+     * @Route("/sites-email-sync", name="cron_sites_email")
+     */
+    public function sitesSyncEmail(KernelInterface $kernel): Response
+    {
+        $application = new Application($kernel);
+        $application->setAutoExit(false);
+
+        $input = new ArrayInput([
+            'command' => 'pmi:sitesync:emails',
+        ]);
+        $application->run($input, new NullOutput());
+
         return $this->json(['success' => true]);
     }
 

--- a/symfony/src/Controller/CronController.php
+++ b/symfony/src/Controller/CronController.php
@@ -61,7 +61,7 @@ class CronController extends AbstractController
     /**
      * @Route("/sites-email-sync", name="cron_sites_email")
      */
-    public function sitesSyncEmail(KernelInterface $kernel): Response
+    public function sitesEmailSync(KernelInterface $kernel): Response
     {
         $application = new Application($kernel);
         $application->setAutoExit(false);

--- a/symfony/src/Service/GoogleGroupsService.php
+++ b/symfony/src/Service/GoogleGroupsService.php
@@ -130,10 +130,14 @@ class GoogleGroupsService
         }
     }
 
-    public function getMembers(string $groupEmail)
+    public function getMembers(string $groupEmail, $roles = [])
     {
+        $params = [];
+        if (!empty($roles)) {
+            $params['roles'] = join(',', $roles);
+        }
         try {
-            $result = $this->callApi('members', 'listMembers', [$groupEmail]);
+            $result = $this->callApi('members', 'listMembers', [$groupEmail, $params]);
             if ($result) {
                 return $result->getMembers();
             }

--- a/symfony/src/Service/SiteSyncService.php
+++ b/symfony/src/Service/SiteSyncService.php
@@ -9,7 +9,6 @@ use Doctrine\ORM\EntityManagerInterface;
 use Pmi\Audit\Log;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
-use Symfony\Component\Stopwatch\Stopwatch;
 
 class SiteSyncService
 {
@@ -21,8 +20,6 @@ class SiteSyncService
     private $normalizer;
     private $orgEndpoint = 'rdr/v1/Awardee?_inactive=true';
     private $entries;
-    private $stopwatch;
-    private $adminEmails = [];
 
     public function __construct(
         RdrApiService $rdrApiService,
@@ -30,8 +27,7 @@ class SiteSyncService
         EnvironmentService $env,
         LoggerService $loggerService,
         ParameterBagInterface $params,
-        NormalizerInterface $normalizer,
-        Stopwatch $stopwatch
+        NormalizerInterface $normalizer
     ) {
         $this->rdrApiService = $rdrApiService;
         $this->em = $em;
@@ -39,7 +35,6 @@ class SiteSyncService
         $this->loggerService = $loggerService;
         $this->params = $params;
         $this->normalizer = $normalizer;
-        $this->stopwatch = $stopwatch;
     }
 
     private function getAwardeeEntriesFromRdr()

--- a/symfony/src/Service/SiteSyncService.php
+++ b/symfony/src/Service/SiteSyncService.php
@@ -21,11 +21,8 @@ class SiteSyncService
     private $normalizer;
     private $orgEndpoint = 'rdr/v1/Awardee?_inactive=true';
     private $entries;
-    private $googleGroupsService;
     private $stopwatch;
     private $adminEmails = [];
-
-    public const MEMBER_DOMAIN = '@pmi-ops.org';
 
     public function __construct(
         RdrApiService $rdrApiService,
@@ -34,7 +31,6 @@ class SiteSyncService
         LoggerService $loggerService,
         ParameterBagInterface $params,
         NormalizerInterface $normalizer,
-        GoogleGroupsService $googleGroupsService,
         Stopwatch $stopwatch
     ) {
         $this->rdrApiService = $rdrApiService;
@@ -43,7 +39,6 @@ class SiteSyncService
         $this->loggerService = $loggerService;
         $this->params = $params;
         $this->normalizer = $normalizer;
-        $this->googleGroupsService = $googleGroupsService;
         $this->stopwatch = $stopwatch;
     }
 
@@ -142,29 +137,6 @@ class SiteSyncService
                     $siteData->setTimezone(isset($site->timeZoneId) ? $site->timeZoneId : null);
                     $siteData->setType($awardee->type);
                     $siteData->setSiteType(isset($site->siteType) ? $site->siteType : null);
-                    if ($this->env->isProd() || $this->env->isLocal()) {
-                        $siteAdmins = [];
-                        $this->stopwatch->start('siteemails', 'getMembers');
-                        $members = $this->googleGroupsService->getMembers($siteId . self::MEMBER_DOMAIN);
-                        $this->stopwatch->stop('siteemails', 'getMembers');
-                        foreach ($members as $member) {
-                            if ($member->role === 'MANAGER' && $member->status === 'ACTIVE') {
-                                if (isset($this->adminEmails[$member->email])) {
-                                    $siteAdmins[] = $member->recoveryEmail;
-                                    $this->adminEmails[$member->email] = $member->recoveryEmail;
-                                    continue;
-                                }
-                                $this->stopwatch->start('siteemails', 'getUser');
-                                $member = $this->googleGroupsService->getUser($member->email);
-                                $this->stopwatch->stop('siteemails', 'getUser');
-                                $siteAdmins[] = $member->recoveryEmail;
-                            }
-                        }
-                        $siteData->setEmail(null);
-                        if (!empty($siteAdmins)) {
-                            $siteData->setEmail(join(', ', $siteAdmins));
-                        }
-                    }
                     if (empty($siteData->getWorkqueueDownload())) {
                         $siteData->setWorkqueueDownload('full_data'); // default value for workqueue downlaod
                     }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-917 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Instead of relying on the RDR representation of `siteAdmins`, this PR queries the Google Groups API to determine the proper notification email addresses for a given site.

### Instructions for testing  <!-- if applicable -->

Console command:

```
$ bin/dx bin/console pmi:sitesync:emails -v
```

Cron task:

```
$ curl -H 'x-appengine-cron: true' http://localhost:8080/s/cron/sites-email-sync
```

### TODO

- [ ] Switch from using `recoveryEmail` to a standardized `type` in the `emails` property of the Google User record.
- [ ] An approach to batching requests?