### PR TITLE
[HPRO-914] Update cron path for email sync job

### DIFF
--- a/cron.yaml.dist
+++ b/cron.yaml.dist
@@ -24,7 +24,7 @@ cron:
   schedule: every day 20:00
   timezone: America/Chicago
 - description: "Sync sites admin emails"
-  url: /s/cron/sites-email-sync
+  url: /cron/sites-email-sync
   schedule: every 1 hours
   timezone: America/Chicago
 - description: "Sync awardees and organizations"


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-914 <!-- Tag which ticket(s) this PR relates to -->

### Summary

The existing cron job path works as-is because of our redirect setup, but we can remove an extra hop.

