### PR TITLE
[HPRO-1387] Only allow restore of samples without active samples.

### DIFF
--- a/src/Controller/NphOrderController.php
+++ b/src/Controller/NphOrderController.php
@@ -152,8 +152,10 @@ class NphOrderController extends BaseController
                 $oderCollectForm->addError(new FormError('Please correct the errors below'));
             }
         }
+        $activeSamples = $this->em->getRepository(NphSample::class)->findActiveSampleCodes($order, $this->siteService->getSiteId());
         return $this->render('program/nph/order/collect.html.twig', [
             'order' => $order,
+            'activeSamples' => $activeSamples,
             'orderCollectForm' => $oderCollectForm->createView(),
             'participant' => $participant,
             'timePoints' => $nphOrderService->getTimePoints(),
@@ -371,9 +373,10 @@ class NphOrderController extends BaseController
         if ($order->canModify($type) === false) {
             throw $this->createNotFoundException();
         }
+        $activeSamples = $this->em->getRepository(NphSample::class)->findActiveSampleCodes($order, $this->siteService->getSiteId());
         $nphOrderService->loadModules($order->getModule(), $order->getVisitType(), $participantId, $participant->biobankId);
         $nphSampleModifyForm = $this->createForm(NphSampleModifyType::class, null, [
-            'type' => $type, 'samples' => $order->getNphSamples()
+            'type' => $type, 'samples' => $order->getNphSamples(), 'activeSamples' => $activeSamples
         ]);
         $nphSampleModifyForm->handleRequest($request);
         if ($nphSampleModifyForm->isSubmitted()) {
@@ -402,6 +405,7 @@ class NphOrderController extends BaseController
             }
         }
         return $this->render('program/nph/order/sample-modify.html.twig', [
+            'activeSamples' => $activeSamples,
             'participant' => $participant,
             'order' => $order,
             'sampleModifyForm' => $nphSampleModifyForm->createView(),

--- a/src/Entity/NphOrder.php
+++ b/src/Entity/NphOrder.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use App\Repository\NphOrderRepository;
+use App\Repository\NphSampleRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -257,10 +258,10 @@ class NphOrder
         return false;
     }
 
-    public function canRestore(): bool
+    public function canRestore(array $activeSamples = []): bool
     {
         foreach ($this->getNphSamples() as $nphSample) {
-            if ($nphSample->getModifyType() === NphSample::CANCEL) {
+            if ($nphSample->getModifyType() === NphSample::CANCEL && !in_array($nphSample->getSampleCode(), $activeSamples, true)){
                 return true;
             }
         }

--- a/src/Entity/NphOrder.php
+++ b/src/Entity/NphOrder.php
@@ -261,7 +261,7 @@ class NphOrder
     public function canRestore(array $activeSamples = []): bool
     {
         foreach ($this->getNphSamples() as $nphSample) {
-            if ($nphSample->getModifyType() === NphSample::CANCEL && !in_array($nphSample->getSampleCode(), $activeSamples, true)){
+            if ($nphSample->getModifyType() === NphSample::CANCEL && !in_array($nphSample->getSampleCode(), $activeSamples, true)) {
                 return true;
             }
         }

--- a/src/Form/Nph/NphSampleModifyType.php
+++ b/src/Form/Nph/NphSampleModifyType.php
@@ -17,17 +17,24 @@ class NphSampleModifyType extends AbstractType
             $samples = $options['samples'];
             foreach ($samples as $sample) {
                 $disabled = false;
+                $checked = false;
                 if ($options['type'] === NphSample::CANCEL) {
                     $disabled = $sample->getModifyType() === NphSample::CANCEL;
+                    $checked = true;
                 } elseif ($options['type'] === NphSample::RESTORE) {
                     $disabled = $sample->getModifyType() !== NphSample::CANCEL;
+                    $checked = true;
+                    if (!$disabled) {
+                        $disabled = in_array($sample->getSampleCode(), $options['activeSamples'], true);
+                        $checked = false;
+                    }
                 }
                 $builder->add($sample->getSampleCode(), Type\CheckboxType::class, [
                     'label' => false,
                     'required' => false,
                     'disabled' => $disabled,
                     'attr' => [
-                        'checked' => $disabled
+                        'checked' => $checked,
                     ]
                 ]);
             }
@@ -90,6 +97,7 @@ class NphSampleModifyType extends AbstractType
         $resolver->setDefaults([
             'type' => null,
             'samples' => null,
+            'activeSamples' => null,
         ]);
     }
 }

--- a/src/Repository/NphSampleRepository.php
+++ b/src/Repository/NphSampleRepository.php
@@ -60,12 +60,14 @@ class NphSampleRepository extends ServiceEntityRepository
             ->andWhere('o.visitType = :visitType')
             ->andWhere('o.site = :site')
             ->andWhere('s.modifyType IN (:types) or s.modifyType is null')
-            ->setParameter('participantId', $order->getParticipantId())
-            ->setParameter('module', $order->getModule())
-            ->setParameter('timepoint', $order->getTimepoint())
-            ->setParameter('visitType', $order->getVisitType())
-            ->setParameter('site', $site)
-            ->setParameter('types', [NphSample::RESTORE, NphSample::UNLOCK, NphSample::EDITED, NphSample::REVERT])
+            ->setParameters([
+                'participantId' => $order->getParticipantId(),
+                'module' => $order->getModule(),
+                'timepoint' => $order->getTimepoint(),
+                'visitType' => $order->getVisitType(),
+                'site' => $site,
+                'types' => [NphSample::RESTORE, NphSample::UNLOCK, NphSample::EDITED, NphSample::REVERT]
+            ])
             ->getQuery()
             ->getResult(\Doctrine\ORM\Query::HYDRATE_SCALAR_COLUMN)
         ;

--- a/src/Repository/NphSampleRepository.php
+++ b/src/Repository/NphSampleRepository.php
@@ -2,6 +2,7 @@
 
 namespace App\Repository;
 
+use App\Entity\NphOrder;
 use App\Entity\NphSample;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Persistence\ManagerRegistry;
@@ -47,4 +48,26 @@ class NphSampleRepository extends ServiceEntityRepository
         ;
     }
     */
+
+    public function findActiveSampleCodes(NphOrder $order, $site)
+    {
+        return $this->createQueryBuilder('s')
+            ->select('s.sampleCode')
+            ->join('s.nphOrder', 'o')
+            ->andWhere('o.participantId = :participantId')
+            ->andWhere('o.module = :module')
+            ->andWhere('o.timepoint = :timepoint')
+            ->andWhere('o.visitType = :visitType')
+            ->andWhere('o.site = :site')
+            ->andWhere('s.modifyType IN (:types) or s.modifyType is null')
+            ->setParameter('participantId', $order->getParticipantId())
+            ->setParameter('module', $order->getModule())
+            ->setParameter('timepoint', $order->getTimepoint())
+            ->setParameter('visitType', $order->getVisitType())
+            ->setParameter('site', $site)
+            ->setParameter('types', [NphSample::RESTORE, NphSample::UNLOCK, NphSample::EDITED, NphSample::REVERT])
+            ->getQuery()
+            ->getResult(\Doctrine\ORM\Query::HYDRATE_SCALAR_COLUMN)
+        ;
+    }
 }

--- a/templates/program/nph/order/collect.html.twig
+++ b/templates/program/nph/order/collect.html.twig
@@ -35,7 +35,7 @@
                                 Cancel
                             </a>
                         {% endif %}
-                        {% if order.canRestore %}
+                        {% if order.canRestore(activeSamples) %}
                             <a href="{{ path('nph_samples_modify', { participantId: participant.id, orderId: order.id,
                                 type: 'restore' }) }}" class="btn btn-xs btn-success">
                                 Restore

