### PR TITLE
[HPRO-1409] Display all old orders, even cancelled. Display cancelled status text.

### DIFF
--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -499,7 +499,7 @@ class NphOrderService
         $returnArray['sampleStatusCount'] = $statusCount;
         return $returnArray;
     }
-    
+
     public function hasAtLeastOneAliquotSample(array $formData, string $sampleCode): bool
     {
         $aliquots = $this->getAliquots($sampleCode);
@@ -830,56 +830,6 @@ class NphOrderService
     private function mapMetadata($metadata, $type, $values): string
     {
         return isset($metadata[$type]) ? array_search($metadata[$type], $values) : '';
-    }
-
-    private function generateOrderSummaryArray(array $nphOrder): array
-    {
-        $sampleCount = 0;
-        $orderSummary = [];
-        $statusCount = [];
-        foreach ($nphOrder as $order) {
-            $samples = $order->getNphSamples()->toArray();
-            foreach ($samples as $sample) {
-                $sampleCount++;
-                $moduleClass = 'App\Nph\Order\Modules\Module' . $order->getModule();
-                $module = new $moduleClass($order->getVisitType());
-                $sampleName = $module->getSampleLabelFromCode($sample->getSampleCode());
-                $timePointsDisplay = $module->getTimePoints();
-                $sampleCollectionVolume = $module->getSampleCollectionVolumeFromCode($sample->getSampleCode());
-                $visitTypes = $module->getVisitTypes();
-                $sampleStatus = $sample->getStatus();
-                $orderId = $order->getOrderId();
-                if (isset($orderSummary[$order->getModule()][$order->getVisitType()][$order->getTimepoint()][$module->getSampleType($sample->getSampleCode())][$sample->getSampleCode()])) {
-                    continue;
-                }
-                $orderSummary[$order->getModule()]
-                [$order->getVisitType()]
-                [$order->getTimepoint()]
-                [$module->getSampleType($sample->getSampleCode())]
-                [$sample->getSampleCode()] = [
-                    'sampleId' => $sample->getSampleID(),
-                    'sampleName' => $sampleName,
-                    'orderId' => $order->getOrderId(),
-                    'healthProOrderId' => $order->getId(),
-                    'createDate' => $order->getCreatedTs()->format('m/d/Y'),
-                    'sampleStatus' => $sampleStatus,
-                    'sampleCollectionVolume' => $sampleCollectionVolume,
-                    'timepointDisplayName' => $timePointsDisplay[$order->getTimepoint()],
-                    'sampleTypeDisplayName' => ucwords($module->getSampleType($sample->getSampleCode())),
-                    'identifier' => $module->getSampleIdentifierFromCode($sample->getSampleCode()),
-                    'visitDisplayName' => $visitTypes[$order->getVisitType()],
-                    'sampleGroup' => $sample->getSampleGroup(),
-                    'modifyType' => $sample->getModifyType(),
-                    'orderStatus' => $order->getStatus(),
-                ];
-                $statusCount[$order->getModule()][$orderId][$sampleStatus] = isset($statusCount[$order->getModule()][$orderId][$sampleStatus]) ? $statusCount[$order->getModule()][$orderId][$sampleStatus] + 1 : 1;
-            }
-        }
-        $returnArray = [];
-        $returnArray['order'] = $orderSummary;
-        $returnArray['sampleCount'] = $sampleCount;
-        $returnArray['sampleStatusCount'] = $statusCount;
-        return $returnArray;
     }
 
     private function saveSampleFinalization(array $formData, NphSample $sample): bool

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -452,54 +452,6 @@ class NphOrderService
         return $orderSummary;
     }
 
