### PR TITLE
[HPRO-1356] Add Fedex Tracking field to HPO order workflow

### DIFF
--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -463,14 +463,14 @@ class OrderController extends BaseController
                             $finalizeForm['fedexTracking']['first']->addError(new FormError('Tracking number required.'));
                         }
                     }
-                }
-                if ($finalizeForm->has('fedexTracking') && !empty($finalizeForm['fedexTracking']->getData())) {
-                    $duplicateFedexTracking = $this->em->getRepository(Order::class)->getDuplicateFedexTracking(
-                        $finalizeForm['fedexTracking']->getData(),
-                        $orderId
-                    );
-                    if (!empty($duplicateFedexTracking)) {
-                        $finalizeForm['fedexTracking']['first']->addError(new FormError('This tracking number has already been used for another order.'));
+                    if ($finalizeForm->has('fedexTracking') && !empty($finalizeForm['fedexTracking']->getData())) {
+                        $duplicateFedexTracking = $this->em->getRepository(Order::class)->getDuplicateFedexTracking(
+                            $finalizeForm['fedexTracking']->getData(),
+                            $orderId
+                        );
+                        if (!empty($duplicateFedexTracking)) {
+                            $finalizeForm['fedexTracking']['first']->addError(new FormError('This tracking number has already been used for another order.'));
+                        }
                     }
                 }
                 if ($finalizeForm->isValid()) {

--- a/src/Controller/OrderController.php
+++ b/src/Controller/OrderController.php
@@ -457,21 +457,20 @@ class OrderController extends BaseController
                     $label = Order::$identifierLabel[$type[0]];
                     $finalizeForm['finalizedNotes']->addError(new FormError("Please remove participant $label \"$type[1]\""));
                 }
-                if ($order->getType() === 'kit' || $order->getType() === 'diversion') {
+                if ($order->getType() === Order::ORDER_TYPE_KIT || $order->getType() === Order::ORDER_TYPE_DIVERSION) {
                     if ($finalizeForm->has('sampleShippingMethod')) {
                         if ($finalizeForm['sampleShippingMethod']->getData() === 'fedex' && empty($finalizeForm['fedexTracking']->getData())) {
                             $finalizeForm['fedexTracking']['first']->addError(new FormError('Tracking number required.'));
                         }
                     }
-
-                    if ($finalizeForm->has('fedexTracking') && !empty($finalizeForm['fedexTracking']->getData())) {
-                        $duplicateFedexTracking = $this->em->getRepository(Order::class)->getDuplicateFedexTracking(
-                            $finalizeForm['fedexTracking']->getData(),
-                            $orderId
-                        );
-                        if (!empty($duplicateFedexTracking)) {
-                            $finalizeForm['fedexTracking']['first']->addError(new FormError('This tracking number has already been used for another order.'));
-                        }
+                }
+                if ($finalizeForm->has('fedexTracking') && !empty($finalizeForm['fedexTracking']->getData())) {
+                    $duplicateFedexTracking = $this->em->getRepository(Order::class)->getDuplicateFedexTracking(
+                        $finalizeForm['fedexTracking']->getData(),
+                        $orderId
+                    );
+                    if (!empty($duplicateFedexTracking)) {
+                        $finalizeForm['fedexTracking']['first']->addError(new FormError('This tracking number has already been used for another order.'));
                     }
                 }
                 if ($finalizeForm->isValid()) {

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -926,12 +926,12 @@ class Order
                 'system' => 'https://orders.mayomedicallaboratories.com/kit-id',
                 'value' => $this->getOrderId()
             ];
-            if (!empty($this->getFedexTracking())) {
-                $identifiers[] = [
-                    'system' => 'https://orders.mayomedicallaboratories.com/tracking-number',
-                    'value' => $this->getFedexTracking()
-                ];
-            }
+        }
+        if (!empty($this->getFedexTracking())) {
+            $identifiers[] = [
+                'system' => 'https://orders.mayomedicallaboratories.com/tracking-number',
+                'value' => $this->getFedexTracking()
+            ];
         }
         if (empty($this->params['ml_mock_order']) && $this->getMayoId() != 'pmitest') {
             $identifiers[] = [

--- a/src/Entity/Order.php
+++ b/src/Entity/Order.php
@@ -23,6 +23,9 @@ class Order
     public const ORDER_EDIT = 'edit';
     public const ORDER_REVERT = 'revert';
     public const INITIAL_VERSION = '1';
+    public const ORDER_STEP_FINALIZED = 'finalized';
+    public const ORDER_TYPE_KIT = 'kit';
+    public const ORDER_TYPE_DIVERSION = 'diversion';
 
     private $params;
     private $samples;
@@ -1519,5 +1522,11 @@ class Order
             return 'Saliva';
         }
         return 'Full HPO';
+    }
+
+    public function hideTrackingFieldByDefault(): bool
+    {
+        return $this->getFedexTracking() === null && ($this->getType() === self::ORDER_TYPE_KIT || $this->getType()
+                === self::ORDER_TYPE_DIVERSION);
     }
 }

--- a/src/Form/OrderType.php
+++ b/src/Form/OrderType.php
@@ -193,27 +193,30 @@ class OrderType extends AbstractType
                 }
             }
         }
