### PR TITLE
[HPRO-980] Update Docker image with the latest gcloud version and python 3 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN mkdir -p /usr/share/man/man1
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
       && apt-get update \
       && apt-get install -y --no-install-recommends \
-        libpython2.7-stdlib \
         default-mysql-client \
         git-all \
         nodejs \
@@ -25,9 +24,9 @@ RUN MAKEFLAGS="-j $(nproc)" pecl install grpc \
 
 # Google Cloud Tools
 WORKDIR /opt
-RUN export CLOUDSDK_PYTHON=/usr/bin/python \
-      && curl -Os https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-267.0.0-linux-x86_64.tar.gz \
-      && tar -xzf google-cloud-sdk-267.0.0-linux-x86_64.tar.gz \
+RUN export CLOUDSDK_PYTHON=/usr/bin/python3 \
+      && curl -Os https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-367.0.0-linux-x86_64.tar.gz \
+      && tar -xzf google-cloud-sdk-367.0.0-linux-x86_64.tar.gz \
       && /opt/google-cloud-sdk/install.sh --quiet --path-update true \
       && /opt/google-cloud-sdk/bin/gcloud components install --quiet beta cloud-datastore-emulator \
       && /opt/google-cloud-sdk/bin/gcloud config set project pmi-hpo-dev \


### PR DESCRIPTION
Co-Authored-By: Jason Tan <860499+jt2k@users.noreply.github.com>

| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-980<!-- Tag which ticket(s) this PR relates to -->

### Summary
Upgrade gcloud sdk to support python3