### PR TITLE
[HPRO-963] Adjust gRoR column to link to PDF consent

### DIFF
--- a/src/Helper/WorkQueue.php
+++ b/src/Helper/WorkQueue.php
@@ -1007,22 +1007,6 @@ class WorkQueue
         return '';
     }
 
-    public static function displayGenomicsConsentStatus($value, $time, $userTimezone, $displayTime = true)
-    {
-        switch ($value) {
-            case 'SUBMITTED':
-                return self::HTML_SUCCESS . ' ' . self::dateFromString($time, $userTimezone, $displayTime) . ' (Consented Yes)';
-            case 'SUBMITTED_NO_CONSENT':
-                return self::HTML_SUCCESS . ' ' . self::dateFromString($time, $userTimezone, $displayTime) . ' (Refused Consent)';
-            case 'SUBMITTED_NOT_SURE':
-                return self::HTML_SUCCESS . ' ' . self::dateFromString($time, $userTimezone, $displayTime) . ' (Responded Not Sure)';
-            case 'SUBMITTED_INVALID':
-                return self::HTML_DANGER . ' ' . self::dateFromString($time, $userTimezone, $displayTime) . ' (Invalid)';
-            default:
-                return self::HTML_DANGER . ' (Consent Not Completed)';
-        }
-    }
-
     public static function displayEhrConsentExpireStatus(
         $consentForElectronicHealthRecords,
         $ehrConsentExpireStatus,

--- a/src/Helper/WorkQueue.php
+++ b/src/Helper/WorkQueue.php
@@ -122,7 +122,7 @@ class WorkQueue
             'rdrField' => 'consentForGenomicsROR',
             'sortField' => 'consentForGenomicsRORAuthored',
             'rdrDateField' => 'consentForGenomicsRORAuthored',
-            'method' => 'displayGenomicsConsentStatus',
+            'method' => 'displayConsentStatus',
             'htmlClass' => 'text-center',
             'toggleColumn' => true,
             'pdfPath' => 'consentForGenomicsRORFilePath'

--- a/src/Service/WorkQueueService.php
+++ b/src/Service/WorkQueueService.php
@@ -311,7 +311,7 @@ class WorkQueueService
                 $participant->ehrConsentExpireAuthored,
                 $userTimezone
             );
-            $row['gRoRConsent'] = WorkQueue::displayGenomicsConsentStatus(
+            $row['gRoRConsent'] = WorkQueue::displayConsentStatus(
                 $participant->consentForGenomicsROR,
                 $participant->consentForGenomicsRORAuthored,
                 $userTimezone,


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-963 <!-- Tag which ticket(s) this PR relates to -->

### Summary

The Genetic Return of Results (gRoR) column should use the `displayConsentStatus` method for rendering so that it can pick up the PDF link if available.
