### PR TITLE
[HPRO-1385] Show multiple samples status per order

### DIFF
--- a/src/Controller/NphParticipantSummaryController.php
+++ b/src/Controller/NphParticipantSummaryController.php
@@ -51,7 +51,7 @@ class NphParticipantSummaryController extends AbstractController
         }
         $nphOrderInfo = $nphOrderService->getParticipantOrderSummary($participantId);
         $nphProgramSummary = $nphProgramSummaryService->getProgramSummary();
-        $combined = $nphProgramSummaryService->combineOrderSummaryWithProgramSummary($nphOrderInfo['order'], $nphProgramSummary);
+        $combined = $nphProgramSummaryService->combineOrderSummaryWithProgramSummary($nphOrderInfo, $nphProgramSummary);
         $isCrossSite = $participant->nphPairedSiteSuffix !== $siteService->getSiteId();
         $hasNoParticipantAccess = $isCrossSite && empty($session->get('agreeCrossSite_' . $participantId));
         if ($hasNoParticipantAccess) {

--- a/src/Entity/NphOrder.php
+++ b/src/Entity/NphOrder.php
@@ -319,4 +319,30 @@ class NphOrder
         }
         return false;
     }
+
+    public function getStatus(): string
+    {
+        $statusCount = [];
+        $sampleCount = count($this->nphSamples);
+        foreach ($this->nphSamples as $nphSample) {
+            $sampleStatus = $nphSample->getStatus();
+            $statusCount[$sampleStatus] = isset($statusCount[$sampleStatus]) ? $statusCount[$sampleStatus] + 1 : 1;
+        }
+        if (isset($statusCount['Canceled']) && $statusCount['Canceled'] === $sampleCount) {
+            return 'Canceled';
+        }
+        if (isset($statusCount['Canceled'])) {
+            $sampleCount = $sampleCount - $statusCount['Canceled'];
+        }
+        if (isset($statusCount['Finalized']) && $statusCount['Finalized'] === $sampleCount) {
+            return 'Finalized';
+        }
+        if (isset($statusCount['Created']) && $statusCount['Created'] === $sampleCount) {
+            return 'Created';
+        }
+        if (isset($statusCount['Collected']) && $statusCount['Collected'] === $sampleCount) {
+            return 'Collected';
+        }
+        return 'In Progress';
+    }
 }

--- a/src/Entity/NphSample.php
+++ b/src/Entity/NphSample.php
@@ -337,7 +337,7 @@ class NphSample
             return 'Unlocked';
         }
 
-        if ($this->collectedTs === null) {
+        if ($this->collectedTs === null && $this->finalizedTs === null) {
             return 'Created';
         }
 

--- a/src/Repository/NphOrderRepository.php
+++ b/src/Repository/NphOrderRepository.php
@@ -138,4 +138,14 @@ class NphOrderRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
     }
