### PR TITLE
[HPRO-1411] Prevent finalized button from clicking when the form is disabled

### DIFF
--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -261,8 +261,8 @@
                         {{ form_errors(sampleFinalizeForm[sampleCode ~ 'Notes']) }}
                     </div>
                     <p>
-                        <button type="submit" class="btn btn-primary {% if sample.disabled %} disabled {% endif %}"
-                                id="sample_finalize_btn" formnovalidate>
+                        <button type="submit" class="btn btn-primary" id="sample_finalize_btn"
+                                {% if sample.disabled %} disabled {% endif %} formnovalidate>
                             Mark as Finalized
                         </button>
                         <a href="{{ path('nph_samples_aliquot') }}" class="btn btn-default">Cancel</a>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.2.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1411<!-- Tag which ticket(s) this PR relates to -->

