### PR TITLE
[HPRO-1415] Better detection of required aliquots. Dynamic error message.

### DIFF
--- a/src/Form/Nph/NphSampleFinalizeType.php
+++ b/src/Form/Nph/NphSampleFinalizeType.php
@@ -65,9 +65,17 @@ class NphSampleFinalizeType extends NphOrderForm
                                     $context->buildViolation('Barcode is required')->addViolation();
                                 }
                             }),
-                            new Constraints\Callback(function ($value, $context) use ($aliquot) {
-                                if (($aliquot['required'] ?? false) && empty($value) && !empty($context->getValue())) {
-                                    $context->buildViolation('At least one 500 μL aliquot is required')->addViolation();
+                            new Constraints\Callback(function ($value, $context) use ($aliquot, $aliquotCode) {
+                                if ($aliquot['required'] ?? false) {
+                                    $requiredFilled = false;
+                                    foreach ($context->getRoot()->getData()[$aliquotCode] as $key => $aliquotId) {
+                                        if (!empty($aliquotId)) {
+                                            $requiredFilled = true;
+                                        }
+                                    }
+                                    if (!$requiredFilled) {
+                                        $context->buildViolation("At least one {$aliquot['expectedVolume']}{$aliquot['units']} aliquot is required")->addViolation();
+                                    }
                                 }
                             })
                         ],


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.3.0 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1415 <!-- Tag which ticket(s) this PR relates to -->

### Summary
Better solution for checking for required aliquots being filled. Should fix issue with the double 500uL p800 aliquots.
<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
