### PR TITLE
[HPRO-1274] Display and disable existing orders & samples

### DIFF
--- a/src/Controller/NphOrderController.php
+++ b/src/Controller/NphOrderController.php
@@ -61,7 +61,8 @@ class NphOrderController extends BaseController
             'timePoints' => $nphOrderService->getTimePoints(),
             'samples' => $nphOrderService->getSamples(),
             'stoolSamples' => $nphOrderService->getStoolSamples(),
-            'nailSamples' => $nphOrderService->getNailSamples()
+            'nailSamples' => $nphOrderService->getNailSamples(),
+            'samplesOrderIds' => $nphOrderService->getSamplesWithOrderIds()
         ]);
     }
 }

--- a/src/Controller/NphOrderController.php
+++ b/src/Controller/NphOrderController.php
@@ -2,6 +2,7 @@
 
 namespace App\Controller;
 
+use App\Entity\NphOrder;
 use App\Form\Nph\NphOrderType;
 use App\Nph\Order\Samples;
 use App\Service\Nph\NphOrderService;
@@ -39,9 +40,10 @@ class NphOrderController extends BaseController
         $nphOrderService->loadModules($module, $visit, $participantId);
         $timePointSamples = $nphOrderService->getTimePointSamples();
         $timePoints = $nphOrderService->getTimePoints();
+        $ordersData = $nphOrderService->getExistingOrdersData();
         $oderForm = $this->createForm(
             NphOrderType::class,
-            null,
+            $ordersData,
             ['timePointSamples' => $timePointSamples, 'timePoints' => $timePoints, 'stoolSamples' => $nphOrderService->getStoolSamples()]
         );
         $oderForm->handleRequest($request);

--- a/src/Controller/NphOrderController.php
+++ b/src/Controller/NphOrderController.php
@@ -51,6 +51,9 @@ class NphOrderController extends BaseController
             $formData = $oderForm->getData();
             $nphOrderService->createOrdersAndSamples($formData);
             $this->addFlash('success', 'Orders Created');
