### PR TITLE
[HPRO-1182] Added fix for spelling mistake on restore samples.

### DIFF
--- a/templates/program/nph/review/recently_modified.html.twig
+++ b/templates/program/nph/review/recently_modified.html.twig
@@ -55,10 +55,10 @@
                 {% else %}
                     <td><i class="fa fa-times text-danger" aria-hidden="true"></i></td>
                 {% endif %}
-                {% if sample.modifyType is not null and sample.modifyType != 'edited' %}
-                    {% set modifyString = sample.modifyType|title ~ 'ed And ' %}
-                {% elseif sample.modifyType is not null and sample.modifyType == 'restore' %}
+                {% if sample.modifyType is not null and sample.modifyType == 'restore' %}
                     {% set modifyString = sample.modifyType|title ~ 'd And ' %}
+                {% elseif sample.modifyType is not null and sample.modifyType != 'edited' %}
+                    {% set modifyString = sample.modifyType|title ~ 'ed And ' %}
                 {% elseif sample.modifyType is not null %}
                     {% set modifyString = sample.modifyType|title ~ ' And ' %}
                 {% else %}

--- a/templates/program/nph/review/recently_modified.html.twig
+++ b/templates/program/nph/review/recently_modified.html.twig
@@ -64,12 +64,12 @@
                 {% else %}
                     {% set modifyString = '' %}
                 {% endif %}
-                {% if sample.finalizedTs is null %}
+                {% if sample.modifyType == 'unlock' %}
+                    <td><p class="btn btn-sm btn-warning">Unlocked</p></td>
+                {% elseif sample.finalizedTs is null %}
                     <td><p class="btn btn-sm btn-danger">{{ modifyString }}Unfinalized</p></td>
                 {% elseif sample.finalizedTs is not null %}
                     <td><p class="btn btn-sm btn-success">{{ modifyString }}Finalized</p></td>
-                {% elseif sample.modifyType == 'unlock' %}
-                    <td><p class="btn btn-sm btn-warning">{{ modifyString }}Unlocked</p></td>
                 {% else %}
                     <td><p class="btn btn-sm btn-danger">{{ modifyString }}Unfinalized</p></td>
                 {% endif %}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1182 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