-    private function generateOrderSummaryArray(array $nphOrder): array
-    {
-        $sampleCount = 0;
-        $orderSummary = array();
-        $statusCount = [];
-        foreach ($nphOrder as $order) {
-            $samples = $order->getNphSamples()->toArray();
-            foreach ($samples as $sample) {
-                $sampleCount++;
-                $moduleClass = 'App\Nph\Order\Modules\Module' . $order->getModule();
-                $module = new $moduleClass($order->getVisitType());
-                $sampleName = $module->getSampleLabelFromCode($sample->getSampleCode());
-                $timePointsDisplay = $module->getTimePoints();
-                $sampleCollectionVolume = $module->getSampleCollectionVolumeFromCode($sample->getSampleCode());
-                $visitTypes = $module->getVisitTypes();
-                $sampleStatus = $sample->getStatus();
-                $orderId = $order->getOrderId();
-                $orderSummary[$order->getModule()]
-                [$order->getVisitType()]
-                [$order->getTimepoint()]
-                [$module->getSampleType($sample->getSampleCode())]
-                [$sample->getSampleCode()]
-                [$order->getOrderId()] = [
-                    'sampleId' => $sample->getSampleID(),
-                    'sampleName' => $sampleName,
-                    'orderId' => $order->getOrderId(),
-                    'healthProOrderId' => $order->getId(),
-                    'createDate' => $order->getCreatedTs()->format('m/d/Y'),
-                    'sampleStatus' => $sampleStatus,
-                    'sampleCollectionVolume' => $sampleCollectionVolume,
-                    'timepointDisplayName' => $timePointsDisplay[$order->getTimepoint()],
-                    'sampleTypeDisplayName' => ucwords($module->getSampleType($sample->getSampleCode())),
-                    'identifier' => $module->getSampleIdentifierFromCode($sample->getSampleCode()),
-                    'visitDisplayName' => $visitTypes[$order->getVisitType()],
-                    'sampleGroup' => $sample->getSampleGroup(),
-                    'modifyType' => $sample->getModifyType(),
-                    'orderStatus' => $order->getStatus(),
-                ];
-                $statusCount[$order->getModule()][$orderId][$sampleStatus] = isset($statusCount[$order->getModule()][$orderId][$sampleStatus]) ? $statusCount[$order->getModule()][$orderId][$sampleStatus] + 1 : 1;
-            }
-        }
-        $returnArray = array();
-        $returnArray['order'] = $orderSummary;
-        $returnArray['sampleCount'] = $sampleCount;
-        $returnArray['sampleStatusCount'] = $statusCount;
-        return $returnArray;
-    }
-
     public function hasAtLeastOneAliquotSample(array $formData, string $sampleCode): bool
     {
         $aliquots = $this->getAliquots($sampleCode);
@@ -796,6 +748,54 @@ class NphOrderService
             }
         }
         return $formErrors;
+    }
+
+    private function generateOrderSummaryArray(array $nphOrder): array
+    {
+        $sampleCount = 0;
+        $orderSummary = [];
+        $statusCount = [];
+        foreach ($nphOrder as $order) {
+            $samples = $order->getNphSamples()->toArray();
+            foreach ($samples as $sample) {
+                $sampleCount++;
+                $moduleClass = 'App\Nph\Order\Modules\Module' . $order->getModule();
+                $module = new $moduleClass($order->getVisitType());
+                $sampleName = $module->getSampleLabelFromCode($sample->getSampleCode());
+                $timePointsDisplay = $module->getTimePoints();
+                $sampleCollectionVolume = $module->getSampleCollectionVolumeFromCode($sample->getSampleCode());
+                $visitTypes = $module->getVisitTypes();
+                $sampleStatus = $sample->getStatus();
+                $orderId = $order->getOrderId();
+                $orderSummary[$order->getModule()]
+                [$order->getVisitType()]
+                [$order->getTimepoint()]
+                [$module->getSampleType($sample->getSampleCode())]
+                [$sample->getSampleCode()]
+                [$order->getOrderId()] = [
+                    'sampleId' => $sample->getSampleID(),
+                    'sampleName' => $sampleName,
+                    'orderId' => $order->getOrderId(),
+                    'healthProOrderId' => $order->getId(),
+                    'createDate' => $order->getCreatedTs()->format('m/d/Y'),
+                    'sampleStatus' => $sampleStatus,
+                    'sampleCollectionVolume' => $sampleCollectionVolume,
+                    'timepointDisplayName' => $timePointsDisplay[$order->getTimepoint()],
+                    'sampleTypeDisplayName' => ucwords($module->getSampleType($sample->getSampleCode())),
+                    'identifier' => $module->getSampleIdentifierFromCode($sample->getSampleCode()),
+                    'visitDisplayName' => $visitTypes[$order->getVisitType()],
+                    'sampleGroup' => $sample->getSampleGroup(),
+                    'modifyType' => $sample->getModifyType(),
+                    'orderStatus' => $order->getStatus(),
+                ];
+                $statusCount[$order->getModule()][$orderId][$sampleStatus] = isset($statusCount[$order->getModule()][$orderId][$sampleStatus]) ? $statusCount[$order->getModule()][$orderId][$sampleStatus] + 1 : 1;
+            }
+        }
+        $returnArray = [];
+        $returnArray['order'] = $orderSummary;
+        $returnArray['sampleCount'] = $sampleCount;
+        $returnArray['sampleStatusCount'] = $statusCount;
+        return $returnArray;
     }
 
     private function getStoolTimePoint(array $formData): ?string