+            // TODO: Redirect to generate orders & print labels page
+            return $this->redirectToRoute('nph_generate_oder', ['participantId' => $participantId, 'module' => $module,
+                'visit' => $visit]);
         }
         return $this->render('program/nph/order/generate-orders.html.twig', [
             'orderForm' => $oderForm->createView(),

--- a/src/Form/Nph/NphOrderType.php
+++ b/src/Form/Nph/NphOrderType.php
@@ -2,7 +2,6 @@
 
 namespace App\Form\Nph;
 
-use App\Nph\Order\Samples;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Extension\Core\Type;
@@ -13,6 +12,7 @@ class NphOrderType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
+        $ordersData = $builder->getData();
         $timePointSamples = $options['timePointSamples'];
         $timePoints = $options['timePoints'];
         foreach ($timePointSamples as $timePoint => $samples) {
@@ -21,6 +21,7 @@ class NphOrderType extends AbstractType
                     $builder->add('stoolKit', Type\TextType::class, [
                         'label' => 'Stool Kit ID',
                         'required' => false,
+                        'disabled' => !empty($ordersData['stoolKit']),
                         'constraints' => new Constraints\Type('string'),
                         'attr' => [
                             'placeholder' => 'Scan Kit ID'
@@ -31,6 +32,7 @@ class NphOrderType extends AbstractType
                     $builder->add($sampleCode, Type\TextType::class, [
                         'label' => $sample,
                         'required' => false,
+                        'disabled' => !empty($ordersData[$sampleCode]),
                         'constraints' => new Constraints\Type('string'),
                         'attr' => [
                             'placeholder' => 'Scan Tube'
@@ -44,7 +46,15 @@ class NphOrderType extends AbstractType
                 'multiple' => true,
                 'label' => $timePoints[$timePoint],
                 'choices' => array_flip($samples),
-                'required' => false
+                'required' => false,
+                'choice_attr' => function ($val) use ($ordersData, $timePoint) {
+                    $attr = [];
+                    if (isset($ordersData[$timePoint]) && in_array($val, $ordersData[$timePoint])) {
+                        $attr['disabled'] = true;
+                        $attr['class'] = 'sample-disabled';
+                    }
+                    return $attr;
+                }
             ]);
         }
         return $builder->getForm();

--- a/src/Form/Nph/NphOrderType.php
+++ b/src/Form/Nph/NphOrderType.php
@@ -21,10 +21,10 @@ class NphOrderType extends AbstractType
                     $builder->add('stoolKit', Type\TextType::class, [
                         'label' => 'Stool Kit ID',
                         'required' => false,
-                        'disabled' => !empty($ordersData['stoolKit']),
                         'constraints' => new Constraints\Type('string'),
                         'attr' => [
-                            'placeholder' => 'Scan Kit ID'
+                            'placeholder' => 'Scan Kit ID',
+                            'disabled' => !empty($ordersData['stoolKit'])
                         ]
                     ]);
                 }
@@ -35,7 +35,8 @@ class NphOrderType extends AbstractType
                         'disabled' => !empty($ordersData[$sampleCode]),
                         'constraints' => new Constraints\Type('string'),
                         'attr' => [
-                            'placeholder' => 'Scan Tube'
+                            'placeholder' => 'Scan Tube',
+                            'disabled' => !empty($ordersData['stoolKit'])
                         ]
                     ]);
                     unset($samples[$sampleCode]);

--- a/src/Repository/NphOrderRepository.php
+++ b/src/Repository/NphOrderRepository.php
@@ -19,32 +19,17 @@ class NphOrderRepository extends ServiceEntityRepository
         parent::__construct($registry, NphOrder::class);
     }
 
-    // /**
-    //  * @return NphOrder[] Returns an array of NphOrder objects
-    //  */
-    /*
-    public function findByExampleField($value)
+    public function getOrdersByVisitType($user, $participantId, $visitType): array
     {
-        return $this->createQueryBuilder('n')
-            ->andWhere('n.exampleField = :val')
-            ->setParameter('val', $value)
-            ->orderBy('n.id', 'ASC')
-            ->setMaxResults(10)
+        return $this->createQueryBuilder('no')
+            ->where('no.user = :user')
+            ->andWhere('no.participantId = :participantId')
+            ->andWhere('no.visitType = :visitType')
+            ->setParameter('user', $user)
+            ->setParameter('participantId', $participantId)
+            ->setParameter('visitType', $visitType)
+            ->orderBy('no.id', 'ASC')
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
-    */
-
-    /*
-    public function findOneBySomeField($value): ?NphOrder
-    {
-        return $this->createQueryBuilder('n')
-            ->andWhere('n.exampleField = :val')
-            ->setParameter('val', $value)
-            ->getQuery()
-            ->getOneOrNullResult()
-        ;
-    }
-    */
 }

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -85,10 +85,19 @@ class NphOrderService
         $ordersData = [];
         $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType($this->user,
             $this->participantId, $this->visit);
+        $addStoolKit = true;
         foreach ($orders as $order) {
             $samples = $order->getNphSamples();
             foreach ($samples as $sample) {
-                $ordersData[$order->getTimepoint()][] = $sample->getSampleCode();
+                if (in_array($sample->getSampleCode(), $this->getStoolSamples())) {
+                    if ($addStoolKit) {
+                        $ordersData['stoolKit'] = $order->getOrderId();
+                        $addStoolKit = false;
+                    }
+                    $ordersData[$sample->getSampleCode()] = $sample->getSampleId();
+                } else {
+                    $ordersData[$order->getTimepoint()][] = $sample->getSampleCode();
+                }
             }
         }
         return $ordersData;

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -103,6 +103,20 @@ class NphOrderService
         return $ordersData;
     }
 
+    public function getSamplesWithOrderIds(): array
+    {
+        $samplesData = [];
+        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType($this->user,
+            $this->participantId, $this->visit);
+        foreach ($orders as $order) {
+            $samples = $order->getNphSamples();
+            foreach ($samples as $sample) {
+                $samplesData[$order->getTimepoint()][$sample->getSampleCode()] = $order->getOrderId();
+            }
+        }
+        return $samplesData;
+    }
+
     public function generateOrderId(): string
     {
         $attempts = 0;

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -80,6 +80,20 @@ class NphOrderService
         return $this->moduleObj->getNailSamples();
     }
 
