### PR TITLE
[HPRO-935] Add PHPStan to Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,9 @@ jobs:
     # PHP CS Fixer
     - run: ./ci/php-cs-fixer.sh
 
+    # PHPStan
+    - run: ./ci/phpstan.sh
+
     # Teardown
     - store_test_results:
         path: /tmp/circleci-test-results

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ ci/*.secret
 /deploy_*.txt
 /docker-compose.override.yml
 .phpunit.result.cache
+phpstan.neon
 
 ###> friendsofphp/php-cs-fixer ###
 /tools/php-cs-fixer/vendor/

--- a/ci/phpstan.sh
+++ b/ci/phpstan.sh
@@ -5,4 +5,4 @@ cp $APP_DIR/phpstan.neon.dist $APP_DIR/phpstan.neon
 
 sed -i 's/var\/cache\/dev/var\/cache\/test/gI' $APP_DIR/phpstan.neon
 sed -i 's/App_KernelDevDebugContainer/App_KernelTestDebugContainer/gI' $APP_DIR/phpstan.neon
-./vendor/bin/phpstan analyse --memory-limit 2G
+APP_ENV=test ./vendor/bin/phpstan analyse --memory-limit 2G

--- a/ci/phpstan.sh
+++ b/ci/phpstan.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+APP_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/.."
+
+cp $APP_DIR/phpstan.neon.dist $APP_DIR/phpstan.neon
+
+sed -i 's/var\/cache\/dev/var\/cache\/test/gI' $APP_DIR/phpstan.neon
+sed -i 's/App_KernelDevDebugContainer/App_KernelTestDebugContainer/gI' $APP_DIR/phpstan.neon
+./vendor/bin/phpstan analyse --memory-limit 2G

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,22 +1,2 @@
 parameters:
 	ignoreErrors:
-		-
-			message: "#^Service \"gaAdminEmail\" is not registered in the container\\.$#"
-			count: 1
-			path: src/Service/GoogleGroupsService.php
-
-		-
-			message: "#^Service \"gaApplicationName\" is not registered in the container\\.$#"
-			count: 1
-			path: src/Service/GoogleGroupsService.php
-
-		-
-			message: "#^Service \"gaAuthJson\" is not registered in the container\\.$#"
-			count: 1
-			path: src/Service/GoogleGroupsService.php
-
-		-
-			message: "#^Service \"gaDomain\" is not registered in the container\\.$#"
-			count: 1
-			path: src/Service/GoogleGroupsService.php
-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,7 +1,22 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Call to static method getNormalizedFhir\\(\\) on an unknown class App\\\\Test\\\\Entity\\\\MeasurementTest\\.$#"
+			message: "#^Service \"gaAdminEmail\" is not registered in the container\\.$#"
 			count: 1
-			path: symfony/src/Controller/MeasurementsController.php
+			path: src/Service/GoogleGroupsService.php
+
+		-
+			message: "#^Service \"gaApplicationName\" is not registered in the container\\.$#"
+			count: 1
+			path: src/Service/GoogleGroupsService.php
+
+		-
+			message: "#^Service \"gaAuthJson\" is not registered in the container\\.$#"
+			count: 1
+			path: src/Service/GoogleGroupsService.php
+
+		-
+			message: "#^Service \"gaDomain\" is not registered in the container\\.$#"
+			count: 1
+			path: src/Service/GoogleGroupsService.php
 

--- a/src/Controller/MeasurementsController.php
+++ b/src/Controller/MeasurementsController.php
@@ -472,7 +472,7 @@ class MeasurementsController extends AbstractController
         }
         $fhir = $measurement->getFhir($date, $parentRdrId);
         if ($isTest) {
-            $fhir = \App\Test\Entity\MeasurementTest::getNormalizedFhir($fhir);
+            $fhir = \App\Tests\Entity\MeasurementTest::getNormalizedFhir($fhir);
             $response = new JsonResponse($fhir);
             $response->setEncodingOptions(JsonResponse::DEFAULT_ENCODING_OPTIONS | JSON_PRETTY_PRINT);
         } else {


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-935 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Wires in PHPStan to our Circle CI runs.

### Screenshots <!-- if applicable -->

![Screen Shot 2021-11-17 at 10 50 40 PM](https://user-images.githubusercontent.com/80459/142353978-70798370-a499-47cf-8b67-86e6a63ca21f.png)

