### PR TITLE
[HPRO-895] Add debug logs to keepalive CSRF token mismatch

### DIFF
--- a/symfony/src/Controller/DefaultController.php
+++ b/symfony/src/Controller/DefaultController.php
@@ -80,7 +80,7 @@ class DefaultController extends AbstractController
      */
     public function keepAliveAction(Request $request, LoggerService $loggerService)
     {
-        if ($this->isCsrfTokenValid('keepAlive', $request->request->get('csrf_token'))) {
+        if (!$this->isCsrfTokenValid('keepAlive', $request->request->get('csrf_token'))) {
             $loggerService->log(LoggerService::CSRF_TOKEN_MISMATCH, [
                 'submitted_token' => $request->request->get('csrf_token'),
                 'referrer' => $request->headers->get('referer')

--- a/symfony/src/Controller/DefaultController.php
+++ b/symfony/src/Controller/DefaultController.php
@@ -78,9 +78,13 @@ class DefaultController extends AbstractController
      * @Route("/keepalive", name="keep_alive")
      * Dummy action that serves to extend the user's session.
      */
-    public function keepAliveAction(Request $request)
+    public function keepAliveAction(Request $request, LoggerService $loggerService)
     {
-        if (!$this->get('security.csrf.token_manager')->isTokenValid(new CsrfToken('keepAlive', $request->request->get('csrf_token')))) {
+        if ($this->isCsrfTokenValid('keepAlive', $request->request->get('csrf_token'))) {
+            $loggerService->log(LoggerService::CSRF_TOKEN_MISMATCH, [
+                'submitted_token' => $request->request->get('csrf_token'),
+                'referrer' => $request->headers->get('referer')
+            ]);
             throw $this->createAccessDeniedException();
         }
         $request->getSession()->set('pmiLastUsed', time());

--- a/symfony/src/Service/LoggerService.php
+++ b/symfony/src/Service/LoggerService.php
@@ -57,6 +57,7 @@ class LoggerService
     public const PATIENT_STATUS_HISTORY_EDIT = 'PATIENT_STATUS_HISTORY_EDIT';
     public const AWARDEE_ADD = 'AWARDEE_ADD';
     public const ORGANIZATION_ADD = 'ORGANIZATION_ADD';
+    public const CSRF_TOKEN_MISMATCH = 'CSRF_TOKEN_MISMATCH';
 
     public function __construct(
         LoggerInterface $logger,


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-895 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Looking to collect some more context around the HTTP 403 errors we're seeing for certain users where the CSRF token doesn't match the submitted value.