+
+    public function getOrdersByParticipantId(string $participantId): array
+    {
+        return $this->createQueryBuilder('no')
+            ->where('no.participantId = :participantId')
+            ->setParameter('participantId', $participantId)
+            ->orderBy('no.id', 'DESC')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Service/Nph/NphProgramSummaryService.php
+++ b/src/Service/Nph/NphProgramSummaryService.php
@@ -53,6 +53,7 @@ class NphProgramSummaryService
     public function combineOrderSummaryWithProgramSummary($orderSummary, $programSummary): array
     {
         $combinedSummary = [];
+        $orderSummaryOrder = $orderSummary['order'];
         foreach ($programSummary as $module => $moduleSummary) {
             foreach ($moduleSummary as $visit => $visitSummary) {
                 foreach ($visitSummary['visitInfo'] as $timePoint => $timePointSummary) {
@@ -64,10 +65,10 @@ class NphProgramSummaryService
                                 continue;
                             }
                             $expectedSamples++;
-                            if (isset($orderSummary[$module][$visit][$timePoint][$sampleType][$sampleCode]['sampleId'])) {
+                            if (isset($orderSummaryOrder[$module][$visit][$timePoint][$sampleType][$sampleCode]['sampleId'])) {
                                 $numberSamples++;
                             }
-                            $combinedSummary[$module][$visit][$timePoint][$sampleType][$sampleCode] = $orderSummary[$module][$visit][$timePoint][$sampleType][$sampleCode] ?? [];
+                            $combinedSummary[$module][$visit][$timePoint][$sampleType][$sampleCode] = $orderSummaryOrder[$module][$visit][$timePoint][$sampleType][$sampleCode] ?? [];
                         }
                         $combinedSummary[$module][$visit][$timePoint][$sampleType]['numberSamples'] = $numberSamples;
                         $combinedSummary[$module][$visit][$timePoint][$sampleType]['expectedSamples'] = $expectedSamples;
@@ -75,6 +76,7 @@ class NphProgramSummaryService
                     $combinedSummary[$module][$visit][$timePoint] = ['timePointInfo' => $combinedSummary[$module][$visit][$timePoint], 'timePointDisplayName' => $visitSummary['visitInfo'][$timePoint]['timePointDisplayName']];
                 }
                 $combinedSummary[$module][$visit] = ['visitInfo' => $combinedSummary[$module][$visit], 'visitDisplayName' => $visitSummary['visitDisplayName']];
+                $combinedSummary[$module]['sampleStatusCount'] = $orderSummary['sampleStatusCount'][$module] ?? [];
             }
         }
         return $combinedSummary;

--- a/templates/program/nph/participant/index.html.twig
+++ b/templates/program/nph/participant/index.html.twig
@@ -2,6 +2,20 @@
 
 {% block title %} NPH Participant Summary {% endblock %}
 
+{% macro generateStatusLabel(status) %}
+    {% if status == 'Collected' %}
+        {% set labelClass = 'label-primary' %}
+    {% elseif status == 'Finalized' %}
+        {% set labelClass = 'label-default' %}
+    {% elseif status == 'In Progress' %}
+        {% set labelClass = 'label-warning' %}
+    {% else %}
+        {% set labelClass = 'label-default' %}
+    {% endif %}
+
+    <div class="col-sm-2"><span class="label {{ labelClass }}">{{ status }}</span></div>
+{% endmacro %}
+
 {% block body %}
     {% if hasNoParticipantAccess %}
     <div class="row">
@@ -73,74 +87,55 @@
             <div class="ModuleGroup {{ modulePanelDisplay }}" id="ModuleGroup{{ moduleNumber }}">
                 <h4 class="col-md-12 participant-module-header">NPH Module {{ moduleNumber }} Collections</h4>
                 {% for VisitCode, visit in programSummaryAndOrderInfo[moduleNumber] %}
-                    <div>
-                        <div class="col-md-12 well-sm well" data-toggle="collapse" data-target="#{{ moduleNumber }}Visit{{ VisitCode }}"
-                             role="button">Visit {{ visit['visitDisplayName'] }}<span class="caret"
-                                                                      style="float: right; margin: 9px 0;"></span></div>
-                        <div style="margin-bottom: 20px" id="{{ moduleNumber }}Visit{{ VisitCode }}" class="collapse in">
-                            <a class="btn btn-primary" role="button"
-                               href="{{ path('nph_generate_oder', {participantId: participant.id, module: moduleNumber, visit: VisitCode}) }}">
-                                <span class="glyphicon glyphicon-plus-sign"></span> Generate Orders and Print Labels
-                            </a>
-                            {% set displayedOrderIDS = [] %}
-                            {% for timepointCode, timepoint in visit['visitInfo'] %}
-                                {% for sampleType, sampleInfo in timepoint['timePointInfo'] %}
-                                    {% if sampleInfo['numberSamples'] > 0 %}
-                                        {% if loop.first %}
-                                            <h4>Timepoint | {{ timepoint['timePointDisplayName'] }}</h4>
-                                        {% endif %}
-                                        {% set SampleGroupStatus = sampleInfo|column('sampleStatus') %}
-                                        {% if 'Unlocked' in SampleGroupStatus %}
-                                            {% set SampleGroupCollectionStatus = 'Unlocked' %}
-                                        {% elseif 'Canceled' in SampleGroupStatus %}
-                                            {% set SampleGroupCollectionStatus = 'Canceled' %}
-                                        {% elseif 'Finalized' in SampleGroupStatus %}
-                                            {% set SampleGroupCollectionStatus = 'Finalized' %}
-                                        {% elseif 'Collected' in SampleGroupStatus %}
-                                            {% set SampleGroupCollectionStatus = 'Collected' %}
-                                        {% else %}
-                                            {% set SampleGroupCollectionStatus = 'Created' %}
-                                        {% endif %}
-                                        {% set StatusCount = 0 %}
-                                        {% for sampleStatus in SampleGroupStatus %}
-                                            {% if sampleStatus == SampleGroupCollectionStatus %}
-                                                {% set StatusCount = StatusCount + 1 %}
+                    {% if VisitCode != 'sampleStatusCount' %}
+                        <div>
+                            <div class="col-md-12 well-sm well" data-toggle="collapse" data-target="#{{ moduleNumber }}Visit{{ VisitCode }}"
+                                 role="button">Visit {{ visit['visitDisplayName'] }}<span class="caret"
+                                                                                          style="float: right; margin: 9px 0;"></span></div>
+                            <div style="margin-bottom: 20px" id="{{ moduleNumber }}Visit{{ VisitCode }}" class="collapse in">
+                                <a class="btn btn-primary" role="button"
+                                   href="{{ path('nph_generate_oder', {participantId: participant.id, module: moduleNumber, visit: VisitCode}) }}">
+                                    <span class="glyphicon glyphicon-plus-sign"></span> Generate Orders and Print Labels
+                                </a>
+                                {% set displayedOrderIDS = [] %}
+                                {% for timepointCode, timepoint in visit['visitInfo'] %}
+                                    {% for sampleType, sampleInfo in timepoint['timePointInfo'] %}
+                                        {% if sampleInfo['numberSamples'] > 0 %}
+                                            {% if loop.first %}
+                                                <h4>Timepoint | {{ timepoint['timePointDisplayName'] }}</h4>
                                             {% endif %}
-                                        {% endfor %}
-                                        {% for sampleCode, sample in sampleInfo %}
-                                            {% set SampleGroupStatus = null %}
-                                            {% if sample is iterable and sample|length > 0 and sample['sampleId'] is not null and sampleInfo['numberSamples'] > 0 and sample['healthProOrderId'] not in displayedOrderIDS %}
-                                                {% set displayedOrderIDS = displayedOrderIDS|merge([sample['healthProOrderId']]) %}
-                                                {% if StatusCount == sampleInfo['expectedSamples'] and SampleGroupCollectionStatus == 'Finalized' %}
-                                                    {% set OrderStatus = 'Completed' %}
-                                                {% elseif StatusCount == sampleInfo['expectedSamples'] and SampleGroupCollectionStatus == 'Collected' %}
-                                                    {% set OrderStatus = 'Collected' %}
-                                                {% elseif SampleGroupCollectionStatus in ['Finalized', 'Collected'] %}
-                                                    {% set OrderStatus = 'In Progress' %}
-                                                {% else %}
-                                                    {% set OrderStatus = SampleGroupCollectionStatus %}
-                                                {% endif %}
-                                                <div class="well well-sm row">
-                                                    <div class="col-sm-2">{{ sample['createDate'] }}</div>
-                                                    <div class="col-sm-3"><a
-                                                            href="{{ path('nph_order_collect', {participantId: participant.id, orderId: sample['healthProOrderId']}) }}">Order
-                                                            ID: {{ sample['orderId'] }}</a></div>
-                                                    <div class="col-sm-2">{{ sample['sampleTypeDisplayName'] }}</div>
-                                                    <div class="col-sm-2">{{ OrderStatus ?? 'Created' }}</div>
-                                                    <div class="col-sm-3">({{ StatusCount }}
-                                                        /{{ sampleInfo['expectedSamples'] }} {{ SampleGroupCollectionStatus }})
+                                            {% set StatusCount = 0 %}
+                                            {% for sampleCode, sample in sampleInfo %}
+                                                {% set SampleGroupStatus = null %}
+                                                {% if sample is iterable and sample|length > 0 and sample['sampleId'] is not null and sampleInfo['numberSamples'] > 0 and sample['healthProOrderId'] not in displayedOrderIDS %}
+                                                    {% set displayedOrderIDS = displayedOrderIDS|merge([sample['healthProOrderId']]) %}
+                                                    <div class="well well-sm row">
+                                                        <div class="col-sm-2">{{ sample['createDate'] }}</div>
+                                                        <div class="col-sm-3"><a
+                                                                href="{{ path('nph_order_collect', {participantId: participant.id, orderId: sample['healthProOrderId']}) }}">Order
+                                                                ID: {{ sample['orderId'] }}</a></div>
+                                                        <div class="col-sm-2">{{ sample['sampleTypeDisplayName'] }}</div>
+                                                        {{ _self.generateStatusLabel(sample['orderStatus']) }}
+                                                        {% for sampleStatus, sampleStatusCount in programSummaryAndOrderInfo[moduleNumber]['sampleStatusCount'][sample['orderId']]|sort %}
+                                                            {% if not loop.first %}
+                                                                <div class="col-sm-9"></div>
+                                                            {% endif %}
+                                                        <div class="col-sm-3 float-right">({{ sampleStatusCount }}
+                                                            / {{ sampleInfo['expectedSamples'] }}) {{ sampleStatus }}
+                                                        </div>
+                                                        {% endfor %}
                                                     </div>
-                                                </div>
-                                            {% endif %}
-                                        {% endfor %}
-                                    {% endif %}
+                                                {% endif %}
+                                            {% endfor %}
+                                        {% endif %}
+                                    {% endfor %}
                                 {% endfor %}
-                            {% endfor %}
-                            {% if displayedOrderIDS is empty %}
-                                <h4>No Orders Generated</h4>
-                            {% endif %}
+                                {% if displayedOrderIDS is empty %}
+                                    <h4>No Orders Generated</h4>
+                                {% endif %}
+                            </div>
                         </div>
-                    </div>
+                    {% endif %}
                 {% endfor %}
             </div>
         {% endfor %}

--- a/tests/Entity/NphOrderTest.php
+++ b/tests/Entity/NphOrderTest.php
@@ -161,4 +161,83 @@ class NphOrderTest extends NphTestCase
             ]
         ];
     }
