### PR TITLE
[HPRO-1020] Display the type of biobank order created on the in-person enrollment tab order overview. (Blood, Urine, Saliva)

### DIFF
--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -1145,6 +1145,16 @@ class Order
         return false;
     }
 
+    public function getUrineSample()
+    {
+        foreach ($this->samples as $sample) {
+            if (in_array($sample, self::$nonBloodSamples)) {
+                return $sample;
+            }
+        }
+        return null;
+    }
+
     // Returns sample's code and display text
     public function getCustomRequestedSamples()
     {

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -1490,7 +1490,7 @@ class Order
     public function isUrineOrder(): bool
     {
         $requestedSamples = json_decode($this->requestedSamples, true);
-        return count($requestedSamples) === 1 && empty(array_diff($requestedSamples, self::$urineSamples));
+        return is_array($requestedSamples) && empty(array_diff($requestedSamples, self::$urineSamples));
     }
 
     public function getOrderTypeDisplayText(): string

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -62,6 +62,8 @@ class Order
 
     public static $nonBloodSamples = ['1UR10', '1UR90', '1SAL', '1SAL2'];
 
+    public static $urineSamples = ['1UR10', '1UR90'];
+
     public static $mapRdrSamples = [
         '1SST8' => [
             'code' => '1SS08',
@@ -1483,5 +1485,30 @@ class Order
         ];
         $this->setBiobankFinalized(1);
         $this->setBiobankChanges(json_encode($biobankChanges));
+    }
+
+    public function isUrineOrder(): bool
+    {
+        $requestedSamples = json_decode($this->requestedSamples, true);
+        return count($requestedSamples) === 1 && empty(array_diff($requestedSamples, self::$urineSamples));
+    }
+
+    public function getOrderTypeDisplayText(): string
+    {
+        if (!empty($this->requestedSamples)) {
+            if ($this->isUrineOrder()) {
+                return 'Urine';
+            }
+            if ($this->type !== 'kit') {
+                return 'Custom HPO';
+            }
+        }
+        if ($this->type === 'kit') {
+            return 'Full Kit';
+        }
+        if ($this->type === 'saliva') {
+            return 'Saliva';
+        }
+        return 'Full HPO';
     }
 }

--- a/templates/biobank/orders-quanum-today.html.twig
+++ b/templates/biobank/orders-quanum-today.html.twig
@@ -57,7 +57,7 @@
                     {{ _self.displayDate(order.collectedTs) }}
                 </td>
                 <td data-order="{{ order.processedTs ? order.processedTs|date('Y-m-d H:i:s', false) : '' }}">
-                    {{ _self.displayDate(order.processedTs) }}
+                    {{ order.type != 'saliva' ? _self.displayDate(order.processedTs) : '--' }}
                 </td>
                 <td data-order="{{ order.finalizedTs ? order.finalizedTs|date('Y-m-d H:i:s', false) : '' }}">
                     {{ _self.displayDate(order.finalizedTs) }}

--- a/templates/biobank/orders-recent-modify.html.twig
+++ b/templates/biobank/orders-recent-modify.html.twig
@@ -57,10 +57,10 @@
                     {{ macros.displaySite(order.collected_site_name, order.collected_site) }}
                 </td>
                 <td data-order="{{ order.processed_ts }}">
-                    {{ macros.displayDate(order, 'processed_ts') }}
+                    {{ order.type != 'saliva' ? macros.displayDate(order, 'processed_ts') : '--' }}
                 </td>
                 <td>
-                    {{ macros.displaySite(order.processed_site_name, order.processed_site) }}
+                    {{ order.type != 'saliva' ? macros.displaySite(order.processed_site_name, order.processed_site) : '--' }}
                 </td>
                 <td data-order="{{ order.finalized_ts }}">
                     {% if order.oh_type != 'unlock' %}

--- a/templates/biobank/orders-today.html.twig
+++ b/templates/biobank/orders-today.html.twig
@@ -61,10 +61,10 @@
                     {{ macros.displaySite(order.collected_site_name, order.collected_site) }}
                 </td>
                 <td data-order="{{ order.processed_ts }}">
-                    {{ macros.displayDate(order, 'processed_ts') }}
+                    {{ order.type != 'saliva' ? macros.displayDate(order, 'processed_ts') : '--'}}
                 </td>
                 <td>
-                    {{ macros.displaySite(order.processed_site_name, order.processed_site) }}
+                    {{ order.type != 'saliva' ? macros.displaySite(order.processed_site_name, order.processed_site) : '--' }}
                 </td>
                 <td data-order="{{ order.finalized_ts is defined }}">
                     {% set showOrderFinalizedTs = order.finalized_ts and order.h_type != 'unlock' and not (order.finalized_ts and order.rdr_id is empty) %}

--- a/templates/biobank/orders-unfinalized.html.twig
+++ b/templates/biobank/orders-unfinalized.html.twig
@@ -57,10 +57,10 @@
                     {{ macros.displaySite(order.collected_site_name, order.collected_site) }}
                 </td>
                 <td data-order="{{ order.processed_ts }}">
-                    {{ macros.displayDate(order, 'processed_ts') }}
+                    {{ order.type != 'saliva' ? macros.displayDate(order, 'processed_ts') : '--' }}
                 </td>
                 <td>
-                    {{ macros.displaySite(order.processed_site_name, order.processed_site) }}
+                    {{ order.type != 'saliva' ? macros.displaySite(order.processed_site_name, order.processed_site) : '--' }}
                 </td>
             </tr>
         {% endfor %}

