### PR TITLE
[HPRO-961] Add dashboard link to login page

### DIFF
--- a/dev_config/config.yml.dist
+++ b/dev_config/config.yml.dist
@@ -151,3 +151,6 @@ ehr_protocol_banner_message:
 
 # Displays participant consents tab in work queue
 # feature.participantconsentsworkqueue: false
+
+# Dashboard URL displayed on the login page
+# dashboard_url:

--- a/src/Controller/AuthController.php
+++ b/src/Controller/AuthController.php
@@ -7,6 +7,7 @@ use App\Service\AuthService;
 use App\Service\EnvironmentService;
 use App\Service\UserService;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,12 +18,13 @@ class AuthController extends AbstractController
     /**
      * @Route("/login", name="login")
      */
-    public function login(UserService $userService, Request $request, UserProviderInterface $userProvider, EnvironmentService $env, AuthService $authService, SessionInterface $session)
+    public function login(UserService $userService, Request $request, UserProviderInterface $userProvider, EnvironmentService $env, AuthService $authService, SessionInterface $session, ParameterBagInterface $params)
     {
         if ($this->getUser()) {
             return $this->redirectToRoute('home');
         }
 
+        $dashboardUrl = $params->has('dashboard_url') ? $params->get('dashboard_url') : null;
         if ($env->isLocal() && $userService->canMockLogin()) {
             $loginForm = $this->createForm(MockLoginType::class);
 
@@ -46,11 +48,14 @@ class AuthController extends AbstractController
             }
 
             return $this->render('login.html.twig', [
-                'loginForm' => $loginForm->createView()
+                'loginForm' => $loginForm->createView(),
+                'dashboardUrl' => $dashboardUrl
             ]);
         }
 
-        return $this->render('login.html.twig');
+        return $this->render('login.html.twig', [
+            'dashboardUrl' => $dashboardUrl
+        ]);
     }
 
     /**

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -4,7 +4,7 @@
 <meta charset="utf-8">
 <title>HealthPro Login</title>
 {% include 'base-head.html.twig' %}
-<link rel="stylesheet" href="/assets/css/login.css" />
+{{ encore_entry_link_tags('login') }}
 </head>
 <body>
     <div id="login-aou-banner">

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -18,19 +18,28 @@
                 </div>
                 <div id="login-action">
                     {% if loginForm is not defined %}
-                    <a href="{{ path('login_start') }}">
-                        <img src="/assets/img/login/sign-in-with-google.svg" alt="Sign in with Google" />
-                    </a>
+                        <div>
+                            <a href="{{ path('login_start') }}">
+                                <img src="/assets/img/login/sign-in-with-google.svg" alt="Sign in with Google" />
+                            </a>
+                        </div>
                     {% else %}
-                    <div class="text-left">
-                        <h4><i class="fa fa-sign-in" aria-hidden="true"></i> Mock Login</h4>
-                        {{ form_start(loginForm, { attr: { class: 'prevent-resubmit' } }) }}
-                        {{ form_widget(loginForm) }}
-                        <p>
-                            <button type="submit" class="btn btn-primary">Submit</button>
-                        </p>
-                        {{ form_end(loginForm) }}
-                    </div>
+                        <div class="text-left">
+                            <h4><i class="fa fa-sign-in" aria-hidden="true"></i> Mock Login</h4>
+                            {{ form_start(loginForm, { attr: { class: 'prevent-resubmit' } }) }}
+                            {{ form_widget(loginForm) }}
+                            <p>
+                                <button type="submit" class="btn btn-primary">Submit</button>
+                            </p>
+                            {{ form_end(loginForm) }}
+                        </div>
+                    {% endif %}
+
+                    {% if dashboardUrl %}
+                        <hr />
+                        <div class="links">
+                            <i class="fas fa-chart-line fa-fw"></i> <a href="{{ dashboardUrl }}">HealthPro Dashboards</a>
+                        </div>
                     {% endif %}
                 </div>
                 <div id="login-help">

--- a/web/assets/css/login.css
+++ b/web/assets/css/login.css
@@ -1,6 +1,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans&display=swap');
 html {
-    background: url('/assets/img/login/login-background.jpg') no-repeat center center fixed;
+    background: url('../img/login/login-background.jpg') no-repeat center center fixed;
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;

--- a/web/assets/css/login.css
+++ b/web/assets/css/login.css
@@ -34,6 +34,14 @@ body {
 #login-action img {
     max-width: 250px;
 }
+#login-action hr {
+    border-top: 2px solid #ddd;
+    width: 75%;
+    margin: 40px auto;
+}
+#login-action .links {
+    font-size: 1.8rem;
+}
 #login-copyright {
     font-size: 1rem;
     position: absolute;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ Encore
      * and one CSS file (e.g. app.css) if your JavaScript imports CSS.
      */
     .addEntry('app', './web/assets/js/app.js')
+    .addEntry('login', './web/assets/css/login.css')
     .addEntry('workqueue', './web/assets/js/views/workqueue.js')
     .addEntry('workqueue-consents', './web/assets/js/views/WorkQueueConsents.js')
     .addEntry('order-check', './web/assets/js/views/OrderSafetyChecks.js')


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ✅ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-961

### Summary

Adds the dashboard link to the login landing page. I made this configurable so that the URL can be changed or removed in the future without needing to deploy new code.

The new configuration item is `dashboard_url`. You will need to add that to test. See the JIRA ticket for the currently requested URL.

I also added the standalone `login.css` file to our webpack config and swapped out the direct CSS include for the webpack entrypoint.

### Instructions for testing

1. Add the `dashboard_url` configuration parameter to your local `dev_config/config.yml` file.
2. Run `npm encore dev` to build the new login entrypoint.

Note that if the `dashboard_url` configuration isn't set, the login page should not include the link and should look exactly as it does before this change.

### Screenshots

![Screen Shot 2021-12-06 at 1 04 58 PM](https://user-images.githubusercontent.com/860499/144907249-566b7df9-6a0e-41ef-9694-0daaaef3e4ad.png)

![Screen Shot 2021-12-06 at 1 04 52 PM](https://user-images.githubusercontent.com/860499/144907260-ba2b8a56-b7f3-4333-bc1c-f9ad993a77ee.png)


