### PR TITLE
[HPRO-1396] Fix aliquot time field width in sample finalize page

### DIFF
--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -155,12 +155,11 @@
                             <thead>
                             <tr>
                                 <td class="col-md-4 required aliquot-tube-td" id="aliquot-tube">Matrix Aliquot Tube/Aliquot Container</td>
-                                <td class="col-md-3 required">Aliquot Time</td>
+                                <td class="col-md-4 required">Aliquot Time</td>
                                 <td class="col-md-2 required">Volume</td>
                                 <td class="col-md-1"></td>
-                                {% if sample.modifyType == 'unlock' %}
-                                    <td class="col-md-1">Remove</td>
-                                    <td class="col-md-1">Restore</td>
+                                {% if sample.modifyType == constant('UNLOCK', sample) %}
+                                    <td class="col-md-1">Remove&nbsp;&nbsp;Restore</td>
                                 {% endif %}
                             </tr>
                             </thead>
@@ -224,8 +223,14 @@
                                                     {% endif %}
                                                 </td>
                                                 {% if sampleFinalizeForm['cancel_' ~ aliquotCode ~ '_' ~ aliquotId] is defined %}
-                                                    <td>{{ form_widget(sampleFinalizeForm['cancel_' ~ aliquotCode ~ '_' ~ aliquotId]) }}</td>
-                                                    <td>{{ form_widget(sampleFinalizeForm['restore_' ~ aliquotCode ~ '_' ~ aliquotId]) }}</td>
+                                                    <td class="row">
+                                                        <div class="col-md-6">
+                                                            {{ form_widget(sampleFinalizeForm['cancel_' ~ aliquotCode ~ '_' ~ aliquotId]) }}
+                                                        </div>
+                                                        <div class="col-md-6">
+                                                            {{ form_widget(sampleFinalizeForm['restore_' ~ aliquotCode ~ '_' ~ aliquotId]) }}
+                                                        </div>
+                                                    </td>
                                                 {% endif %}
                                             </tr>
                                         {% endif %}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.3.0 <!-- which milestone is this for? -->
| Bug fix?            | ✅<!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1396<!-- Tag which ticket(s) this PR relates to -->


### Screenshots <!-- if applicable -->
<img width="1216" alt="image" src="https://user-images.githubusercontent.com/6041980/226466363-23fb08fd-dbbf-4259-a0a6-5e0a78ff7044.png">