--- a/templates/biobank/orders-unlocked.html.twig
+++ b/templates/biobank/orders-unlocked.html.twig
@@ -53,10 +53,10 @@
                     {{ macros.displaySite(order.collected_site_name, order.collected_site) }}
                 </td>
                 <td data-order="{{ order.processed_ts }}">
-                    {{ macros.displayDate(order, 'processed_ts') }}
+                    {{ order.type != 'saliva' ? macros.displayDate(order, 'processed_ts') : '--' }}
                 </td>
                 <td>
-                    {{ macros.displaySite(order.processed_site_name, order.processed_site) }}
+                    {{ order.type != 'saliva' ? macros.displaySite(order.processed_site_name, order.processed_site) : '--' }}
                 </td>
             </tr>
         {% endfor %}

--- a/templates/order/print-requisition.html.twig
+++ b/templates/order/print-requisition.html.twig
@@ -40,6 +40,7 @@
 {% endblock %}
 
 {% block pagejs %}
+    {{ encore_entry_script_tags('order-sub') }}
     <script>
         $(document).ready(function () {
             $('#requisition-loaded').hide();
@@ -56,6 +57,9 @@
                     // https://github.com/mozilla/pdf.js/issues/5397
                     $('#requisition-loading-widget').hide();
                 }
+            });
+            new PMI.views['OrderSubPage']({
+                el: $("body")
             });
         });
     </script>

--- a/templates/partials/participant-orders-list.html.twig
+++ b/templates/partials/participant-orders-list.html.twig
@@ -43,6 +43,8 @@
                             <span class="label label-default">Collected</span> {{ order.collectedTs|date('n/j/Y g:ia', app.user.timezone) }}
                         {% endif %}
                     </small>
+                    {% if order.collectedTs %} <br/> {% endif %}
+                    <small>Order Type: {{ order.orderTypeDisplayText }}</small>
                     </a>
             {% endfor %}
             {% if type is not defined and orders|length > 5 %}

--- a/tests/Entity/OrderTest.php
+++ b/tests/Entity/OrderTest.php
@@ -398,27 +398,28 @@ class OrderTest extends TestCase
         $this->assertSame(true, $order->canUnlock());
     }
 
-    public function testOrderTypeDisplayText()
+    /**
+     * @dataProvider orderTypeProvider
+     */
+    public function testOrderTypeDisplayText($orderDisplayText, $orderType, $requestedSamples)
     {
         $orderData = $this->getOrderData();
         $order = $this->createOrder($orderData);
 
-        // DV Kit orders
-        $order->setType('kit');
-        self::assertEquals('Full Kit', $order->getOrderTypeDisplayText());
-        $order->setRequestedSamples('["1UR10"]');
-        self::assertEquals('Urine', $order->getOrderTypeDisplayText());
+        $order->setType($orderType);
+        $order->setRequestedSamples($requestedSamples);
+        self::assertEquals($orderDisplayText, $order->getOrderTypeDisplayText());
+    }
 
-        // HPO orders
-        $order->setType(null);
-        $order->setRequestedSamples('["1SS08", "1PS08", "1UR10"]');
-        self::assertEquals('Custom HPO', $order->getOrderTypeDisplayText());
-        $order->setRequestedSamples(null);
-        self::assertEquals('Full HPO', $order->getOrderTypeDisplayText());
-        $order->setType('saliva');
-        self::assertEquals('Saliva', $order->getOrderTypeDisplayText());
-        $order->setType(null);
-        $order->setRequestedSamples('["1UR10"]');
-        self::assertEquals('Urine', $order->getOrderTypeDisplayText());
+    public function orderTypeProvider(): array
+    {
+        return [
+            ['Full Kit', 'kit', null],
+            ['Urine', 'kit', '["1UR10"]'],
+            ['Custom HPO', null, '["1SS08", "1PS08", "1UR10"]'],
+            ['Full HPO', null, null],
+            ['Saliva', 'saliva', null],
+            ['Urine', null, '["1UR10"]']
+        ];
     }
 }

--- a/tests/Entity/OrderTest.php
+++ b/tests/Entity/OrderTest.php
@@ -397,4 +397,28 @@ class OrderTest extends TestCase
         $orderHistory->setType('active');
         $this->assertSame(true, $order->canUnlock());
     }
+
+    public function testOrderTypeDisplayText()
+    {
+        $orderData = $this->getOrderData();
+        $order = $this->createOrder($orderData);
+
+        // DV Kit orders
+        $order->setType('kit');
+        self::assertEquals('Full Kit', $order->getOrderTypeDisplayText());
+        $order->setRequestedSamples('["1UR10"]');
+        self::assertEquals('Urine', $order->getOrderTypeDisplayText());
+
+        // HPO orders
+        $order->setType(null);
+        $order->setRequestedSamples('["1SS08", "1PS08", "1UR10"]');
+        self::assertEquals('Custom HPO', $order->getOrderTypeDisplayText());
+        $order->setRequestedSamples(null);
+        self::assertEquals('Full HPO', $order->getOrderTypeDisplayText());
+        $order->setType('saliva');
+        self::assertEquals('Saliva', $order->getOrderTypeDisplayText());
+        $order->setType(null);
+        $order->setRequestedSamples('["1UR10"]');
+        self::assertEquals('Urine', $order->getOrderTypeDisplayText());
+    }
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅<!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1020 <!-- Tag which ticket(s) this PR relates to -->