### PR TITLE
[HPRO-1388] Fix for unknown constants, don't display cancelled orders in unfinalized

### DIFF
--- a/src/Repository/NphOrderRepository.php
+++ b/src/Repository/NphOrderRepository.php
@@ -107,7 +107,7 @@ class NphOrderRepository extends ServiceEntityRepository
             ->join('no.nphSamples', 'ns')
             ->where('no.site = :site')
             ->andWhere('ns.finalizedTs IS NULL')
-            ->andWhere('ns.modifyType != :modifyType')
+            ->andWhere('ns.modifyType != :modifyType OR ns.modifyType IS NULL')
             ->setParameters(['site' => $siteId, 'modifyType' => NphSample::CANCEL])
             ->getQuery()
             ->getResult();
@@ -121,7 +121,7 @@ class NphOrderRepository extends ServiceEntityRepository
             ->join('no.nphSamples', 'ns')
             ->where('ns.finalizedTs IS NULL')
             ->andWhere('no.site = :site')
-            ->andWhere('ns.modifyType != :modifyType')
+            ->andWhere('ns.modifyType != :modifyType OR ns.modifyType IS NULL')
             ->setParameters(['site' => $site, 'modifyType' => NphSample::CANCEL])
             ->orderBy('no.id', 'ASC')
             ->getQuery()

--- a/src/Repository/NphOrderRepository.php
+++ b/src/Repository/NphOrderRepository.php
@@ -4,6 +4,7 @@ namespace App\Repository;
 
 use App\Entity\NphFieldSort;
 use App\Entity\NphOrder;
+use App\Entity\NphSample;
 use DateTime;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\ORM\Query\Expr\Join;
@@ -106,7 +107,8 @@ class NphOrderRepository extends ServiceEntityRepository
             ->join('no.nphSamples', 'ns')
             ->where('no.site = :site')
             ->andWhere('ns.finalizedTs IS NULL')
-            ->setParameter('site', $siteId)
+            ->andWhere('ns.modifyType != :modifyType')
+            ->setParameters(['site' => $siteId, 'modifyType' => NphSample::CANCEL])
             ->getQuery()
             ->getResult();
     }
@@ -119,7 +121,8 @@ class NphOrderRepository extends ServiceEntityRepository
             ->join('no.nphSamples', 'ns')
             ->where('ns.finalizedTs IS NULL')
             ->andWhere('no.site = :site')
-            ->setParameter('site', $site)
+            ->andWhere('ns.modifyType != :modifyType')
+            ->setParameters(['site' => $site, 'modifyType' => NphSample::CANCEL])
             ->orderBy('no.id', 'ASC')
             ->getQuery()
             ->getResult();

--- a/templates/program/nph/review/recently_modified.html.twig
+++ b/templates/program/nph/review/recently_modified.html.twig
@@ -55,13 +55,13 @@
                 {% else %}
                     <td><i class="fa fa-times text-danger" aria-hidden="true"></i></td>
                 {% endif %}
-                {% if sample.modifyType == constant('UNLOCK', sample) %}
+                {% if sample.modifyType == constant('App\\Entity\\NphSample::UNLOCK') %}
                     <td><p class="btn btn-sm btn-warning">Unlocked</p></td>
-                {% elseif sample.modifyType == constant('CANCEL', sample) %}
+                {% elseif sample.modifyType == constant('App\\Entity\\NphSample::CANCEL') %}
                     <td><p class="btn btn-sm btn-danger">Cancelled</p></td>
                 {% elseif sample.finalizedTs is null %}
                     <td><p class="btn btn-sm btn-warning">Unfinalized</p></td>
-                {% elseif sample.finalizedTs is not null and sample.modifyType == constant('EDITED', sample) %}
+                {% elseif sample.finalizedTs is not null and sample.modifyType == constant('App\\Entity\\NphSample::EDITED') %}
                     <td><p class="btn btn-sm btn-success">Edited and Finalized</p></td>
                 {% elseif sample.finalizedTs is not null %}
                     <td><p class="btn btn-sm btn-success">Finalized</p></td>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1388 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Changes references to constants and removes cancelled orders from the unfinalized view.

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