+
+    /**
+     * @dataProvider getOrderStatusDataProvider
+     */
+    public function testGetOrderStatus($samples, $expectedStatus) {
+        $orderData = $this->getOrderData();
+        $nphOrder = $this->createNphOrder($orderData);
+        foreach ($samples as $sample) {
+            $sample['nphOrder'] = $nphOrder;
+            $this->createNphSample($sample);
+        }
+        $this->assertSame($expectedStatus, $nphOrder->getStatus());
+        $nphOrder->getStatus();
+    }
+
+    public function getOrderStatusDataProvider(): array {
+        $finalizedTs = new \DateTime('2023-01-01 08:00:00');
+        $collectedTs = new \DateTime('2023-01-01 08:00:00');
+        return [
+            [
+                [
+                    [
+                        'sampleId' => '1000000000',
+                        'sampleCode' => 'ST1',
+                        'finalizedTs' => $finalizedTs
+                    ],
+                    [
+                        'sampleId' => '2000000000',
+                        'sampleCode' => 'ST2',
+                        'finalizedTs' => $finalizedTs
+                    ],
+                ],
+                'Finalized'
+            ],
+            [
+                [
+                    [
+                        'sampleId' => '3000000000',
+                        'sampleCode' => 'ST1',
+                        'finalizedTs' => $finalizedTs
+                    ],
+                    [
+                        'sampleId' => '4000000000',
+                        'sampleCode' => 'ST2',
+                    ],
+                ],
+                'In Progress'
+            ],
+            [
+                [
+                    [
+                        'sampleId' => '5000000000',
+                        'sampleCode' => 'ST1',
+                        'collectedTs' => $collectedTs
+                    ],
+                    [
+                        'sampleId' => '6000000000',
+                        'sampleCode' => 'ST2',
+                    ],
+                ],
+                'In Progress'
+            ],
+            [
+                [
+                    [
+                        'sampleId' => '7000000000',
+                        'sampleCode' => 'ST1',
+                        'collectedTs' => $collectedTs
+                    ],
+                    [
+                        'sampleId' => '8000000000',
+                        'sampleCode' => 'ST2',
+                        'collectedTs' => $collectedTs
+                    ],
+                ],
+                'Collected'
+            ],
+        ];
+    }
 }

