### PR TITLE
[HPRO-1331] Display proper status for sample collection state, partial collections.

### DIFF
--- a/templates/program/nph/participant/index.html.twig
+++ b/templates/program/nph/participant/index.html.twig
@@ -98,9 +98,6 @@
                                             {% set SampleGroupCollectionStatus = 'Finalized' %}
                                         {% elseif 'Collected' in SampleGroupStatus %}
                                             {% set SampleGroupCollectionStatus = 'Collected' %}
-                                            {% if 'Created' in SampleGroupStatus %}
-                                                {% set SampleGroupCollectionStatus = 'In Progress' %}
-                                            {% endif %}
                                         {% else %}
                                             {% set SampleGroupCollectionStatus = 'Created' %}
                                         {% endif %}
@@ -114,13 +111,22 @@
                                             {% set SampleGroupStatus = null %}
                                             {% if sample is iterable and sample|length > 0 and sample['sampleId'] is not null and sampleInfo['numberSamples'] > 0 and sample['healthProOrderId'] not in displayedOrderIDS %}
                                                 {% set displayedOrderIDS = displayedOrderIDS|merge([sample['healthProOrderId']]) %}
+                                                {% if StatusCount == sampleInfo['expectedSamples'] and SampleGroupCollectionStatus == 'Finalized' %}
+                                                    {% set OrderStatus = 'Completed' %}
+                                                {% elseif StatusCount == sampleInfo['expectedSamples'] and SampleGroupCollectionStatus == 'Collected' %}
+                                                    {% set OrderStatus = 'Collected' %}
+                                                {% elseif SampleGroupCollectionStatus in ['Finalized', 'Collected'] %}
+                                                    {% set OrderStatus = 'In Progress' %}
+                                                {% else %}
+                                                    {% set OrderStatus = SampleGroupCollectionStatus %}
+                                                {% endif %}
                                                 <div class="well well-sm row">
                                                     <div class="col-sm-2">{{ sample['createDate'] }}</div>
                                                     <div class="col-sm-3"><a
                                                             href="{{ path('nph_order_collect', {participantId: participant.id, orderId: sample['healthProOrderId']}) }}">Order
                                                             ID: {{ sample['orderId'] }}</a></div>
                                                     <div class="col-sm-2">{{ sample['sampleTypeDisplayName'] }}</div>
-                                                    <div class="col-sm-2">{{ SampleGroupCollectionStatus ?? 'Created' }}</div>
+                                                    <div class="col-sm-2">{{ OrderStatus ?? 'Created' }}</div>
                                                     <div class="col-sm-3">({{ StatusCount }}
                                                         /{{ sampleInfo['expectedSamples'] }} Samples {{ SampleGroupCollectionStatus }})
                                                     </div>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1331 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
