### PR TITLE
[HPRO-1089] PHPStan level 2: Part II

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
     "require": {
         "ext-ctype": "*",
         "ext-iconv": "*",
+        "ext-json" : "*",
         "beberlei/doctrineextensions": "^1.2",
         "composer/package-versions-deprecated": "1.11.99.4",
         "doctrine/doctrine-bundle": "^2.4",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,5 @@
-includes:
-	- phpstan-baseline.neon
-
 parameters:
-	level: 1
+	level: 2
 	paths:
 		- src
 	bootstrapFiles:

--- a/src/Command/ReleaseTicketCommand.php
+++ b/src/Command/ReleaseTicketCommand.php
@@ -3,6 +3,7 @@
 namespace App\Command;
 
 use App\Service\JiraService;
+use stdClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -65,6 +66,7 @@ class ReleaseTicketCommand extends Command
         $tableHeaders = ['Version', 'Released?', 'Release Date', 'Tickets (Done / Total)'];
         $tableRows = [];
         $releaseDateMap = [];
+        /** @var stdClass $version */
         foreach ($versions as $version) {
             $totalIssues = $completedIssues = 0;
             foreach ($version->issuesStatusForFixVersion as $type => $count) {

--- a/src/Controller/DeceasedReportsController.php
+++ b/src/Controller/DeceasedReportsController.php
@@ -27,8 +27,7 @@ class DeceasedReportsController extends BaseController
     public function __construct(
         ParameterBagInterface $params,
         EntityManagerInterface $em
-    )
-    {
+    ) {
         parent::__construct($em);
         $this->cache = new DatastoreAdapter($params->get('ds_clean_up_limit'));
     }

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -4,7 +4,6 @@ namespace App\Controller;
 
 use App\Entity\Order;
 use App\Entity\Site;
-use App\Entity\User;
 use App\Form\OrderCreateType;
 use App\Form\OrderModifyType;
 use App\Form\OrderRevertType;
@@ -22,6 +21,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Csrf\CsrfToken;
@@ -415,7 +415,8 @@ class OrderController extends BaseController
      * @Route("/participant/{participantId}/order/{orderId}/finalize", name="order_finalize")
      * @Route("/read/participant/{participantId}/order/{orderId}/finalize", name="read_order_finalize", methods={"GET"})
      */
-    public function orderFinalizeAction($participantId, $orderId, Request $request, SessionInterface $session)
+    // @ToDo - Replace SessionInterface with Symfony\Component\HttpFoundation\Session
+    public function orderFinalizeAction($participantId, $orderId, Request $request, Session $session)
     {
         $order = $this->loadOrder($participantId, $orderId);
         $wasPrintRequisitionStepAvailable = in_array('print_requisition', $order->getAvailableSteps());

--- a/src/Controller/PatientStatusController.php
+++ b/src/Controller/PatientStatusController.php
@@ -14,6 +14,7 @@ use App\Form\PatientStatusImportConfirmFormType;
 use App\Service\PatientStatusService;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\SubmitButton;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -98,7 +99,9 @@ class PatientStatusController extends BaseController
         $form = $this->createForm(PatientStatusImportConfirmFormType::class);
         $form->handleRequest($request);
         if ($form->isSubmitted() && $form->isValid()) {
-            if ($form->get('Confirm')->isClicked()) {
+            /** @var SubmitButton $confirmButton */
+            $confirmButton = $form->get('Confirm');
+            if ($confirmButton->isClicked()) {
                 // Update confirm status
                 $patientStatusImport->setConfirm(1);
                 $this->em->flush();

--- a/src/Controller/ProblemController.php
+++ b/src/Controller/ProblemController.php
@@ -208,7 +208,7 @@ class ProblemController extends BaseController
             throw $this->createAccessDeniedException('Participant ineligible for problem report.');
         }
         $problem = $problemRepository->findOneBy(['id' => $problemId, 'participantId' => $participantId]);
-        if (!$problem && !$problem->getFinalizedTs()) {
+        if (is_null($problem)) {
             throw $this->createNotFoundException('Problem report not found.');
         }
 

--- a/src/Entity/Measurement.php
+++ b/src/Entity/Measurement.php
@@ -7,6 +7,7 @@ use App\Model\Measurement\Fhir;
 use App\Exception\InvalidSchemaException;
 use App\Exception\MissingSchemaException;
 use App\Helper\Util;
+use stdClass;
 
 /**
  * @ORM\Table(name="evaluations", indexes={
@@ -347,7 +348,7 @@ class Measurement
         if (empty($this->currentVersion) && empty($this->version)) {
             $this->currentVersion = self::CURRENT_VERSION;
         }
-        $data = empty($this->getData()) ? new \StdClass() : $this->getData();
+        $data = empty($this->getData()) ? new StdClass() : $this->getData();
         if (is_object($data)) {
             $this->fieldData = $data;
         } else {
@@ -412,6 +413,7 @@ class Measurement
                 $this->fieldData->$key = $this->fieldData->$key->format('Y-m-d');
             }
         }
+        /** @var stdClass $field */
         foreach ($this->schema->fields as $field) {
             if (isset($field->replicates)) {
                 $key = $field->name;
@@ -626,6 +628,7 @@ class Measurement
     public function getWarnings()
     {
         $warnings = [];
+        /** @var stdClass $metric */
         foreach ($this->schema->fields as $metric) {
             if (!empty($metric->warnings) && is_array($metric->warnings)) {
                 $warnings[$metric->name] = $metric->warnings;
@@ -637,6 +640,7 @@ class Measurement
     public function getConversions()
     {
         $conversions = [];
+        /** @var stdClass $metric */
         foreach ($this->schema->fields as $metric) {
             if (!empty($metric->convert)) {
                 $conversions[$metric->name] = $metric->convert;

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -2,6 +2,8 @@
 
 namespace App\Entity;
 
+use DateTime;
+use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -359,12 +361,12 @@ class Order
         return $this;
     }
 
-    public function getCreatedTs(): ?\DateTimeInterface
+    public function getCreatedTs(): ?DateTime
     {
         return $this->createdTs;
     }
 
-    public function setCreatedTs(\DateTimeInterface $createdTs): self
+    public function setCreatedTs(DateTime $createdTs): self
     {
         $this->createdTs = $createdTs;
 
@@ -407,12 +409,12 @@ class Order
         return $this;
     }
 
-    public function getPrintedTs(): ?\DateTimeInterface
+    public function getPrintedTs(): ?DateTimeInterface
     {
         return $this->printedTs;
     }
 
-    public function setPrintedTs(?\DateTimeInterface $printedTs): self
+    public function setPrintedTs(?DateTimeInterface $printedTs): self
     {
         $this->printedTs = $printedTs;
 
@@ -443,12 +445,12 @@ class Order
         return $this;
     }
 
-    public function getCollectedTs(): ?\DateTimeInterface
+    public function getCollectedTs(): ?DateTime
     {
         return $this->collectedTs;
     }
 
-    public function setCollectedTs(?\DateTimeInterface $collectedTs): self
+    public function setCollectedTs(?DateTime $collectedTs): self
     {
         $this->collectedTs = $collectedTs;
 
@@ -503,12 +505,12 @@ class Order
         return $this;
     }
 
-    public function getProcessedTs(): ?\DateTimeInterface
+    public function getProcessedTs(): ?DateTimeInterface
     {
         return $this->processedTs;
     }
 
-    public function setProcessedTs(?\DateTimeInterface $processedTs): self
+    public function setProcessedTs(?DateTimeInterface $processedTs): self
     {
         $this->processedTs = $processedTs;
 
@@ -575,12 +577,12 @@ class Order
         return $this;
     }
 
-    public function getFinalizedTs(): ?\DateTimeInterface
+    public function getFinalizedTs(): ?DateTimeInterface
     {
         return $this->finalizedTs;
     }
 
-    public function setFinalizedTs(?\DateTimeInterface $finalizedTs): self
+    public function setFinalizedTs(?DateTimeInterface $finalizedTs): self
     {
         $this->finalizedTs = $finalizedTs;
 
@@ -1017,7 +1019,7 @@ class Order
             $processedSampleTimes = json_decode($this->getProcessedSamplesTs(), true);
             if (!empty($processedSampleTimes[$sample])) {
                 try {
-                    $time = new \DateTime();
+                    $time = new DateTime();
                     $time->setTimestamp($processedSampleTimes[$sample]);
                     return $time->format('Y-m-d\TH:i:s\Z');
                 } catch (\Exception $e) {
@@ -1350,7 +1352,7 @@ class Order
 
         $biobankChanges = !empty($this->getBiobankChanges()) ? json_decode($this->getBiobankChanges(), true) : [];
         if (!empty($biobankChanges['collected']['time'])) {
-            $collectedTs = new \DateTime();
+            $collectedTs = new DateTime();
             $collectedTs->setTimestamp($biobankChanges['collected']['time']);
             $collectedTs->setTimezone(new \DateTimeZone($timeZone));
             $biobankChanges['collected']['time'] = $collectedTs;
@@ -1370,7 +1372,7 @@ class Order
             foreach ($biobankChanges['processed']['samples_ts'] as $sample => $time) {
                 $sampleDetails[$sample]['code'] = array_search($sample, $this->getCustomRequestedSamples());
                 $sampleDetails[$sample]['color'] = $samplesInfo[$sample]['color'];
-                $processedTs = new \DateTime();
+                $processedTs = new DateTime();
                 $processedTs->setTimestamp($time);
                 $processedTs->setTimezone(new \DateTimeZone($timeZone));
                 $sampleDetails[$sample]['time'] = $processedTs;
@@ -1383,7 +1385,7 @@ class Order
         }
 
         if (!empty($biobankChanges['finalized']['time'])) {
-            $collectedTs = new \DateTime();
+            $collectedTs = new DateTime();
             $collectedTs->setTimestamp($biobankChanges['finalized']['time']);
             $collectedTs->setTimezone(new \DateTimeZone($timeZone));
             $biobankChanges['finalized']['time'] = $collectedTs;

--- a/src/Entity/PatientStatusImport.php
+++ b/src/Entity/PatientStatusImport.php
@@ -167,7 +167,7 @@ class PatientStatusImport
     {
         if (!$this->PatientStatusImportRows->contains($PatientStatusImportRow)) {
             $this->PatientStatusImportRows[] = $PatientStatusImportRow;
-            $PatientStatusImportRow->setImportId($this);
+            $PatientStatusImportRow->setImport($this);
         }
 
         return $this;
@@ -178,8 +178,8 @@ class PatientStatusImport
         if ($this->PatientStatusImportRows->contains($PatientStatusImportRow)) {
             $this->PatientStatusImportRows->removeElement($PatientStatusImportRow);
             // set the owning side to null (unless already changed)
-            if ($PatientStatusImportRow->getImportId() === $this) {
-                $PatientStatusImportRow->setImportId(null);
+            if ($PatientStatusImportRow->getImport()->getId() === $this->getId()) {
+                $PatientStatusImportRow->setImport(null);
             }
         }
 

--- a/src/Helper/Util.php
+++ b/src/Helper/Util.php
@@ -8,7 +8,7 @@ class Util
 {
     public static function generateUuid()
     {
-        return (string)Uuid::uuid4();
+        return Uuid::uuid4()->toString();
     }
 
     public static function generateShortUuid($length = 16, $upper = true)

--- a/src/Helper/WorkQueue.php
+++ b/src/Helper/WorkQueue.php
@@ -2461,6 +2461,7 @@ class WorkQueue
     {
         if ($digitalHealthSharingStatus) {
             if (isset($digitalHealthSharingStatus->{$type}->status)) {
+                /** @phpstan-ignore-next-line */
                 $authoredDate = $digitalHealthSharingStatus->{$type}->history[0]->authoredTime ?? '';
                 if ($digitalHealthSharingStatus->{$type}->status === 'YES') {
                     return self::HTML_SUCCESS . ' ' . self::dateFromString($authoredDate, $userTimezone);

--- a/src/Model/Measurement/Fhir.php
+++ b/src/Model/Measurement/Fhir.php
@@ -4,6 +4,7 @@ namespace App\Model\Measurement;
 
 use App\Entity\Measurement;
 use App\Helper\Util;
+use stdClass;
 
 class Fhir
 {
@@ -62,6 +63,7 @@ class Fhir
     protected function getMetricUrns()
     {
         $metrics = [];
+        /** @var stdClass $field */
         foreach ($this->schema->fields as $field) {
             if (preg_match('/^blood-pressure-/', $field->name)) {
                 if (!preg_match('/^blood-pressure-(systolic|protocol-modification)/', $field->name)) {
@@ -1147,7 +1149,7 @@ class Fhir
 
     public function toObject()
     {
-        $fhir = new \StdClass();
+        $fhir = new StdClass();
         $fhir->entry = [];
         $fhir->resourceType = 'Bundle';
         $fhir->type = 'document';

--- a/src/Security/GoogleGroupsAuthenticator.php
+++ b/src/Security/GoogleGroupsAuthenticator.php
@@ -80,6 +80,10 @@ class GoogleGroupsAuthenticator extends AbstractGuardAuthenticator
         if (!$this->env->isProd() && $this->params->has('gaBypass') && $this->params->get('gaBypass')) {
             return true; // Bypass groups auth
         }
+        if (!($user instanceof User)) {
+            throw new Exception("Invalid user type");
+        }
+
         $valid2fa = !($this->params->has('enforce2fa') && $this->params->get('enforce2fa')) || $user->hasTwoFactorAuth();
         $this->authEmail = $user->getUsername();
         if (!$valid2fa) {

--- a/src/Service/DeceasedReportsService.php
+++ b/src/Service/DeceasedReportsService.php
@@ -52,10 +52,6 @@ class DeceasedReportsService
         return json_decode($response->getBody());
     }
 
-    /**
-     * @var array $data
-     * @var User $actor
-     */
     public function buildDeceasedReportFhir(DeceasedReport $deceasedReport, User $actor)
     {
         $report = [
@@ -112,10 +108,6 @@ class DeceasedReportsService
         return $report;
     }
 
-    /**
-     * @var array $data
-     * @var User $actor
-     */
     public function buildDeceasedReportReviewFhir(DeceasedReport $deceasedReport, User $actor)
     {
         $report = [

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -6,7 +6,9 @@ use App\Entity\Order;
 use App\Entity\OrderHistory;
 use App\Entity\Site;
 use App\Entity\User;
+use DateTime;
 use Doctrine\ORM\EntityManagerInterface;
+use stdClass;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use App\Audit\Log;
 
@@ -184,7 +186,7 @@ class OrderService
         }
         $result = ['status' => 'fail'];
         // Set collected time to created date at midnight local time
-        $collectedAt = new \DateTime($this->order->getCreatedTs()->format('Y-m-d'), new \DateTimeZone($this->userService->getUser()->getTimezone()));
+        $collectedAt = new DateTime($this->order->getCreatedTs()->format('Y-m-d'), new \DateTimeZone($this->userService->getUser()->getTimezone()));
         if ($site = $this->em->getRepository(Site::class)->findOneBy(['deleted' => 0, 'googleGroup' => $this->siteService->getSiteId()])) {
             $mayoClientId = $site->getMayolinkAccount();
         }
@@ -407,7 +409,7 @@ class OrderService
             foreach (Order::$samplesRequiringProcessing as $sample) {
                 if (!empty($processedSampleTimes[$sample])) {
                     try {
-                        $sampleTs = new \DateTime();
+                        $sampleTs = new DateTime();
                         $sampleTs->setTimestamp($processedSampleTimes[$sample]);
                         $sampleTs->setTimezone(new \DateTimeZone($this->userService->getUser()->getTimezone()));
                         $formData['processedSamplesTs'][$sample] = $sampleTs;
@@ -436,7 +438,7 @@ class OrderService
         }
         $result = ['status' => 'fail'];
         // Set collected time to user local time
-        $collectedAt = new \DateTime($this->order->getCollectedTs()->format('Y-m-d H:i:s'), new \DateTimeZone($this->userService->getUser()->getTimezone()));
+        $collectedAt = new DateTime($this->order->getCollectedTs()->format('Y-m-d H:i:s'), new \DateTimeZone($this->userService->getUser()->getTimezone()));
         // Check if mayo account number exists
         if (!empty($mayoClientId)) {
             $birthDate = $this->params->has('ml_real_dob') ? $this->participant->dob : $this->participant->getMayolinkDob();
@@ -544,7 +546,7 @@ class OrderService
             if (!empty($this->order->getProcessedSamplesTs())) {
                 $processedSamplesTs = json_decode($this->order->getProcessedSamplesTs(), true);
                 if (!empty($processedSamplesTs[$value])) {
-                    $processedTs = new \DateTime();
+                    $processedTs = new DateTime();
                     $processedTs->setTimestamp($processedSamplesTs[$value]);
                     $processedTs->setTimezone(new \DateTimeZone($this->userService->getUser()->getTimezone()));
                     $sample['processed_ts'] = $processedTs;
@@ -574,7 +576,7 @@ class OrderService
             $orderHistory->setUser($userRepository->find($this->userService->getUser()->getId()));
             $orderHistory->setSite($this->siteService->getSiteId());
             $orderHistory->setType($type === Order::ORDER_REVERT ? Order::ORDER_ACTIVE : $type);
-            $orderHistory->setCreatedTs(new \DateTime());
+            $orderHistory->setCreatedTs(new DateTime());
             $this->em->persist($orderHistory);
             $this->em->flush();
             $this->loggerService->log(Log::ORDER_HISTORY_CREATE, ['id' => $orderHistory->getId(), 'type' => $orderHistory->getType()]);
@@ -613,7 +615,7 @@ class OrderService
                 }
                 if (!empty($sample->processed)) {
                     $processedSamples[] = $sampleCode;
-                    $processedTs = new \DateTime($sample->processed);
+                    $processedTs = new DateTime($sample->processed);
                     $processedSamplesTs[$sampleCode] = $processedTs->getTimestamp();
                 }
                 if (!empty($sample->finalized)) {
@@ -640,11 +642,11 @@ class OrderService
         $connection->beginTransaction();
         try {
             $this->order->setCollectedSamples(json_encode(!empty($collectedSamples) ? $collectedSamples : []));
-            $this->order->setCollectedTs(!empty($collectedTs) ? new \DateTime($collectedTs) : null);
+            $this->order->setCollectedTs(!empty($collectedTs) ? new DateTime($collectedTs) : null);
             $this->order->setProcessedSamples(json_encode(!empty($processedSamples) ? $processedSamples : []));
             $this->order->setProcessedSamplesTs(json_encode(!empty($processedSamplesTs) ? $processedSamplesTs : []));
             $this->order->setFinalizedSamples(json_encode(!empty($finalizedSamples) ? $finalizedSamples : []));
-            $this->order->setFinalizedTs(!empty($finalizedTs) ? new \DateTime($finalizedTs) : null);
+            $this->order->setFinalizedTs(!empty($finalizedTs) ? new DateTime($finalizedTs) : null);
             $this->order->setCollectedNotes($collectedNotes);
             $this->order->setProcessedNotes($processedNotes);
             $this->order->setFinalizedNotes($finalizedNotes);
@@ -670,7 +672,7 @@ class OrderService
         return !$this->participant->status && !empty($this->order->getId()) ? $this->participant->editExistingOnly : $this->participant->status;
     }
 
-    public function loadFromJsonObject($object)
+    public function loadFromJsonObject(stdClass $object)
     {
         if (!empty($object->samples)) {
             foreach ($object->samples as $sample) {
@@ -686,7 +688,7 @@ class OrderService
                 if (!empty($sample->processed)) {
                     $processedSamples[] = $sampleCode;
                     $processedTs = $sample->processed;
-                    $processedSamplesTs[$sampleCode] = (new \DateTime($sample->processed))->getTimestamp();
+                    $processedSamplesTs[$sampleCode] = (new DateTime($sample->processed))->getTimestamp();
                 }
                 if (!empty($sample->finalized)) {
                     $finalizedSamples[] = $sampleCode;
@@ -726,16 +728,16 @@ class OrderService
         }
         $this->order->setType('kit');
         if (!empty($object->created)) {
-            $this->order->setCreatedTs(new \DateTime($object->created));
+            $this->order->setCreatedTs(new DateTime($object->created));
         }
         if (!empty($processedTs)) {
-            $this->order->setProcessedTs(new \DateTime($processedTs));
+            $this->order->setProcessedTs(new DateTime($processedTs));
         }
         if (!empty($collectedTs)) {
-            $this->order->setCollectedTs(new \DateTime($collectedTs));
+            $this->order->setCollectedTs(new DateTime($collectedTs));
         }
         if (!empty($finalizedTs)) {
-            $this->order->setFinalizedTs(new \DateTime($finalizedTs));
+            $this->order->setFinalizedTs(new DateTime($finalizedTs));
         }
         $this->order->setProcessedCentrifugeType((!empty($centrifugeType)) ? $centrifugeType : null);
         $this->order->setCollectedSamples(json_encode(!empty($collectedSamples) ? $collectedSamples : []));
@@ -751,7 +753,7 @@ class OrderService
         if (!empty($object->collectedInfo)) {
             $this->order->setQuanumCollectedUser($object->collectedInfo->author->value);
         }
-        if (!empty($object->collectedInfo->address)) {
+        if ($object->collectedInfo instanceof stdClass && !empty($object->collectedInfo->address)) {
             $this->order->setCollectedSiteAddress($object->collectedInfo->author->value);
         }
         $this->order->setCollectedSiteName('A Quest Site');

--- a/src/Service/SiteSyncService.php
+++ b/src/Service/SiteSyncService.php
@@ -94,6 +94,7 @@ class SiteSyncService
             if (!isset($awardee->organizations) || !is_array($awardee->organizations)) {
                 continue;
             }
+            /** @var stdClass $organization */
             foreach ($awardee->organizations as $organization) {
                 if (!isset($organization->sites) || !is_array($organization->sites)) {
                     continue;

--- a/src/Service/SiteSyncService.php
+++ b/src/Service/SiteSyncService.php
@@ -6,8 +6,8 @@ use App\Audit\Log;
 use App\Entity\Awardee;
 use App\Entity\Organization;
 use App\Entity\Site;
-use App\Entity\SiteSync;
 use Doctrine\ORM\EntityManagerInterface;
+use stdClass;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBagInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
@@ -89,6 +89,7 @@ class SiteSyncService
         $deleted = array_keys($existingSites); // add everything to the deleted array, then remove as we find them
         $entries = $this->getAwardeeEntriesFromRdr();
         foreach ($entries as $entry) {
+            /** @var stdClass $awardee */
             $awardee = $entry->resource;
             if (!isset($awardee->organizations) || !is_array($awardee->organizations)) {
                 continue;

--- a/src/Util.php
+++ b/src/Util.php
@@ -8,7 +8,7 @@ class Util
 {
     public static function generateUuid()
     {
-        return (string)Uuid::uuid4();
+        return Uuid::uuid4()->toString();
     }
 
     public static function generateShortUuid($length = 16, $upper = true)


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌<!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1089 <!-- Tag which ticket(s) this PR relates to -->

### Summary
This PR expands on the previous PHPStan fixes by addressing a few other issues NOT related to the `getUser` errors. 

