### PR TITLE
[HPRO-1409] Participant Summary sample counts show number samples on order.

### DIFF
--- a/templates/program/nph/participant/index.html.twig
+++ b/templates/program/nph/participant/index.html.twig
@@ -129,7 +129,7 @@
                                                                 <div class="col-sm-9"></div>
                                                             {% endif %}
                                                             <div class="col-sm-3 float-right">({{ sampleStatusCount }}
-                                                                / {{ sampleInfo['expectedSamples'] }}) {{ sampleStatus }}
+                                                                / {{ sampleInfo['numberSamples'][orderid] }}) {{ sampleStatus }}
                                                             </div>
                                                             {% endfor %}
                                                                 </div>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.3.0 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1409 <!-- Tag which ticket(s) this PR relates to -->

### Summary

![image](https://user-images.githubusercontent.com/666617/230139040-26e1cbee-88bf-4161-8eba-025ea6ce125e.png)
Show the number of samples on an order as opposed to the maximum expected samples for that order type.

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
