### PR TITLE
[HPRO-1300] Adjusted several things due to feedback from NPH Demo.

### DIFF
--- a/src/Controller/NphOrderController.php
+++ b/src/Controller/NphOrderController.php
@@ -70,7 +70,8 @@ class NphOrderController extends BaseController
             'samples' => $nphOrderService->getSamples(),
             'stoolSamples' => $nphOrderService->getSamplesByType('stool'),
             'nailSamples' => $nphOrderService->getSamplesByType('nail'),
-            'samplesOrderIds' => $nphOrderService->getSamplesWithOrderIds()
+            'samplesOrderIds' => $nphOrderService->getSamplesWithOrderIds(),
+            'samplesStatus' => $nphOrderService->getSamplesWithStatus()
         ]);
     }
 

--- a/src/Nph/Order/Samples/Module1.json
+++ b/src/Nph/Order/Samples/Module1.json
@@ -13,14 +13,14 @@
       "aliquots": {
         "SST8P5A1": {
           "identifier": "SSTS1",
-          "container": "1.4mL Matrix tube",
+          "container": "1.4mL Matrix tube 500μL",
           "expectedAliquots": 1,
           "expectedVolume": 500,
           "units": "μL"
         },
         "SST8P5A2": {
           "identifier": "SSTS1",
-          "container": "1.4mL Matrix tube",
+          "container": "1.4mL Matrix tube 1000μL",
           "expectedAliquots": 3,
           "expectedVolume": 1000,
           "units": "μL"
@@ -38,14 +38,14 @@
       "aliquots": {
         "PST8A1": {
           "identifier": "LHPSTP1",
-          "container": "1.4mL Matrix tube",
+          "container": "1.4mL Matrix tube 500μL",
           "expectedAliquots": 1,
           "expectedVolume": 500,
           "units": "μL"
         },
         "PST8A2": {
           "identifier": "LHPSTP1",
-          "container": "1.4mL Matrix tube",
+          "container": "1.4mL Matrix tube 1000μL",
           "expectedAliquots": 3,
           "expectedVolume": 1000,
           "units": "μL"
@@ -63,14 +63,14 @@
       "aliquots": {
         "EDTA10A1": {
           "identifier": "EDPAP1",
-          "container": "1.4mL Matrix tube",
+          "container": "1.4mL Matrix tube 500μL",
           "expectedAliquots": 1,
           "expectedVolume": 500,
           "units": "μL"
         },
         "EDTA10A2": {
           "identifier": "EDPAP1",
-          "container": "1.4mL Matrix tube",
+          "container": "1.4mL Matrix tube 1000μL",
           "expectedAliquots": 4,
           "expectedVolume": 1000,
           "units": "μL"

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -400,7 +400,6 @@ class NphOrderService
                     'healthProOrderId' => $order->getId(),
                     'createDate' => $order->getCreatedTs()->format('Y-M-D'),
                     'sampleStatus' => $sample->getStatus(),
-                    'sampleType' => $module->getSampleType($sample->getSampleCode()),
                     'sampleCollectionVolume' => $sampleCollectionVolume,
                     'timepointDisplayName' => $timePointsDisplay[$order->getTimepoint()],
                     'sampleTypeDisplayName' => ucwords($module->getSampleType($sample->getSampleCode()))
@@ -487,5 +486,21 @@ class NphOrderService
             $sampleData["{$aliquot->getAliquotCode()}Volume"][] = $aliquot->getVolume();
         }
         return $sampleData;
+    }
+
+    public function getSamplesWithStatus(): array
+    {
+        $samplesData = [];
+        $orders = $this->em->getRepository(NphOrder::class)->getOrdersByVisitType(
+            $this->participantId,
+            $this->visit
+        );
+        foreach ($orders as $order) {
+            $samples = $order->getNphSamples();
+            foreach ($samples as $sample) {
+                $samplesData[$order->getTimepoint()][$sample->getSampleCode()] = $sample->getStatus();
+            }
+        }
+        return $samplesData;
     }
 }

--- a/templates/program/nph/order/collect.html.twig
+++ b/templates/program/nph/order/collect.html.twig
@@ -5,8 +5,7 @@
     <div class="alert bg-light well-sm">
         {{ timePoints[order.timepoint] }} {{ order.orderType|capitalize }}
         <div class="pull-right">
-            <a href="#">View Order Summary</a> /
-            <a href="#">Reprint Labels <i class="fa fa-arrow-right"></i></a>
+            <a href="#">View Order Summary</a>
         </div>
     </div>
     <div class="row">

--- a/templates/program/nph/order/generate-orders.html.twig
+++ b/templates/program/nph/order/generate-orders.html.twig
@@ -44,7 +44,7 @@
                     <div class="panel-body timepoint-samples" id="timepoint_samples_{{ timePoint }}"
                          data-timepoint="{{ timePoint }}">
                         {{ samples.form_widget(orderForm, timePoint, nailSamples, stoolSamples, samplesOrderIds,
-                            participant.id, module, visit) }}
+                            participant.id, module, visit, samplesStatus) }}
                     </div>
                 </div>
             {% endfor %}

