### PR TITLE
[HPRO-928] Fix column check/uncheck url

### DIFF
--- a/templates/partials/workqueue-consents-columns.html.twig
+++ b/templates/partials/workqueue-consents-columns.html.twig
@@ -1,6 +1,6 @@
 <div class="collapse navbar-collapse consent-columns" id="navbar-collapse-2">
     <ul class="nav navbar-nav">
-        <li class="dropdown columns-filter-group" id="columns_group">
+        <li class="dropdown columns-filter-group" id="columns_group" data-consent-columns-url="{{ path('workqueue_consent_columns') }}">
             <button href="#" class="dropdown-toggle btn btn-default" data-toggle="dropdown">
                 <i class="fa fa-columns" aria-hidden="true"></i> Columns
                 <b class="caret"></b>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.6.6 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-928 <!-- Tag which ticket(s) this PR relates to -->

### Summary
This `data-consent-columns-url` got removed when the UI is changed [Line](https://github.com/all-of-us/healthpro/pull/984/files#diff-c0451496feed1f82f1e34f692bf7774d2707e73c9f67b501a6b2521c0b241b68L11)