-        // Display fedex tracking for kit and diversion type orders
-        if ($options['step'] === 'finalized' && ($options['order']->getType() === 'kit' || $options['order']->getType() === 'diversion')) {
-            $shippingMethodOptions = [
-                'label' => 'Select the sample shipping method',
-                'required' => true,
-                'disabled' => $disabled,
-                'choices' => [
-                    'Shipped via FedEx or UPS' => 'fedex',
-                    'Shipped via Courier Service' => 'courier'
-                ],
-                'multiple' => false,
-                'expanded' => true,
-                'constraints' => new Constraints\NotBlank([
-                    'message' => 'Shipping method required'
-                ])
-            ];
-            if ($options['order']->getFinalizedTs()) {
-                $shippingMethodOptions['data'] = $options['order']->getFedexTracking() ? 'fedex' : 'courier';
+        if ($options['step'] === Order::ORDER_STEP_FINALIZED) {
+            // Display shipping method for kit and diversion type orders
+            if ($options['order']->getType() === Order::ORDER_TYPE_KIT || $options['order']->getType() === Order::ORDER_TYPE_DIVERSION) {
+                $shippingMethodOptions = [
+                    'label' => 'Select the sample shipping method',
+                    'required' => true,
+                    'disabled' => $disabled,
+                    'choices' => [
+                        'Shipped via FedEx or UPS' => 'fedex',
+                        'Shipped via Courier Service' => 'courier'
+                    ],
+                    'multiple' => false,
+                    'expanded' => true,
+                    'constraints' => new Constraints\NotBlank([
+                        'message' => 'Shipping method required'
+                    ])
+                ];
+                if ($options['order']->getFinalizedTs()) {
+                    $shippingMethodOptions['data'] = $options['order']->getFedexTracking() ? 'fedex' : 'courier';
+                }
+                $builder
+                    ->add('sampleShippingMethod', Type\ChoiceType::class, $shippingMethodOptions);
             }
             $builder
-                ->add('sampleShippingMethod', Type\ChoiceType::class, $shippingMethodOptions)
                 ->add('fedexTracking', Type\RepeatedType::class, [
                     'type' => Type\TextType::class,
                     'disabled' => $disabled,

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -328,7 +328,7 @@ class OrderService
                 }
             }
         }
-        if ($step === 'finalized' && ($this->order->getType() === 'kit' || $this->order->getType() === 'diversion')) {
+        if ($step === Order::ORDER_STEP_FINALIZED && isset($formData['fedexTracking'])) {
             $this->order->setFedexTracking($formData['fedexTracking']);
         }
     }

--- a/src/Service/OrderService.php
+++ b/src/Service/OrderService.php
@@ -424,7 +424,7 @@ class OrderService
                 $formData["processedCentrifugeType"] = $this->order->getProcessedCentrifugeType();
             }
         }
-        if ($step === 'finalized' && ($this->order->getType() === 'kit' || $this->order->getType() === 'diversion')) {
+        if ($step === Order::ORDER_STEP_FINALIZED) {
             $formData['fedexTracking'] = $this->order->getFedexTracking();
         }
         return $formData;

--- a/templates/order/finalize.html.twig
+++ b/templates/order/finalize.html.twig
@@ -42,7 +42,7 @@
     </div>
 
     {% if finalizeForm.fedexTracking is defined %}
-        <div id="shipping_fields" {% if order.fedexTracking is null %} style="display:none;" {% endif %}>
+        <div id="shipping_fields" {% if order.hideTrackingFieldByDefault %} style="display:none;" {% endif %}>
             <ul class="nav nav-tabs">
                 <li role="presentation" class="active"><a href="#" id="enable-number">
                         <i class="fa fa-keyboard-o" aria-hidden="true"></i>

--- a/templates/order/finalize.html.twig
+++ b/templates/order/finalize.html.twig
@@ -42,6 +42,9 @@
     </div>
 
     {% if finalizeForm.fedexTracking is defined %}
+        {% if order.type != constant('App\\Entity\\Order::ORDER_TYPE_KIT') %}
+            <label>Enter tracking number (optional)</label>
+        {% endif %}
         <div id="shipping_fields" {% if order.hideTrackingFieldByDefault %} style="display:none;" {% endif %}>
             <ul class="nav nav-tabs">
                 <li role="presentation" class="active"><a href="#" id="enable-number">

--- a/tests/Entity/OrderTest.php
+++ b/tests/Entity/OrderTest.php
@@ -597,4 +597,46 @@ class OrderTest extends KernelTestCase
             ['3.1', '3.1']
         ];
     }
+
+    /**
+     * @dataProvider orderDataProvider
+     */
+    public function testHideTrackingFieldByDefault(?string $fedexTracking, ?string $orderType, bool $expected): void
+    {
+        $order = new Order();
+        $order->setFedexTracking($fedexTracking);
+        $order->setType($orderType);
+        $this->assertEquals($expected, $order->hideTrackingFieldByDefault());
+    }
+
+    public function orderDataProvider(): array
+    {
+        return [
+            'noFedexTrackingAndTypeIsKit' => [
+                'fedexTracking' => null,
+                'orderType' => Order::ORDER_TYPE_KIT,
+                'expected' => true
+            ],
+            'fedexTrackingAndTypeIsKit' => [
+                'fedexTracking' => '123456789',
+                'orderType' => Order::ORDER_TYPE_KIT,
+                'expected' => false,
+            ],
+            'noFedexTrackingAndTypeIsDiversion' => [
+                'fedexTracking' => null,
+                'orderType' => Order::ORDER_TYPE_DIVERSION,
+                'expected' => true,
+            ],
+            'fedexTrackingAndTypeIsDiversion' => [
+                'fedexTracking' => '123456789',
+                'orderType' => Order::ORDER_TYPE_DIVERSION,
+                'expected' => false,
+            ],
+            'fedexTrackingAndTypeIsRegular' => [
+                'fedexTracking' => '123456789',
+                'orderType' => null,
+                'expected' => false,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.1.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1356<!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/6041980/222794068-076fd9e7-9d1b-4318-988d-77a5f120aee9.png)
![image](https://user-images.githubusercontent.com/6041980/222794523-b0a0e98b-a6f0-41ba-aadf-0e0349be9f56.png)