--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -141,9 +141,6 @@
                                         {% if sample.finalizedTs is empty %}
                                             <td>
                                                 <i class="fa fa-eraser clear-aliquot-widget" role="button"></i>
-                                                {% if i != 0 %}
-                                                    <i class="fa fa-trash delete-aliquot-widget" role="button"></i>
-                                                {% endif %}
                                             </td>
                                         {% endif %}
                                     </tr>

--- a/templates/program/nph/order/samples.html.twig
+++ b/templates/program/nph/order/samples.html.twig
@@ -1,11 +1,11 @@
-{% macro form_widget(orderForm, timePoint, nailSamples, stoolSamples, samplesOrderIds, participantId, module, visit) %}
+{% macro form_widget(orderForm, timePoint, nailSamples, stoolSamples, samplesOrderIds, participantId, module, visit, samplesStatus) %}
     {% set formField = orderForm[timePoint] %}
     {% for sample in formField.children %}
         {% if sample.vars.value in nailSamples %}
             <div class="sub-samples nail-sub-samples">
                 {{ form_widget(sample) }}
                 {% if samplesOrderIds[timePoint][sample.vars.value] is defined %}
-                    {{ _self.displayOrderId(samplesOrderIds[timePoint][sample.vars.value], participantId, module, visit) }}
+                    {{ _self.displayOrderId(samplesOrderIds[timePoint][sample.vars.value], participantId, module, visit, samplesStatus[timePoint][sample.vars.value]) }}
                 {% endif %}
             </div>
         {% elseif sample.vars.value == 'STOOL' %}
@@ -16,7 +16,7 @@
             {% for stoolSample in stoolSamples %}
                 {{ form_label(orderForm[stoolSample]) }}
                 {% if samplesOrderIds[timePoint][stoolSample] is defined %}
-                    {{ _self.displayOrderId(samplesOrderIds[timePoint][stoolSample], participantId, module, visit) }}
+                    {{ _self.displayOrderId(samplesOrderIds[timePoint][stoolSample], participantId, module, visit, samplesStatus[timePoint][sample.vars.value]) }}
                 {% endif %}
                 {{ form_widget(orderForm[stoolSample]) }}
                 <br>
@@ -24,21 +24,23 @@
         {% else %}
             {{ form_widget(sample) }}
             {% if samplesOrderIds[timePoint][sample.vars.value] is defined %}
-                {{ _self.displayOrderId(samplesOrderIds[timePoint][sample.vars.value], participantId, module, visit) }}
+                {{ _self.displayOrderId(samplesOrderIds[timePoint][sample.vars.value], participantId, module, visit, samplesStatus[timePoint][sample.vars.value]) }}
             {% endif %}
         {% endif %}
     {% endfor %}
 {% endmacro %}
 
-{% macro displayOrderId(order, participantId, module, visit) %}
+{% macro displayOrderId(order, participantId, module, visit, sampleStatus) %}
     <div>
         Order ID:
         <a href="{{ path('nph_order_collect', {'participantId': participantId, 'orderId': order['id']}) }}">
             {{ order['orderId'] }}
         </a>
-        <a href="{{ path('nph_order_label_print', {'participantId': participantId, 'module': module, 'visit': visit}) }}"
-           class="btn btn-primary btn-xs">
-            Reprint Labels
-        </a>
+        {% if sampleStatus == 'Created' %}
+            <a href="{{ path('nph_order_label_print', {'participantId': participantId, 'module': module, 'visit': visit}) }}"
+               class="btn btn-primary btn-xs">
+                Reprint Labels
+            </a>
+        {% endif %}
     </div>
 {% endmacro %}

--- a/web/assets/js/views/NphSampleFinalize.js
+++ b/web/assets/js/views/NphSampleFinalize.js
@@ -24,7 +24,7 @@ $(document).ready(function () {
             '<td style="position: relative">' + newTsWidget + '</td>' +
             '<td>' + newVolumeWidget + '</td>' +
             '<td>' + aliquotUnits + '</td>' +
-            '<td><i class="fa fa-eraser clear-aliquot-widget" role="button"></i> <i class="fa fa-trash delete-aliquot-widget" role="button"></i></td>'
+            '<td><i class="fa fa-eraser clear-aliquot-widget" role="button"></i></td>'
         );
 
         $('.aliquots-row-' + aliquotId).last().after(newElem);


### PR DESCRIPTION
No reprint labels if a sample is in a non Created Status. No Trash Icon for the aliquot page, can't remove aliquots. Show collection volume for aliquot tubes of the same size.

| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.0.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1300<!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

No reprint labels if a sample is in a non Created Status.
No Trash Icon for the aliquot page, can't remove aliquots.
Show collection volume for aliquot tubes of the same size.

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