--- a/src/Service/Nph/NphOrderService.php
+++ b/src/Service/Nph/NphOrderService.php
@@ -491,14 +491,12 @@ class NphOrderService
                 $visitTypes = $module->getVisitTypes();
                 $sampleStatus = $sample->getStatus();
                 $orderId = $order->getOrderId();
-                if (isset($orderSummary[$order->getModule()][$order->getVisitType()][$order->getTimepoint()][$module->getSampleType($sample->getSampleCode())][$sample->getSampleCode()])) {
-                    continue;
-                }
                 $orderSummary[$order->getModule()]
                 [$order->getVisitType()]
                 [$order->getTimepoint()]
                 [$module->getSampleType($sample->getSampleCode())]
-                [$sample->getSampleCode()] = [
+                [$sample->getSampleCode()]
+                [$order->getOrderId()] = [
                     'sampleId' => $sample->getSampleID(),
                     'sampleName' => $sampleName,
                     'orderId' => $order->getOrderId(),

--- a/src/Service/Nph/NphProgramSummaryService.php
+++ b/src/Service/Nph/NphProgramSummaryService.php
@@ -58,15 +58,22 @@ class NphProgramSummaryService
             foreach ($moduleSummary as $visit => $visitSummary) {
                 foreach ($visitSummary['visitInfo'] as $timePoint => $timePointSummary) {
                     foreach ($timePointSummary['timePointInfo'] as $sampleType => $sample) {
-                        $numberSamples = 0;
+                        $numberSamples = [];
                         $expectedSamples = 0;
                         foreach (array_keys($sample) as $sampleCode) {
                             if ($sampleCode === 'STOOL' || $sampleCode === 'NAIL') {
                                 continue;
                             }
                             $expectedSamples++;
-                            if (isset($orderSummaryOrder[$module][$visit][$timePoint][$sampleType][$sampleCode]['sampleId'])) {
-                                $numberSamples++;
+                            if (isset($orderSummaryOrder[$module][$visit][$timePoint][$sampleType][$sampleCode])) {
+                                foreach ($orderSummaryOrder[$module][$visit][$timePoint][$sampleType][$sampleCode] as $orderid => $orderInfo) {
+                                    if (!isset($numberSamples[$orderid])) {
+                                        $numberSamples[$orderid] = 0;
+                                    }
+                                    if ($orderInfo['sampleId'] !== null) {
+                                        $numberSamples[$orderid]++;
+                                    }
+                                }
                             }
                             $combinedSummary[$module][$visit][$timePoint][$sampleType][$sampleCode] = $orderSummaryOrder[$module][$visit][$timePoint][$sampleType][$sampleCode] ?? [];
                         }

--- a/src/Service/PDFService.php
+++ b/src/Service/PDFService.php
@@ -59,38 +59,40 @@ class PDFService
         $stoolPrinted = false;
         foreach ($OrderSummary as $timePointOrder) {
             foreach ($timePointOrder as $sampleType => $sampleInfo) {
-                foreach ($sampleInfo as $sample) {
-                    try {
-                        $participantFullName = $participant->firstName . ' ' . $participant->lastName;
-                        if (strlen($participantFullName) > 20) {
-                            $participantFullName = substr(
-                                $participant->firstName[0] . '. ' . $participant->lastName,
-                                0,
-                                20
+                foreach ($sampleInfo as $sampleCode => $orderInfo) {
+                    foreach ($orderInfo as $sample) {
+                        try {
+                            $participantFullName = $participant->firstName . ' ' . $participant->lastName;
+                            if (strlen($participantFullName) > 20) {
+                                $participantFullName = substr(
+                                    $participant->firstName[0] . '. ' . $participant->lastName,
+                                    0,
+                                    20
+                                );
+                            }
+                            $sampleId = $sample['sampleId'];
+                            if ($sampleType === "stool" && $stoolPrinted === false) {
+                                $sample['identifier'] = "ST-KIT";
+                                $sampleId = $sample['orderId'];
+                                $sampleId = preg_replace("/KIT-?/", "", $sampleId);
+                                $stoolPrinted = true;
+                            } elseif ($sampleType === "stool" && $stoolPrinted === true) {
+                                continue;
+                            }
+                            $this->renderPDF(
+                                $participantFullName,
+                                $sampleType,
+                                $participant->dob,
+                                $sampleId,
+                                $module,
+                                $sample['timepointDisplayName'],
+                                $sample['identifier'],
+                                $sample['visitDisplayName'],
+                                $sample['sampleCollectionVolume']
                             );
+                        } catch (MpdfException | LoaderError | RuntimeError | SyntaxError $e) {
+                            return "Unable to render PDF";
                         }
-                        $sampleId = $sample['sampleId'];
-                        if ($sampleType === "stool" && $stoolPrinted === false) {
-                            $sample['identifier'] = "ST-KIT";
-                            $sampleId = $sample['orderId'];
-                            $sampleId = preg_replace("/KIT-?/", "", $sampleId);
-                            $stoolPrinted = true;
-                        } elseif ($sampleType === "stool" && $stoolPrinted === true) {
-                            continue;
-                        }
-                        $this->renderPDF(
-                            $participantFullName,
-                            $sampleType,
-                            $participant->dob,
-                            $sampleId,
-                            $module,
-                            $sample['timepointDisplayName'],
-                            $sample['identifier'],
-                            $sample['visitDisplayName'],
-                            $sample['sampleCollectionVolume']
-                        );
-                    } catch (MpdfException | LoaderError | RuntimeError | SyntaxError $e) {
-                        return "Unable to render PDF";
                     }
                 }
             }

--- a/src/Service/PDFService.php
+++ b/src/Service/PDFService.php
@@ -47,12 +47,12 @@ class PDFService
                                 );
                             }
                             $sampleId = $sample['sampleId'];
-                            if ($sampleType === "stool" && $stoolPrinted === false) {
-                                $sample['identifier'] = "ST-KIT";
+                            if ($sampleType === 'stool' && $stoolPrinted === false) {
+                                $sample['identifier'] = 'ST-KIT';
                                 $sampleId = $sample['orderId'];
-                                $sampleId = preg_replace("/KIT-?/", "", $sampleId);
+                                $sampleId = preg_replace('/KIT-?/', '', $sampleId);
                                 $stoolPrinted = true;
-                            } elseif ($sampleType === "stool" && $stoolPrinted === true) {
+                            } elseif ($sampleType === 'stool' && $stoolPrinted === true) {
                                 continue;
                             }
                             $this->renderPDF(
@@ -66,31 +66,9 @@ class PDFService
                                 $sample['visitDisplayName'],
                                 $sample['sampleCollectionVolume']
                             );
-                        } catch (MpdfException | LoaderError | RuntimeError | SyntaxError $e) {
-                            return "Unable to render PDF";
+                        } catch (MpdfException|LoaderError|RuntimeError|SyntaxError $e) {
+                            return 'Unable to render PDF';
                         }
-                        $sampleId = $sample['sampleId'];
-                        if ($sampleType === 'stool' && $stoolPrinted === false) {
-                            $sample['identifier'] = 'ST-KIT';
-                            $sampleId = $sample['orderId'];
-                            $sampleId = preg_replace('/KIT-?/', '', $sampleId);
-                            $stoolPrinted = true;
-                        } elseif ($sampleType === 'stool' && $stoolPrinted === true) {
-                            continue;
-                        }
-                        $this->renderPDF(
-                            $participantFullName,
-                            $sampleType,
-                            $participant->dob,
-                            $sampleId,
-                            $module,
-                            $sample['timepointDisplayName'],
-                            $sample['identifier'],
-                            $sample['visitDisplayName'],
-                            $sample['sampleCollectionVolume']
-                        );
-                    } catch (MpdfException | LoaderError | RuntimeError | SyntaxError $e) {
-                        return 'Unable to render PDF';
                     }
                 }
             }

--- a/src/Service/PDFService.php
+++ b/src/Service/PDFService.php
@@ -59,8 +59,8 @@ class PDFService
         $stoolPrinted = false;
         foreach ($OrderSummary as $timePointOrder) {
             foreach ($timePointOrder as $sampleType => $sampleInfo) {
-                foreach ($sampleInfo as $sampleCode => $orderInfo) {
-                    foreach ($orderInfo as $sample) {
+                foreach (array_keys($sampleInfo) as $sampleCode) {
+                    foreach ($sampleInfo[$sampleCode] as $sample) {
                         try {
                             $participantFullName = $participant->firstName . ' ' . $participant->lastName;
                             if (strlen($participantFullName) > 20) {

--- a/templates/program/nph/order/label-print.html.twig
+++ b/templates/program/nph/order/label-print.html.twig
@@ -35,26 +35,28 @@
                     <th>Collection Samples</th>
                     <th>Collection Sample ID</th>
                 </tr>
-                {% set lastOrderID = '' %}
+                {% set lastSampleType = '' %}
                 {% for timepointName,timepoint in orderSummary %}
-                    {% for orderId, orderInfo in timepoint %}
-                        {% if orderId != lastOrderID %}
-                            {% set printOrderTD = true %}
+                    {% for sampleType, sampleInfo in timepoint %}
+                        {% if sampleType != lastSampleType %}
+                            {% set printSampleTd = true %}
                         {% else %}
-                            {% set printOrderTD = false %}
+                            {% set printSampleTd = false %}
                         {% endif %}
-                        {% for sampleCode,sampleInfo in orderInfo %}
-                             <tr>
-                                 {% if printOrderTD %}
-                                    <td rowspan="{{ orderInfo|length }}"><a href="{{ path('nph_order_collect', {'participantId': participant.id, 'orderId': sampleInfo.healthProOrderId}) }}">{{ sampleInfo.orderId }}</a></td>
-                                    <td rowspan="{{ orderInfo|length }}">{{ sampleInfo.timepointDisplayName }}</td>
-                                    <td rowspan="{{ orderInfo|length }}">{{ sampleInfo.sampleTypeDisplayName }}</td>
-                                    {% set printOrderTD = false %}
-                                 {% endif %}
-                                 <td>{{ sampleInfo.sampleName }}</td>
-                                 <td>{{ sampleInfo.sampleId }}</td>
-                             </tr>
-                         {% endfor %}
+                        {% for sampleCode,sampleCodeInfo in sampleInfo %}
+                            {% for orderId, orderInfo in sampleCodeInfo %}
+                            <tr>
+                                {% if printSampleTd %}
+                                    <td rowspan="{{ orderInfo|length }}"><a href="{{ path('nph_order_collect', {'participantId': participant.id, 'orderId': orderInfo.healthProOrderId}) }}">{{ orderInfo.orderId }}</a></td>
+                                    <td rowspan="{{ orderInfo|length }}">{{ orderInfo.timepointDisplayName }}</td>
+                                    <td rowspan="{{ orderInfo|length }}">{{ orderInfo.sampleTypeDisplayName }}</td>
+                                    {% set printSampleTd = false %}
+                                {% endif %}
+                                <td>{{ orderInfo.sampleName }}</td>
+                                <td>{{ orderInfo.sampleId }}</td>
+                            </tr>
+                            {% endfor %}
+                        {% endfor %}
                     {% endfor %}
                 {% endfor %}
             </table>

--- a/templates/program/nph/participant/index.html.twig
+++ b/templates/program/nph/participant/index.html.twig
@@ -96,15 +96,17 @@
                                     <span class="glyphicon glyphicon-plus-sign"></span> Generate Orders and Print Labels
                                 </a>
                                 {% set displayedOrderIDS = [] %}
+                                {% set displayedTimePointHeaders = [] %}
                                 {% for timepointCode, timepoint in visit['visitInfo'] %}
                                     {% for sampleType, sampleInfo in timepoint['timePointInfo'] %}
                                         {% if sampleInfo['numberSamples'] is not empty %}
-                                            {% if loop.first %}
-                                                <h4>Timepoint | {{ timepoint['timePointDisplayName'] }}</h4>
-                                            {% endif %}
                                             {% for sampleCode, sample in sampleInfo %}
                                                 {% for orderid, numberSamples in sampleInfo['numberSamples'] %}
                                                     {% if sample is iterable and sample[orderid] is defined and sample[orderid] is iterable and sample[orderid]['healthProOrderId'] not in displayedOrderIDS %}
+                                                        {% if timepointCode not in displayedTimePointHeaders %}
+                                                            {% set displayedTimePointHeaders = displayedTimePointHeaders|merge([timepointCode]) %}
+                                                            <h4>Timepoint | {{ timepoint['timePointDisplayName'] }}</h4>
+                                                        {% endif %}
                                                         {% set displayedOrderIDS = displayedOrderIDS|merge([sample[orderid]['healthProOrderId']]) %}
                                                         <div class="well well-sm order-row">
                                                             <div class="clearfix">

--- a/templates/program/nph/participant/index.html.twig
+++ b/templates/program/nph/participant/index.html.twig
@@ -98,34 +98,34 @@
                                 {% set displayedOrderIDS = [] %}
                                 {% for timepointCode, timepoint in visit['visitInfo'] %}
                                     {% for sampleType, sampleInfo in timepoint['timePointInfo'] %}
-                                        {% if sampleInfo['numberSamples'] > 0 %}
+                                        {% if sampleInfo['numberSamples'] is not empty %}
                                             {% if loop.first %}
                                                 <h4>Timepoint | {{ timepoint['timePointDisplayName'] }}</h4>
                                             {% endif %}
-                                            {% set StatusCount = 0 %}
                                             {% for sampleCode, sample in sampleInfo %}
-                                                {% set SampleGroupStatus = null %}
-                                                {% if sample is iterable and sample|length > 0 and sample['sampleId'] is not null and sampleInfo['numberSamples'] > 0 and sample['healthProOrderId'] not in displayedOrderIDS %}
-                                                    {% set displayedOrderIDS = displayedOrderIDS|merge([sample['healthProOrderId']]) %}
-                                                    <div class="well well-sm order-row">
-                                                        <div class="clearfix">
-                                                        <div class="col-sm-2">{{ sample['createDate'] }}</div>
-                                                        <div class="col-sm-3"><a
-                                                                href="{{ path('nph_order_collect', {participantId: participant.id, orderId: sample['healthProOrderId']}) }}">Order
-                                                                ID: {{ sample['orderId'] }}</a></div>
-                                                        <div class="col-sm-2">{{ sample['sampleTypeDisplayName'] }}</div>
-                                                        {{ _self.generateStatusLabel(sample['orderStatus']) }}
-                                                        {% for sampleStatus, sampleStatusCount in programSummaryAndOrderInfo[moduleNumber]['sampleStatusCount'][sample['orderId']]|sort %}
+                                                {% for orderid, numberSamples in sampleInfo['numberSamples'] %}
+                                                    {% if sample is iterable and sample[orderid] is defined and sample[orderid] is iterable and sample[orderid]['healthProOrderId'] not in displayedOrderIDS %}
+                                                        {% set displayedOrderIDS = displayedOrderIDS|merge([sample[orderid]['healthProOrderId']]) %}
+                                                        <div class="well well-sm order-row">
+                                                            <div class="clearfix">
+                                                            <div class="col-sm-2">{{ sample[orderid]['createDate'] }}</div>
+                                                            <div class="col-sm-3"><a
+                                                                    href="{{ path('nph_order_collect', {participantId: participant.id, orderId: sample[orderid]['healthProOrderId']}) }}">Order
+                                                                    ID: {{ orderid }}</a></div>
+                                                            <div class="col-sm-2">{{ sample[orderid]['sampleTypeDisplayName'] }}</div>
+                                                            {{ _self.generateStatusLabel(sample[orderid]['orderStatus']) }}
+                                                            {% for sampleStatus, sampleStatusCount in programSummaryAndOrderInfo[moduleNumber]['sampleStatusCount'][orderid]|sort %}
                                                             {% if not loop.first %}
                                                                 <div class="col-sm-9"></div>
                                                             {% endif %}
-                                                        <div class="col-sm-3 float-right">({{ sampleStatusCount }}
-                                                            / {{ sampleInfo['expectedSamples'] }}) {{ sampleStatus }}
+                                                            <div class="col-sm-3 float-right">({{ sampleStatusCount }}
+                                                                / {{ sampleInfo['expectedSamples'] }}) {{ sampleStatus }}
+                                                            </div>
+                                                            {% endfor %}
+                                                                </div>
                                                         </div>
-                                                        {% endfor %}
-                                                        </div>
-                                                    </div>
-                                                {% endif %}
+                                                    {% endif %}
+                                                {% endfor %}
                                             {% endfor %}
                                         {% endif %}
                                     {% endfor %}

--- a/tests/Service/NphOrderServiceTest.php
+++ b/tests/Service/NphOrderServiceTest.php
@@ -433,7 +433,7 @@ class NphOrderServiceTest extends ServiceTestCase
         $this->assertIsArray($orderSummary);
         $this->assertArrayHasKey('order', $orderSummary);
         $this->assertSame(count($orderSummary['order']), 1);
-        $this->assertArrayHasKey('sampleName', $orderSummary['order']['1']['LMT']['preLMT']['urine']['URINES']);
+        $this->assertArrayHasKey('sampleName', $orderSummary['order']['1']['LMT']['preLMT']['urine']['URINES']['100000001']);
     }
 
     public function testGetParticipantOrderSummaryByVisitAndModule(): void
@@ -444,7 +444,7 @@ class NphOrderServiceTest extends ServiceTestCase
         $this->assertIsArray($orderSummary);
         $this->assertArrayHasKey('order', $orderSummary);
         $this->assertSame(count($orderSummary['order']), 1);
-        $this->assertArrayHasKey('sampleName', $orderSummary['order']['preLMT']['urine']['URINES']);
+        $this->assertArrayHasKey('sampleName', $orderSummary['order']['preLMT']['urine']['URINES']['100000001']);
     }
 
     public function testGetSamplesWithStatus(): void


### PR DESCRIPTION
Missed File.

| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.3.0 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1409 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:
Displays all orders for a participant, even cancelled ones.

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