--- a/templates/program/nph/order/sample-modify.html.twig
+++ b/templates/program/nph/order/sample-modify.html.twig
@@ -77,7 +77,7 @@
                     </p>
                 </td>
             </tr>
-            {% if nphSample.modifyType == 'cancel' and nphSample.sampleCode in activeSamples %}
+            {% if nphSample.modifyType == constant('App\\Entity\\NphSample::CANCEL') and nphSample.sampleCode in activeSamples %}
             <tr class="row-message"><td></td><td colspan="3"><span class="text-warning">An active order already exists for this timepoint/sample. To restore this sample, cancel the active order.</span></td></tr>
             {% endif %}
         {% endfor %}

--- a/templates/program/nph/order/sample-modify.html.twig
+++ b/templates/program/nph/order/sample-modify.html.twig
@@ -36,7 +36,7 @@
         </thead>
         <tbody class="modify-samples">
         {% for index, nphSample in order.nphSamples %}
-            {% if nphSample.modifyType == 'cancel' and nphSample.sampleCode in activeSamples %}
+            {% if nphSample.modifyType == constant('App\\Entity\\NphSample::CANCEL') and nphSample.sampleCode in activeSamples %}
                 {% set sampleClass = 'no-restore' %}
             {% else %}
                 {% set sampleClass = '' %}
