### PR TITLE
[HPRO-1479] Changed Route to correct NPH route.

### DIFF
--- a/templates/program/nph/review/recently_modified.html.twig
+++ b/templates/program/nph/review/recently_modified.html.twig
@@ -28,7 +28,7 @@
                         <a href="{{ path('nph_participant_summary', { participantId: sample.participantId }) }}">{{ sample.participant.lastName }}, {{ sample.participant.firstName }}</a>
                     </td>
                 {% else %}
-                    <td data-participant-id="{{ sample.participantId }}" data-href="{{ path('participant', { id: sample.participantId }) }}" class="load-name">
+                    <td data-participant-id="{{ sample.participantId }}" data-href="{{ path('nph_participant_summary', { participantId: sample.participantId }) }}" class="load-name">
                         <i class="fa fa-spinner fa-spin" aria-hidden="true"></i>
                         <span class="sr-only">Loading...</span>
                     </td>

--- a/templates/program/nph/review/unfinalized.html.twig
+++ b/templates/program/nph/review/unfinalized.html.twig
@@ -26,7 +26,7 @@
                         <a href="{{ path('nph_participant_summary', { participantId: sample.participantId }) }}">{{ sample.participant.lastName }}, {{ sample.participant.firstName }}</a>
                     </td>
                 {% else %}
-                    <td data-participant-id="{{ sample.participantId }}" data-href="{{ path('participant', { id: sample.participantId }) }}" class="load-name">
+                    <td data-participant-id="{{ sample.participantId }}" data-href="{{ path('nph_participant_summary', { participantId: sample.participantId }) }}" class="load-name">
                         <i class="fa fa-spinner fa-spin" aria-hidden="true"></i>
                         <span class="sr-only">Loading...</span>
                     </td>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1479<!-- Tag which ticket(s) this PR relates to -->

### Summary

The route for the participant review pages were incorrectly pointed to AOU participant pages instead of NPH ones.
<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
