### PR TITLE
[HPRO-914] Log only if site admin emails change

### DIFF
--- a/src/Service/SiteSyncService.php
+++ b/src/Service/SiteSyncService.php
@@ -272,6 +272,9 @@ class SiteSyncService
     {
         $siteAdmins = [];
         $groupEmail = self::SITE_PREFIX . $site->getGoogleGroup() . '@' . $this->params->get('gaDomain');
+
+        error_log($groupEmail);
+
         $members = $this->googleGroupsService->getMembers($groupEmail, ['OWNER', 'MANAGER']);
         if (count($members) === 0) {
             return $siteAdmins;

--- a/src/Service/SiteSyncService.php
+++ b/src/Service/SiteSyncService.php
@@ -272,9 +272,6 @@ class SiteSyncService
     {
         $siteAdmins = [];
         $groupEmail = self::SITE_PREFIX . $site->getGoogleGroup() . '@' . $this->params->get('gaDomain');
-
-        error_log($groupEmail);
-
         $members = $this->googleGroupsService->getMembers($groupEmail, ['OWNER', 'MANAGER']);
         if (count($members) === 0) {
             return $siteAdmins;


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-914 <!-- Tag which ticket(s) this PR relates to -->

### Summary

This PR prevents extraneous log entries when the site admin emails are identical to the previous value.