@@ -47,7 +47,7 @@
                 </td>
                 <td>
                     <p>({{ index + 1 }}) {{ samples[nphSample.sampleCode] }} ({{ nphSample.sampleId }})
-                    {% if nphSample.modifyType == 'cancel'%}
+                    {% if nphSample.modifyType == constant('App\\Entity\\NphSample::CANCEL')%}
                         <span class="text-danger">Cancelled</span>
                     {% else %}
                         <span class="text-success">Active</span>

--- a/templates/program/nph/order/sample-modify.html.twig
+++ b/templates/program/nph/order/sample-modify.html.twig
@@ -36,19 +36,26 @@
         </thead>
         <tbody class="modify-samples">
         {% for index, nphSample in order.nphSamples %}
-            <tr class="row-samples">
+            {% if nphSample.modifyType == 'cancel' and nphSample.sampleCode in activeSamples %}
+                {% set sampleClass = 'no-restore' %}
+            {% else %}
+                {% set sampleClass = '' %}
+            {% endif %}
+            <tr class="row-samples {{ sampleClass }}">
                 <td>
                     {{ form_widget(sampleModifyForm[nphSample.sampleCode]) }}
                 </td>
                 <td>
-                    ({{ index + 1 }}) {{ samples[nphSample.sampleCode] }} ({{ nphSample.sampleId }})
-                    {% if nphSample.modifyType == 'cancel' %}
+                    <p>({{ index + 1 }}) {{ samples[nphSample.sampleCode] }} ({{ nphSample.sampleId }})
+                    {% if nphSample.modifyType == 'cancel'%}
                         <span class="text-danger">Cancelled</span>
                     {% else %}
                         <span class="text-success">Active</span>
                     {% endif %}
+                    </p>
                 </td>
                 <td>
+                    <p>
                     {% if nphSample.collectedTs is not empty %}
                         <i class="fa fa-check text-success" aria-hidden="true"></i>
                         {{ nphSample.collectedTs|date('n/j/Y g:ia', app.user.timezone) }}
@@ -56,8 +63,10 @@
                     {% else %}
                         <i class="fa fa-times text-danger"></i>
                     {% endif %}
+                    </p>
                 </td>
                 <td>
+                    <p>
                     {% if nphSample.finalizedTs is not empty %}
                         <i class="fa fa-check text-success" aria-hidden="true"></i>
                         {{ nphSample.finalizedTs|date('n/j/Y g:ia', app.user.timezone) }}
@@ -65,8 +74,12 @@
                     {% else %}
                         <i class="fa fa-times text-danger"></i>
                     {% endif %}
+                    </p>
                 </td>
             </tr>
+            {% if nphSample.modifyType == 'cancel' and nphSample.sampleCode in activeSamples %}
+            <tr class="row-message"><td></td><td colspan="3"><span class="text-warning">An active order already exists for this timepoint/sample. To restore this sample, cancel the active order.</span></td></tr>
+            {% endif %}
         {% endfor %}
         <tr>
             <td colspan="3" {% if not sampleModifyForm['samplesCheckAll'].vars.valid %}

--- a/web/assets/css/nph.css
+++ b/web/assets/css/nph.css
@@ -82,3 +82,11 @@ table tr td input.aliquot-volume {
 li.participant-activity > a {
     padding: 10px 29px
 }
+.table>tbody>tr.row-message>td {
+    padding: 0 0 10px 0;
+    margin: 0;
+}
+.table>tbody>tr.row-samples>td>p {
+    margin-bottom: 10px;
+    margin-top: 10px;
+}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.2.0<!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1387 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/666617/224373063-95ec2558-69c8-483f-b866-d99a2aa20aaa.png)
![image](https://user-images.githubusercontent.com/666617/224373264-b4f1bf98-e24b-423f-b305-ee74608ae34e.png)
