### PR TITLE
[HPRO-851] Fix absolute URL redirect

### DIFF
--- a/symfony/config/routes.yaml
+++ b/symfony/config/routes.yaml
@@ -1,8 +1,0 @@
-# 'home' route is still used in a lot of places so this redirect is left in place
-# to both continue functionality of that route without and also to redirect / to
-# the Symfony home page (/s/) when anyone goes straight to /
-home:
-    path: /
-    controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
-    defaults:
-        route: 'symfony_home'

--- a/symfony/src/Controller/AuthController.php
+++ b/symfony/src/Controller/AuthController.php
@@ -23,7 +23,7 @@ class AuthController extends AbstractController
     public function login(UserService $userService, Request $request, UserProviderInterface $userProvider, EnvironmentService $env, AuthService $authService, SessionInterface $session)
     {
         if ($this->getUser()) {
-            return $this->redirectToRoute('symfony_home');
+            return $this->redirectToRoute('home');
         }
 
         if ($env->isLocal() && $userService->canMockLogin()) {

--- a/symfony/src/Controller/DefaultController.php
+++ b/symfony/src/Controller/DefaultController.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Csrf\CsrfToken;
 class DefaultController extends AbstractController
 {
     /**
-     * @Route("/", name="symfony_home")
+     * @Route("/", name="home")
      */
     public function index()
     {
@@ -67,7 +67,7 @@ class DefaultController extends AbstractController
                 return $this->render('site-select.html.twig', ['siteEmail' => $siteId]);
             }
             if ($siteService->switchSite($siteId)) {
-                return $this->redirectToRoute('symfony_home');
+                return $this->redirectToRoute('home');
             } else {
                 throw $this->createAccessDeniedException();
             }
@@ -147,6 +147,6 @@ class DefaultController extends AbstractController
         $loggerService->log(Log::LOGOUT);
         $this->get('security.token_storage')->setToken(null);
         $session->invalidate();
-        return $this->redirect($authService->getGoogleLogoutUrl($timeout ? 'timeout' : 'symfony_home'));
+        return $this->redirect($authService->getGoogleLogoutUrl($timeout ? 'timeout' : 'home'));
     }
 }

--- a/symfony/src/Controller/HomeRedirectController.php
+++ b/symfony/src/Controller/HomeRedirectController.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
+
+class HomeRedirectController extends AbstractController
+{
+    /**
+     * @Route("/")
+     */
+    public function homeRedirectAction()
+    {
+        return $this->redirectToRoute('home');
+    }
+}

--- a/symfony/src/Security/GoogleGroupsAuthenticator.php
+++ b/symfony/src/Security/GoogleGroupsAuthenticator.php
@@ -108,7 +108,7 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
         $this->userService->updateLastLogin();
         // Instead of using a service, the token should eventually contain the User entity (not Pmi\Security\User)
         // which will make updating the last login trivial.
-        return $this->redirectToRoute('symfony_home');
+        return $this->redirectToRoute('home');
     }
 
     public function start(Request $request, AuthenticationException $authException = null)

--- a/symfony/src/Service/AuthService.php
+++ b/symfony/src/Service/AuthService.php
@@ -92,7 +92,7 @@ class AuthService
         $this->tokenStorage->setToken($token);
     }
 
-    public function getGoogleLogoutUrl($route = 'symfony_home')
+    public function getGoogleLogoutUrl($route = 'home')
     {
         $dest = $this->generateUrl($route);
 

--- a/symfony/templates/accessmanagement/add-member.html.twig
+++ b/symfony/templates/accessmanagement/add-member.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 {% block body %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('symfony_home') }}">Home</a></li>
+        <li><a href="{{ path('home') }}">Home</a></li>
         <li><a href="{{ path('access_manage_dashboard') }}">Management Tools</a></li>
         <li><a href="{{ path('access_manage_user_groups') }}">HealthPro Groups</a></li>
         <li><a href="{{ path('access_manage_user_group', { groupId: group.id }) }}">{{ group.name }}</a></li>

--- a/symfony/templates/accessmanagement/dashboard.html.twig
+++ b/symfony/templates/accessmanagement/dashboard.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 {% block body %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('symfony_home') }}">Home</a></li>
+        <li><a href="{{ path('home') }}">Home</a></li>
         <li class="active">Management Tools</li>
     </ol>
     <div class="page-header">

--- a/symfony/templates/accessmanagement/group-members.html.twig
+++ b/symfony/templates/accessmanagement/group-members.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 {% block body %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('symfony_home') }}">Home</a></li>
+        <li><a href="{{ path('home') }}">Home</a></li>
         <li><a href="{{ path('access_manage_dashboard') }}">Management Tools</a></li>
         <li><a href="{{ path('access_manage_user_groups') }}">HealthPro Groups</a></li>
         <li class="active">{{ group.name }}</li>

--- a/symfony/templates/accessmanagement/groups.html.twig
+++ b/symfony/templates/accessmanagement/groups.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 {% block body %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('symfony_home') }}">Home</a></li>
+        <li><a href="{{ path('home') }}">Home</a></li>
         <li><a href="{{ path('access_manage_dashboard') }}">Management Tools</a></li>
         <li class="active">HealthPro Groups</li>
     </ol>

--- a/symfony/templates/accessmanagement/remove-member.html.twig
+++ b/symfony/templates/accessmanagement/remove-member.html.twig
@@ -1,7 +1,7 @@
 {% extends 'base.html.twig' %}
 {% block body %}
     <ol class="breadcrumb">
-        <li><a href="{{ path('symfony_home') }}">Home</a></li>
+        <li><a href="{{ path('home') }}">Home</a></li>
         <li><a href="{{ path('access_manage_dashboard') }}">Management Tools</a></li>
         <li><a href="{{ path('access_manage_user_groups') }}">HealthPro Groups</a></li>
         <li><a href="{{ path('access_manage_user_group', { groupId: group.id }) }}">{{ group.name }}</a></li>

--- a/symfony/templates/timeout.html.twig
+++ b/symfony/templates/timeout.html.twig
@@ -9,7 +9,7 @@
 </head>
 <body>
 <div style="margin: 20px;">
-    <strong>Your session has expired.</strong> For security reasons, you have been automatically logged out. <a href="{{ path('symfony_home') }}">Return to HealthPro</a>.
+    <strong>Your session has expired.</strong> For security reasons, you have been automatically logged out. <a href="{{ path('home') }}">Return to HealthPro</a>.
 </div>
 </body>
 </html>


### PR DESCRIPTION
Fixes issue with absolute URL being generated for location header when using the Symfony built-in RedirectController

| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.6.3 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-851 <!-- Tag which ticket(s) this PR relates to -->

### Summary

I had originally used the Symfony built-in RedirectController to accomplish two things:

1. Maintain the existing use of the named `home` route
2. Redirect `/` to `/s/`

This created a problem when behind the WAF because the RedirectController [generates an absolute URL](https://github.com/symfony/symfony/blob/4.4/src/Symfony/Bundle/FrameworkBundle/Controller/RedirectController.php#L88).

This PR creates a new controller just to do the redirect. I also went ahead and cleaned up our home page route names to always use `home` instead of a mix of `home` and `symfony_home`.

### Screenshots

Before:

![before](https://user-images.githubusercontent.com/860499/136093445-c526bb83-503f-4cc1-bb6b-3c03baa166e2.png)

After:

![after](https://user-images.githubusercontent.com/860499/136093513-a4a81156-4a2e-4a81-bfb4-c7028c69edf8.png)
