### PR TITLE
[HPRO-1330] Move Atlantic standard time option above eastern time

### DIFF
--- a/src/Service/EnvironmentService.php
+++ b/src/Service/EnvironmentService.php
@@ -20,6 +20,7 @@ class EnvironmentService
     public $values = [];
 
     public static $timezoneOptions = [
+        'America/Puerto_Rico' => 'Atlantic Standard Time',
         'America/New_York' => 'Eastern Time',
         'America/Chicago' => 'Central Time',
         'America/Denver' => 'Mountain Time',

--- a/src/Service/TimezoneService.php
+++ b/src/Service/TimezoneService.php
@@ -5,14 +5,14 @@ namespace App\Service;
 class TimezoneService
 {
     public static $timezoneOptions = [
+        'America/Puerto_Rico' => 'Atlantic Standard Time',
         'America/New_York' => 'Eastern Time',
         'America/Chicago' => 'Central Time',
         'America/Denver' => 'Mountain Time',
         'America/Phoenix' => 'Mountain Time - Arizona',
         'America/Los_Angeles' => 'Pacific Time',
         'America/Anchorage' => 'Alaska Time',
-        'Pacific/Honolulu' => 'Hawaii Time',
-        'America/Puerto_Rico' => 'Atlantic Standard Time'
+        'Pacific/Honolulu' => 'Hawaii Time'
     ];
 
     /**


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.0.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1330<!-- Tag which ticket(s) this PR relates to -->

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/6041980/219471278-321a1f8d-9703-425a-97be-91bb365498b4.png)

