### PR TITLE
Added 2 new status to EHR consent, custom status display per consent.

### DIFF
--- a/src/Service/WorkQueueService.php
+++ b/src/Service/WorkQueueService.php
@@ -660,6 +660,11 @@ class WorkQueueService
 
     private function getConsent($participant, $columnDef): string
     {
+        if (array_key_exists('statusDisplay', $columnDef)) {
+            $statusDisplay = $columnDef['statusDisplay'][$participant->{$columnDef['rdrField']}];
+        } else {
+            $statusDisplay = null;
+        }
         return WorkQueue::{$columnDef['consentMethod']}(
             $participant->id,
             $participant->{$columnDef['reconsentField']},
@@ -674,7 +679,8 @@ class WorkQueueService
                 'consentType' => $columnDef['rdrField']
             ]) : null,
             $columnDef['historicalType'],
-            $this->userService->getUser()->getTimezone()
+            $this->userService->getUser()->getTimezone(),
+            $statusDisplay
         );
     }
 }

--- a/templates/macros/display-text.html.twig
+++ b/templates/macros/display-text.html.twig
@@ -14,7 +14,31 @@
     {% endif %}
 {% endmacro %}
 
-{% macro displayConsentStatus(value, time, ehrExpireStatus = '', ehrExpireDate = '') %}
+{% macro displayConsentStatus(value, time) %}
+    {% set time = time ? time|date('n/j/Y', app.user.timezone) %}
+    {% if value == 'SUBMITTED' %}
+        <i class="fa fa-check text-success" aria-hidden="true"></i>
+        {{ time }} <br/>
+        (Consented Yes)
+    {% elseif value == 'SUBMITTED_NO_CONSENT' %}
+        <i class="fa fa-times text-danger" aria-hidden="true"></i>
+        {{ time }} <br/>
+        (Refused Consent)
+    {% elseif value == 'SUBMITTED_NOT_SURE' %}
+        <i class="fa fa-question text-warning" aria-hidden="true"></i>
+        {{ time }} <br/>
+        (Responded Not Sure)
+    {% elseif value == 'SUBMITTED_INVALID' %}
+        <i class="fa fa-times text-danger" aria-hidden="true"></i>
+        {{ time }} <br/>
+        (Invalid)
+    {% else %}
+        <i class="fa fa-times text-danger" aria-hidden="true"></i>
+        (Consent Not Completed) <br/>
+    {% endif %}
+{% endmacro %}
+
+{% macro displayEHRConsentStatus(value, time, ehrExpireStatus = '', ehrExpireDate = '') %}
     {% set time = time ? time|date('n/j/Y', app.user.timezone) %}
     {% if ehrExpireStatus == 'EXPIRED' %}
         <i class="fa fa-exclamation-triangle text-warning" aria-hidden="true"></i>
@@ -35,7 +59,11 @@
     {% elseif value == 'SUBMITTED_INVALID' %}
         <i class="fa fa-times text-danger" aria-hidden="true"></i>
         {{ time }} <br/>
-        (Invalid)
+        <span title="An error has been identified with this EHR Consent and a ticket has been submitted to PTSC for review." data-toggle="tooltip" data-container="body">Invalid</span>
+    {% elseif value == 'SUBMITTED_NOT_VALIDATED' %}
+        <i class="fa fa-sync text-warning" aria-hidden="true"></i>
+        {{ time }} <br/>
+        <span title="The EHR Consent has been submitted and is currently undergoing validation. This process could take up to 24hrs to process." data-toggle="tooltip" data-container="body">(Processing)</span>
     {% else %}
         <i class="fa fa-times text-danger" aria-hidden="true"></i>
         (Consent Not Completed) <br/>

--- a/templates/partials/participant-consent.html.twig
+++ b/templates/partials/participant-consent.html.twig
@@ -8,7 +8,7 @@
     </div>
     <div class="status-block">
         <strong>EHR Consent</strong>
-        {{ macros.displayConsentStatus(participant.consentForElectronicHealthRecords, participant.consentForElectronicHealthRecordsAuthored, participant.ehrConsentExpireStatus, participant.ehrConsentExpireAuthored) }}
+        {{ macros.displayEHRConsentStatus(participant.consentForElectronicHealthRecords, participant.consentForElectronicHealthRecordsAuthored, participant.ehrConsentExpireStatus, participant.ehrConsentExpireAuthored) }}
         <br/>
     </div>
     <div class="status-block">

--- a/tests/Helper/WorkQueueTest.php
+++ b/tests/Helper/WorkQueueTest.php
@@ -247,6 +247,8 @@ class WorkQueueTest extends TestCase
                         [
                             '' => 'View All',
                             'SUBMITTED' => 'Consented',
+                            'SUBMITTED_NOT_VALIDATED' => 'Processing',
+                            'SUBMITTED_INVALID' => 'Invalid',
                             'SUBMITTED_NO_CONSENT' => 'Refused consent',
                             'UNSET' => 'Consent not completed',
                         ],

--- a/web/assets/css/app.css
+++ b/web/assets/css/app.css
@@ -314,7 +314,7 @@ label.label-normal {
     text-align: center;
     min-width: 150px;
 }
-#participant-consent-status .status-block i.fa-check, #participant-consent-status .status-block i.fa-times, #participant-consent-status .status-block i.fa-question, #participant-consent-status .status-block i.fa-exclamation-triangle {
+#participant-consent-status .status-block i.fa-check, #participant-consent-status .status-block i.fa-times, #participant-consent-status .status-block i.fa-question, #participant-consent-status .status-block i.fa-exclamation-triangle, #participant-consent-status .status-block i.fa-sync {
     display: block;
     font-size: 36px;
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1378 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Adds two new status's to EHR consent, displays tooltips for the new status's.
<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
