### PR TITLE
[HPRO-963] Revert to use prior Genomics Consent Status icons

### DIFF
--- a/src/Helper/WorkQueue.php
+++ b/src/Helper/WorkQueue.php
@@ -122,7 +122,7 @@ class WorkQueue
             'rdrField' => 'consentForGenomicsROR',
             'sortField' => 'consentForGenomicsRORAuthored',
             'rdrDateField' => 'consentForGenomicsRORAuthored',
-            'method' => 'displayConsentStatus',
+            'method' => 'displayGenomicsConsentStatus',
             'htmlClass' => 'text-center',
             'toggleColumn' => true,
             'pdfPath' => 'consentForGenomicsRORFilePath'
@@ -990,6 +990,23 @@ class WorkQueue
                 return self::HTML_DANGER . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Refused Consent)';
             case 'SUBMITTED_NOT_SURE':
                 return self::HTML_WARNING . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Responded Not Sure)';
+            case 'SUBMITTED_INVALID':
+                return self::HTML_DANGER . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Invalid)';
+            default:
+                return self::HTML_DANGER . ' (Consent Not Completed)';
+        }
+    }
+
+    public static function displayGenomicsConsentStatus($value, $time, $userTimezone, $displayTime = true, $link = null)
+    {
+        switch ($value) {
+            // Note the icons differ from ::displayConsentStatus
+            case 'SUBMITTED':
+                return self::HTML_SUCCESS . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Consented Yes)';
+            case 'SUBMITTED_NO_CONSENT':
+                return self::HTML_SUCCESS . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Refused Consent)';
+            case 'SUBMITTED_NOT_SURE':
+                return self::HTML_SUCCESS . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Responded Not Sure)';
             case 'SUBMITTED_INVALID':
                 return self::HTML_DANGER . ' ' . self::dateFromString($time, $userTimezone, $displayTime, $link) . ' (Invalid)';
             default:

--- a/src/Service/WorkQueueService.php
+++ b/src/Service/WorkQueueService.php
@@ -311,7 +311,7 @@ class WorkQueueService
                 $participant->ehrConsentExpireAuthored,
                 $userTimezone
             );
-            $row['gRoRConsent'] = WorkQueue::displayConsentStatus(
+            $row['gRoRConsent'] = WorkQueue::displayGenomicsConsentStatus(
                 $participant->consentForGenomicsROR,
                 $participant->consentForGenomicsRORAuthored,
                 $userTimezone,


### PR DESCRIPTION

| Q                   | A
| ------------------- | --------------
| Target Release?     | 2.6.7 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-963 <!-- Tag which ticket(s) this PR relates to -->

### Summary

This restores the previous static method that had a slightly different set of icons while adding the capability to link content as requested.

