### PR TITLE
[HPRO-965] Ensure Google Groups error not handled as empty response

### DIFF
--- a/src/Command/SyncSiteEmailsCommand.php
+++ b/src/Command/SyncSiteEmailsCommand.php
@@ -66,10 +66,17 @@ class SyncSiteEmailsCommand extends Command
             return 0;
         }
 
+        $returnCode = 0;
         foreach ($sites as $site) {
             $existingArray = $this->normalizer->normalize($site, null, [AbstractNormalizer::IGNORED_ATTRIBUTES => ['siteSync']]);
             $output->writeln($site->getName());
-            $siteAdmins = $this->siteSyncService->getSiteAdminEmails($site);
+            try {
+                $siteAdmins = $this->siteSyncService->getSiteAdminEmails($site);
+            } catch (\Exception $e) {
+                $output->writeln('ERROR: ' . $e->getMessage());
+                $returnCode = 1;
+                continue;
+            }
             if (count($siteAdmins) > 0) {
                 $output->writeln(' └ Setting: ' . join(', ', $siteAdmins));
             }
@@ -91,6 +98,6 @@ class SyncSiteEmailsCommand extends Command
         }
         $this->em->flush();
         $output->writeln('');
-        return 0;
+        return $returnCode;
     }
 }

--- a/src/Controller/AccessManagementController.php
+++ b/src/Controller/AccessManagementController.php
@@ -55,7 +55,12 @@ class AccessManagementController extends AbstractController
         if (empty($group)) {
             throw $this->createNotFoundException();
         }
-        $members = $this->googleGroupsService->getMembers($group->email);
+        try {
+            $members = $this->googleGroupsService->getMembers($group->email);
+        } catch (\Exception $e) {
+            $this->addFlash('error', 'Unable to retrieve member list for group.');
+            $members = [];
+        }
         return $this->render('accessmanagement/group-members.html.twig', [
             'group' => $group,
             'members' => $members,

--- a/src/Controller/SitesController.php
+++ b/src/Controller/SitesController.php
@@ -109,7 +109,16 @@ class SitesController extends AbstractController
         if (!$site) {
             throw $this->createNotFoundException('Site not found.');
         }
-        $emails = join(', ', $siteSyncService->getSiteAdminEmails($site));
+        try {
+            $emails = join(', ', $siteSyncService->getSiteAdminEmails($site));
+        } catch (\Exception $e) {
+            $this->addFlash('error', sprintf(
+                'Unable to retrieve email for %s (%s)',
+                $site->getName(),
+                $site->getSiteId(),
+            ));
+            return $this->redirectToRoute('admin_sites');
+        }
 
         if (!$env->isProd() && !$env->isLocal()) {
             $this->addFlash('error', sprintf(

--- a/src/Service/GoogleGroupsService.php
+++ b/src/Service/GoogleGroupsService.php
@@ -61,6 +61,7 @@ class GoogleGroupsService
                     $doRetry = true;
                     $retryCount++;
                 } else {
+                    error_log($e->getMessage());
                     throw $e;
                 }
             }
@@ -137,15 +138,11 @@ class GoogleGroupsService
         if (!empty($roles)) {
             $params['roles'] = join(',', $roles);
         }
-        try {
-            $result = $this->callApi('members', 'listMembers', [$groupEmail, $params]);
-            if ($result) {
-                return $result->getMembers();
-            }
-            return [];
-        } catch (GoogleException $e) {
-            return [];
+        $result = $this->callApi('members', 'listMembers', [$groupEmail, $params]);
+        if ($result) {
+            return $result->getMembers();
         }
+        return [];
     }
 
     public function getUser(string $user)

--- a/src/Service/SiteSyncService.php
+++ b/src/Service/SiteSyncService.php
@@ -273,6 +273,7 @@ class SiteSyncService
         $siteAdmins = [];
         $groupEmail = self::SITE_PREFIX . $site->getGoogleGroup() . '@' . $this->params->get('gaDomain');
         $members = $this->googleGroupsService->getMembers($groupEmail, ['OWNER', 'MANAGER']);
+
         if (count($members) === 0) {
             return $siteAdmins;
         }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-965 <!-- Tag which ticket(s) this PR relates to -->

### Summary

As currently written, our application treats any error from the Google Groups API "getMembers" call as an empty response. This could cause empty data to be written to the `sites.email` field. This PR handles the exception at the controller level, preventing invalid data from being written to the table.