### PR TITLE
[HPRO-1227] Asset loader for site specific templates

### DIFF
--- a/src/Service/ContextTemplateService.php
+++ b/src/Service/ContextTemplateService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Service;
+use Symfony\Component\HttpFoundation\Session;
+use Twig\Extension\RuntimeExtensionInterface;
+
+
+class ContextTemplateService implements RuntimeExtensionInterface {
+    private Session\SessionInterface $session;
+    public function __construct(Session\SessionInterface $session) {
+        $this->session = $session;
+    }
+    public function GetProgramTemplate(string $RelativePath): string {
+        return 'program/' . $this->session->get('program', 'hpo') . '/' . $RelativePath;
+    }
+}

--- a/src/Service/ContextTemplateService.php
+++ b/src/Service/ContextTemplateService.php
@@ -1,16 +1,19 @@
 <?php
 
 namespace App\Service;
+
 use Symfony\Component\HttpFoundation\Session;
 use Twig\Extension\RuntimeExtensionInterface;
 
-
-class ContextTemplateService implements RuntimeExtensionInterface {
+class ContextTemplateService implements RuntimeExtensionInterface
+{
     private Session\SessionInterface $session;
-    public function __construct(Session\SessionInterface $session) {
+    public function __construct(Session\SessionInterface $session)
+    {
         $this->session = $session;
     }
-    public function GetProgramTemplate(string $RelativePath): string {
+    public function GetProgramTemplate(string $RelativePath): string
+    {
         return 'program/' . $this->session->get('program', 'hpo') . '/' . $RelativePath;
     }
 }

--- a/src/Service/ContextTemplateService.php
+++ b/src/Service/ContextTemplateService.php
@@ -2,16 +2,18 @@
 
 namespace App\Service;
 
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Twig\Extension\RuntimeExtensionInterface;
 
 class ContextTemplateService implements RuntimeExtensionInterface
 {
-    private Session\SessionInterface $session;
-    public function __construct(Session\SessionInterface $session)
+    private SessionInterface $session;
+
+    public function __construct(SessionInterface $session)
     {
         $this->session = $session;
     }
+
     public function GetProgramTemplate(string $RelativePath): string
     {
         return 'program/' . $this->session->get('program', 'hpo') . '/' . $RelativePath;

--- a/src/Twig/ContextLoaderExtension.php
+++ b/src/Twig/ContextLoaderExtension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Twig;
+
+use App\Service\ContextTemplateService;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class ContextLoaderExtension extends AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction('LoadProgramTemplate', [ContextTemplateService::class, 'GetProgramTemplate']),
+        ];
+    }
+}

--- a/templates/base-head.html.twig
+++ b/templates/base-head.html.twig
@@ -3,7 +3,7 @@
 <meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 {{ encore_entry_link_tags('app') }}
-
+<link rel="stylesheet" href="{{ asset('css/'~app.session.get('program')|default('hpo')~'.css') }}?v={{ assetVer }}">
 <!--[if IE]>
 <link rel="stylesheet" href="{{ asset('css/ie.css') }}?v={{ assetVer }}">
 <![endif]-->

--- a/tests/Service/ContextTemplateServiceTest.php
+++ b/tests/Service/ContextTemplateServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+namespace App\Tests\Service;
+
+use App\Entity\User;
+use App\Service\ContextTemplateService;
+use Symfony\Component\HttpFoundation\Session\SessionInterface;
+
+class ContextTemplateServiceTest extends ServiceTestCase
+{
+    protected $contextTemplateService;
+
+    public function setUp(): void
+    {
+        $this->contextTemplateService = static::getContainer()->get(ContextTemplateService::class);
+        $this->session = static::getContainer()->get(SessionInterface::class);
+    }
+
+    public function testGetDocumentTitlesList(): void
+    {
+        foreach (User::PROGRAMS as $program) {
+            $this->session->set('program', $program);
+            $this->assertIsString($this->contextTemplateService->GetProgramTemplate('index.html.twig'));
+            $this->assertMatchesRegularExpression("/program\/{$program}\/.*/", $this->contextTemplateService->GetProgramTemplate('index.html.twig'));
+        }
+    }
+}

--- a/web/assets/css/hpo.css
+++ b/web/assets/css/hpo.css
@@ -1,0 +1,22 @@
+.navbar, .navbar .navbar-toggle {
+    background-color: #262262;
+}
+.navbar .navbar-toggle:focus, .navbar .navbar-toggle:hover {
+    background-color: #363272;
+}
+.navbar .navbar-nav>.open>a, .navbar .navbar-nav>.open>a:focus, .navbar .navbar-nav>.open>a:hover {
+    background-color: #161252;
+}
+.page-header h2 {
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #363272;
+    font-weight: 700;
+}
+.home-menu .btn-block i.fa {
+    display: block;
+    font-size: 150%;
+    color: #363272;
+    margin-top: 5px;
+    margin-bottom: 3px;
+}

--- a/web/assets/css/nph.css
+++ b/web/assets/css/nph.css
@@ -1,0 +1,24 @@
+.navbar, .navbar .navbar-toggle {
+    background-color: #719500;
+}
+
+.navbar .navbar-toggle:focus, .navbar .navbar-toggle:hover {
+    background-color: #9ed101;
+}
+.navbar .navbar-nav>.open>a, .navbar .navbar-nav>.open>a:focus, .navbar .navbar-nav>.open>a:hover {
+    background-color: #526801;
+}
+
+.page-header h2 {
+    margin-top: 0;
+    margin-bottom: 0;
+    color: #9ed101;
+    font-weight: 700;
+}
+.home-menu .btn-block i.fa {
+    display: block;
+    font-size: 150%;
+    color: #9ed101;
+    margin-top: 5px;
+    margin-bottom: 3px;
+}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.0.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1227 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

small service that adds a function to build an include string that changes the file to be loaded based upon a users selected program.

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
