### PR TITLE
[HPRO-1024] Reversed placement of some submit/cancel buttons

### DIFF
--- a/templates/accessmanagement/add-member.html.twig
+++ b/templates/accessmanagement/add-member.html.twig
@@ -40,8 +40,8 @@
             <br/>
             {{ form_rest(groupMemberForm) }}
             <p>
-                <a href="{{ path('access_manage_user_group', { groupId: group.id }) }}" class="btn btn-default">Cancel</a>
                 <button type="submit" class="btn btn-primary">Submit</button>
+                <a href="{{ path('access_manage_user_group', { groupId: group.id }) }}" class="btn btn-default">Cancel</a>
             </p>
             {{ form_end(groupMemberForm) }}
         </div>

--- a/templates/accessmanagement/remove-member.html.twig
+++ b/templates/accessmanagement/remove-member.html.twig
@@ -42,8 +42,8 @@
                 {{ form_row(removeGoupMemberForm.attestation) }}
             </div>
             <p>
-                <a href="{{ path('access_manage_user_group', { groupId: group.id }) }}" class="btn btn-default">Cancel</a>
                 <button type="submit" class="btn btn-primary" style="display:none">Submit</button>
+                <a href="{{ path('access_manage_user_group', { groupId: group.id }) }}" class="btn btn-default">Cancel</a>
             </p>
             {{ form_end(removeGoupMemberForm) }}
         </div>

--- a/templates/measurement/modify.html.twig
+++ b/templates/measurement/modify.html.twig
@@ -46,8 +46,8 @@
             {{ form_errors(measurementModifyForm) }}
             {{ form_rest(measurementModifyForm) }}
             <p>
-                <a href="{{ path('participant', { id: participant.id }) }}" class="btn btn-default">Exit</a>
                 <button type="submit" name="reportable" class="btn {% if type == 'cancel' %} btn-danger {% elseif type == 'restore' %} btn-success {% else %} btn-primary {% endif %}">{{ type|capitalize }} Physical Measurements</button>
+                <a href="{{ path('participant', { id: participant.id }) }}" class="btn btn-default">Exit</a>
             </p>
             {{ form_end(measurementModifyForm) }}
         </div>

--- a/templates/order/modify.html.twig
+++ b/templates/order/modify.html.twig
@@ -74,8 +74,8 @@
             {{ form_errors(orderModifyForm) }}
             {{ form_rest(orderModifyForm) }}
             <p>
-                <a href="{{ path('participant', { id: participant.id }) }}" class="btn btn-default">Exit</a>
                 <button type="submit" name="reportable" class="btn {% if type == 'cancel' %} btn-danger {% elseif type == 'restore' %} btn-success {% else %} btn-primary {% endif %}">{{ type|capitalize }} Order</button>
+                <a href="{{ path('participant', { id: participant.id }) }}" class="btn btn-default">Exit</a>
             </p>
             {{ form_end(orderModifyForm) }}
         </div>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1024 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->
Reversed placement of some submit/cancel buttons to match placement in other places in healthpro.