--- a/tests/Service/NphOrderServiceTest.php
+++ b/tests/Service/NphOrderServiceTest.php
@@ -404,7 +404,7 @@ class NphOrderServiceTest extends ServiceTestCase
     public function testGetParticipantOrderSummary(): void
     {
         $orderSummary = $this->service->getParticipantOrderSummary('P0000000001');
-        $this->assertSame(array('order' => array(), 'sampleCount' => 0), $orderSummary);
+        $this->assertSame(array('order' => array(), 'sampleCount' => 0, 'sampleStatusCount' => []), $orderSummary);
         $participant = $this->testSetup->generateParticipant();
         $this->testSetup->generateNPHOrder($participant, self::getContainer()->get(UserService::class)->getUserEntity(), self::getContainer()->get(SiteService::class));
         $orderSummary = $this->service->getParticipantOrderSummary($participant->id);


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.2.0 <!-- which milestone is this for? -->
| Bug fix?            | ✅/❌ <!-- fixes an issue -->
| New feature?        | ✅/❌ <!-- adds a new feature/behavior change -->
| Database migration? | ✅/❌ <!-- lets us know to look for migrations -->
| New configuration?  | ✅/❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ✅/❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ✅/❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1385 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/666617/223767068-04e06a98-81d2-4309-9b58-4fb88eaefb34.png)
