### PR TITLE
[HPRO-943] Fix Doctrine Migration environment variable reading

### DIFF
--- a/dev_config/migrations-db.php
+++ b/dev_config/migrations-db.php
@@ -3,15 +3,16 @@
 use Symfony\Component\Yaml\Parser;
 
 // Determine migration target from loaded environment variable, set at runtime
-$migrationTarget = isset($_ENV['MIGRATION_TARGET']) ? $_ENV['MIGRATION_TARGET'] : null;
+$migrationTarget = getenv('MIGRATION_TARGET');
 if (!$migrationTarget) {
     throw new \Exception('Must prefix command with `MIGRATION_TARGET=<environment>`, see ' . __FILE__);
 }
 
 $filename = basename(sprintf('migrations-%s.yml', $migrationTarget));
-if (file_exists(dirname(__FIlE__) . '/' .$filename)) {
+if (file_exists(dirname(__FILE__) . '/' . $filename)) {
+    echo 'Loaded configuration: ' . $filename . PHP_EOL;
     $yaml = new Parser();
-    return $yaml->parse(file_get_contents(dirname(__FIlE__) . '/' . $filename));
+    return $yaml->parse(file_get_contents(dirname(__FILE__) . '/' . $filename));
 }
 
 // If file not found, show additional help instructions


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-943 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Ran into trouble with reading from `$_ENV` in the configuration file. The value was available in `$_SERVER` and using `getenv()`. I suspect some of the globals may be cleaned up a bit to only those defined in a `.env` file. Also addresses a constant casing issue.