+    public function getExistingOrdersData(): array
+    {
+        $ordersData = [];
+        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType($this->user,
+            $this->participantId, $this->visit);
+        foreach ($orders as $order) {
+            $samples = $order->getNphSamples();
+            foreach ($samples as $sample) {
+                $ordersData[$order->getTimepoint()][] = $sample->getSampleCode();
+            }
+        }
+        return $ordersData;
+    }
+
     public function generateOrderId(): string
     {
         $attempts = 0;

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -171,7 +171,8 @@ class NphOrderService
         }
         // For stool kit samples
         if (!empty($formData['stoolKit'])) {
-            $nphOrder = $this->createOrder('LMT', $formData['stoolKit']);
+            // TODO: dynamically load stool visit type
+            $nphOrder = $this->createOrder('preLMT', $formData['stoolKit']);
             foreach ($this->getStoolSamples() as $stoolSample) {
                 $this->createSample($stoolSample, $nphOrder, $formData[$stoolSample]);
             }

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -83,8 +83,11 @@ class NphOrderService
     public function getExistingOrdersData(): array
     {
         $ordersData = [];
-        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType($this->user,
-            $this->participantId, $this->visit);
+        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType(
+            $this->user,
+            $this->participantId,
+            $this->visit
+        );
         $addStoolKit = true;
         foreach ($orders as $order) {
             $samples = $order->getNphSamples();
@@ -106,8 +109,11 @@ class NphOrderService
     public function getSamplesWithOrderIds(): array
     {
         $samplesData = [];
-        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType($this->user,
-            $this->participantId, $this->visit);
+        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType(
+            $this->user,
+            $this->participantId,
+            $this->visit
+        );
         foreach ($orders as $order) {
             $samples = $order->getNphSamples();
             foreach ($samples as $sample) {

--- a/templates/program/nph/order/generate-orders.html.twig
+++ b/templates/program/nph/order/generate-orders.html.twig
@@ -8,15 +8,8 @@
             Generate Order and Print Labels
         </h2>
     </div>
-    <div class="row">
-        <div class="col-sm-6">
-            {% include 'program/nph/order/partials/participant-dl.html.twig' %}
-        </div>
-        <div class="col-sm-6">
-            <div class="alert well-sm bg-warning-new text-white">Module | NPH Module {{ module }}</div>
-            <div class="alert well-sm bg-primary">Visit | {{ visit }}</div>
-        </div>
-    </div>
+
+    {% include 'program/nph/order/partials/generate-orders-header.html.twig' %}
 
     <div class="row" id="order_create"
          data-samples="{{ samples|json_encode() }}"
@@ -41,13 +34,13 @@
                         <input type="checkbox"> {{ form_label(orderForm[timePoint]) }}
                     </div>
                     <div class="panel-body timepoint-samples" data-timepoint="{{ timePoint }}">
-                        {{ samples.form_widget(orderForm[timePoint], orderForm, nailSamples, stoolSamples) }}
+                        {{ samples.form_widget(orderForm, timePoint, nailSamples, stoolSamples, samplesOrderIds) }}
                     </div>
                 </div>
             {% endfor %}
             {{ form_rest(orderForm) }}
             <a class="btn btn-default" href="#">Cancel</a>
-            <button type="button" class="btn btn-primary" id="order_next_btn">Next</button>
+            <button type="submit" class="btn btn-primary" id="order_next_btn">Next</button>
             {{ form_end(orderForm) }}
             <br>
         </div>

--- a/templates/program/nph/order/generate-orders.html.twig
+++ b/templates/program/nph/order/generate-orders.html.twig
@@ -13,7 +13,7 @@
             {% include 'program/nph/order/partials/participant-dl.html.twig' %}
         </div>
         <div class="col-sm-6">
-            <div class="alert well-sm bg-warning-new">Module | NPH Module {{ module }}</div>
+            <div class="alert well-sm bg-warning-new text-white">Module | NPH Module {{ module }}</div>
             <div class="alert well-sm bg-primary">Visit | {{ visit }}</div>
         </div>
     </div>

--- a/templates/program/nph/order/generate-orders.html.twig
+++ b/templates/program/nph/order/generate-orders.html.twig
@@ -11,6 +11,13 @@
 
     {% include 'program/nph/order/partials/generate-orders-header.html.twig' %}
 
+    {% if samplesOrderIds is not empty %}
+        <div class="alert alert-warning">
+            <p><strong>Existing order found within this visit.</strong></p>
+            If you need to create a new order while a previous order exists, please cancel the existing order first.
+        </div>
+    {% endif %}
+
     <div class="row" id="order_create"
          data-samples="{{ samples|json_encode() }}"
          data-time-points="{{ timePoints|json_encode() }}"

--- a/templates/program/nph/order/generate-orders.html.twig
+++ b/templates/program/nph/order/generate-orders.html.twig
@@ -47,7 +47,7 @@
             {% endfor %}
             {{ form_rest(orderForm) }}
             <a class="btn btn-default" href="#">Cancel</a>
-            <button type="submit" class="btn btn-primary" id="order_next_btn">Next</button>
+            <button type="button" class="btn btn-primary" id="order_next_btn">Next</button>
             {{ form_end(orderForm) }}
             <br>
         </div>

--- a/templates/program/nph/order/partials/generate-orders-header.html.twig
+++ b/templates/program/nph/order/partials/generate-orders-header.html.twig
@@ -1,0 +1,9 @@
+<div class="row">
+    <div class="col-sm-6">
+        {% include 'program/nph/order/partials/participant-dl.html.twig' %}
+    </div>
+    <div class="col-sm-6">
+        <div class="alert well-sm bg-warning-new text-white">Module | NPH Module {{ module }}</div>
+        <div class="alert well-sm bg-primary">Visit | {{ visit }}</div>
+    </div>
+</div>

--- a/templates/program/nph/order/samples.html.twig
+++ b/templates/program/nph/order/samples.html.twig
@@ -1,17 +1,38 @@
-{% macro form_widget(form, orderForm, nailSamples, stoolSamples) %}
-    {% for sample in form.children %}
+{% macro form_widget(orderForm, timePoint, nailSamples, stoolSamples, samplesOrderIds) %}
+    {% set formField = orderForm[timePoint] %}
+    {% for sample in formField.children %}
         {% if sample.vars.value in nailSamples %}
-            <div class="sub-samples nail-sub-samples">{{ form_widget(sample) }}</div>
+            <div class="sub-samples nail-sub-samples">
+                {{ form_widget(sample) }}
+                {% if samplesOrderIds[timePoint][sample.vars.value] is defined %}
+                    {{ _self.displayOrderId(samplesOrderIds[timePoint][sample.vars.value]) }}
+                {% endif %}
+            </div>
         {% elseif sample.vars.value == 'stool' %}
             {{ form_widget(sample) }}
             {{ form_label(orderForm.stoolKit) }}
             {{ form_widget(orderForm.stoolKit) }}
+            <br>
             {% for stoolSample in stoolSamples %}
                 {{ form_label(orderForm[stoolSample]) }}
+                {% if samplesOrderIds[timePoint][stoolSample] is defined %}
+                    {{ _self.displayOrderId(samplesOrderIds[timePoint][stoolSample]) }}
+                {% endif %}
                 {{ form_widget(orderForm[stoolSample]) }}
+                <br>
             {% endfor %}
         {% else %}
             {{ form_widget(sample) }}
+            {% if samplesOrderIds[timePoint][sample.vars.value] is defined %}
+                {{ _self.displayOrderId(samplesOrderIds[timePoint][sample.vars.value]) }}
+            {% endif %}
         {% endif %}
     {% endfor %}
+{% endmacro %}
+
+{% macro displayOrderId(orderId) %}
+    <div>
+        Order ID: <a href="#">{{ orderId }}</a>
+        <button class="btn btn-primary btn-xs">Reprint Labels</button>
+    </div>
 {% endmacro %}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.0.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1274<!-- Tag which ticket(s) this PR relates to -->

### Screenshots <!-- if applicable -->

![Existing-Generate-Orders-Page](https://user-images.githubusercontent.com/6041980/201439782-27cc1172-fe46-4fc1-a7dd-2cc4c2f4c28b.png)
