### PR TITLE
[HPRO-1419] Biobank aliquot page

### DIFF
--- a/migrations/Version20230519135344.php
+++ b/migrations/Version20230519135344.php
@@ -7,9 +7,6 @@ namespace DoctrineMigrations;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\Migrations\AbstractMigration;
 
-/**
- * Auto-generated Migration: Please modify to your needs!
- */
 final class Version20230519135344 extends AbstractMigration
 {
     public function getDescription() : string

--- a/migrations/Version20230519135344.php
+++ b/migrations/Version20230519135344.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230519135344 extends AbstractMigration
+{
+    public function getDescription() : string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema) : void
+    {
+       $this->addSql('ALTER TABLE nph_samples ADD biobank_finalized boolean default false');
+    }
+
+    public function down(Schema $schema) : void
+    {
+       $this->addSql('ALTER TABLE nph_samples DROP biobank_finalized');
+    }
+}

--- a/migrations/Version20230519135344.php
+++ b/migrations/Version20230519135344.php
@@ -14,7 +14,7 @@ final class Version20230519135344 extends AbstractMigration
 {
     public function getDescription() : string
     {
-        return '';
+        return 'Adds biobank finalized field to the nph_samples table to show when a sample has been finalized by the biobank';
     }
 
     public function up(Schema $schema) : void

--- a/src/Controller/NphBiobankController.php
+++ b/src/Controller/NphBiobankController.php
@@ -311,8 +311,7 @@ class NphBiobankController extends BaseController
             'sampleModifyForm' => isset($nphSampleModifyForm) ? $nphSampleModifyForm->createView() : '',
             'modifyType' => $modifyType ?? '',
             'revertForm' => $this->createForm(NphSampleRevertType::class)->createView(),
-            'disableForm' => true,
-            'biobankView' => true,
+            'biobankView' => true
         ]);
     }
 }

--- a/src/Controller/NphBiobankController.php
+++ b/src/Controller/NphBiobankController.php
@@ -153,6 +153,9 @@ class NphBiobankController extends BaseController
             if ($sample) {
                 $participantId = $sample->getNphOrder()->getParticipantId();
                 $participant = $nphParticipantSummaryService->getParticipantById($participantId);
+                if (!$participant) {
+                    throw $this->createNotFoundException("Participant not found for sample ID $sample->getSampleId()");
+                }
                 return $this->redirectToRoute('nph_biobank_sample_finalize', [
                     'biobankId' => $participant->biobankId,
                     'sampleId' => $sample->getId(),

--- a/src/Controller/NphBiobankController.php
+++ b/src/Controller/NphBiobankController.php
@@ -171,8 +171,8 @@ class NphBiobankController extends BaseController
      * @Route("/{biobankId}/order/{orderId}/collect", name="nph_biobank_order_collect")
      */
     public function orderCollectDetailsAction(
-        $biobankId,
-        $orderId,
+        string $biobankId,
+        string $orderId,
         NphOrderService $nphOrderService,
         NphParticipantSummaryService $nphNphParticipantSummaryService
     ): Response {
@@ -198,9 +198,9 @@ class NphBiobankController extends BaseController
      * @Route("/{biobankId}/order/{orderId}/sample/{sampleId}/finalize", name="nph_biobank_sample_finalize")
      */
     public function aliquotFinalizeAction(
-        $biobankId,
-        $orderId,
-        $sampleId,
+        string $biobankId,
+        string $orderId,
+        string $sampleId,
         NphOrderService $nphOrderService,
         NphParticipantSummaryService $nphParticipantSummaryService,
         Request $request

--- a/src/Controller/NphOrderController.php
+++ b/src/Controller/NphOrderController.php
@@ -328,7 +328,8 @@ class NphOrderController extends BaseController
             'sampleData' => $sampleData,
             'sampleModifyForm' => isset($nphSampleModifyForm) ? $nphSampleModifyForm->createView() : '',
             'modifyType' => $modifyType ?? '',
-            'revertForm' => $this->createForm(NphSampleRevertType::class)->createView()
+            'revertForm' => $this->createForm(NphSampleRevertType::class)->createView(),
+            'biobankView' => false,
         ]);
     }
 

--- a/src/Entity/NphOrder.php
+++ b/src/Entity/NphOrder.php
@@ -362,6 +362,9 @@ class NphOrder
         if (isset($statusCount['Collected']) && $statusCount['Collected'] === $sampleCount) {
             return 'Collected';
         }
+        if ((isset($statusCount['Finalized']) && isset($statusCount['Biobank Finalized'])) && ($statusCount['Finalized'] + $statusCount['Biobank Finalized'] === $sampleCount)) {
+            return 'Finalized';
+        }
         return 'In Progress';
     }
 

--- a/src/Entity/NphSample.php
+++ b/src/Entity/NphSample.php
@@ -175,6 +175,10 @@ class NphSample
      * @ORM\Column(type="integer", nullable=true)
      */
     private $modifiedTimezoneId;
+    /**
+     * @ORM\Column(type="boolean", nullable=true)
+     */
+    private $biobankFinalized;
 
     public function __construct()
     {
@@ -341,6 +345,18 @@ class NphSample
         $this->rdrId = $rdrId;
 
         return $this;
+    }
+
+    public function setBiobankFinalized(bool $biobankFinalized): self
+    {
+        $this->biobankFinalized = $biobankFinalized;
+
+        return $this;
+    }
+
+    public function getBiobankFinalized(): ?bool
+    {
+        return $this->biobankFinalized;
     }
 
     public function getCollectedTimezoneId(): ?int
@@ -603,5 +619,12 @@ class NphSample
             ) : '';
         }
         return $sampleMetadata;
+    }
+
+    public function getMostRecentSite()
+    {
+        if ($this->getCollectedSite()) {
+            return $this->getCollectedSite();
+        }
     }
 }

--- a/src/Entity/NphSample.php
+++ b/src/Entity/NphSample.php
@@ -625,11 +625,4 @@ class NphSample
         }
         return $sampleMetadata;
     }
-
-    public function getMostRecentSite()
-    {
-        if ($this->getCollectedSite()) {
-            return $this->getCollectedSite();
-        }
-    }
 }

--- a/src/Entity/NphSample.php
+++ b/src/Entity/NphSample.php
@@ -412,6 +412,11 @@ class NphSample
         if ($this->finalizedTs === null) {
             return 'Collected';
         }
+
+        if ($this->biobankFinalized) {
+            return 'Biobank Finalized';
+        }
+
         return 'Finalized';
     }
 

--- a/templates/program/nph/biobank/order-collect-details.html.twig
+++ b/templates/program/nph/biobank/order-collect-details.html.twig
@@ -65,7 +65,7 @@
                         <td>
                             <p>
                                 {# TODO Link to Andrew's biobank aliquot finalize page #}
-                                <a href="" class="btn btn-primary btn-xs">
+                                <a href="{{ path('nph_biobank_sample_finalize', {biobankId: participant.biobankId, sampleId: nphSample.id, orderId: order.id}) }}" class="btn btn-primary btn-xs">
                                     View
                                 </a>
                             </p>

--- a/templates/program/nph/order/collect.html.twig
+++ b/templates/program/nph/order/collect.html.twig
@@ -73,8 +73,8 @@
                                 <p class="text-danger"><i class="fa fa-times"></i> Cancelled</p>
                             {% elseif nphSample.finalizedTs is not empty %}
                                 <p class="text-success"><i class="fa fa-check-circle"></i>
-                                    {{ nphSample.modifyType == constant('EDITED', nphSample) ? 'Edited and Finalized' : 'Aliquoted and Finalized' }}
-                                    {{ nphSample.finalizedTs|date('n/j/Y g:ia', app.user.timezone) }}</p>
+                                    {{ macros.displayAliquotStatus(nphSample) }}
+                                </p>
                             {% endif %}
                         </td>
                         {% if orderCollectForm[nphSample.sampleCode ~ 'CollectedTs'] is defined %}

--- a/templates/program/nph/order/macros/display-text.html.twig
+++ b/templates/program/nph/order/macros/display-text.html.twig
@@ -50,3 +50,13 @@
         <i class="fa fa-times text-danger" aria-hidden="true"></i>
     {% endif %}
 {% endmacro %}
+
+{% macro displayAliquotStatus(nphSample) %}
+    {% if nphSample.biobankFinalized %}
+        {% set biobank = 'Biobank ' %}
+    {% else %}
+        {% set biobank = '' %}
+    {% endif %}
+    {{ nphSample.modifyType == constant('EDITED', nphSample) ? 'Edited and ' ~ biobank ~'Finalized' : 'Aliquoted and ' ~ biobank ~' Finalized' }}
+    {{ nphSample.finalizedTs|date('n/j/Y g:ia', app.user.timezone) }}
+{% endmacro %}

--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -272,7 +272,11 @@
                                 {% if sample.disabled %} disabled {% endif %} formnovalidate>
                             Mark as Finalized
                         </button>
-                        <a href="{{ path('nph_samples_aliquot') }}" class="btn btn-default">Cancel</a>
+                        {% if biobankView %}
+                            <a href="{{ path('nph_biobank_samples_aliquot') }}" class="btn btn-default">Cancel</a>
+                        {% else %}
+                            <a href="{{ path('nph_samples_aliquot') }}" class="btn btn-default">Cancel</a>
+                        {% endif %}
                     </p>
                     {{ form_end(sampleFinalizeForm) }}
                     {% if sample.modifyType == 'unlock' %}

--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -269,7 +269,10 @@
                     </div>
                     <p>
                         <button type="submit" class="btn btn-primary" id="sample_finalize_btn"
-                                {% if sample.disabled %} disabled {% endif %} formnovalidate>
+                                {% if sample.disabled or (not order.orderType == constant('App\\Entity\\NphOrder::TYPE_STOOL') and biobankView) %}
+                                    disabled
+                                {% endif %}
+                                formnovalidate>
                             Mark as Finalized
                         </button>
                         {% if biobankView %}

--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -67,11 +67,20 @@
         <div class="col-sm-7">
             {% if sample.rdrId and sample.finalizedTs %}
                 <div class="alert alert-success well-sm">
+                    {% if sample.biobankFinalized %}
+                        <i class="fa fa-exclamation-circle"></i>
+                        <strong class="warning-text">
+                            Finalized
+                            by Biobank user
+                            on {{ sample.finalizedTs|date('n/j/Y g:ia', app.user.timezone) }}
+                        </strong>
+                    {% else %}
                     <strong>
                         Finalized
                         by {{ sample.finalizedUser.email|default('Unknown') }}
                         on {{ sample.finalizedTs|date('n/j/Y g:ia', app.user.timezone) }}
                     </strong>
+                    {% endif %}
                 </div>
             {% endif %}
             <div class="panel panel-default">

--- a/tests/Entity/NphOrderTest.php
+++ b/tests/Entity/NphOrderTest.php
@@ -10,7 +10,6 @@ class NphOrderTest extends NphTestCase
     /**
      * @dataProvider canCancelRestoreDataProvider
      */
-
     public function testCanCancelRestore($samples, $canCancel, $canRestore)
     {
         $orderData = $this->getOrderData();
@@ -98,7 +97,6 @@ class NphOrderTest extends NphTestCase
     /**
      * @dataProvider isDisabledAndMetadataDisabledDataProvider
      */
-
     public function testIsDisabledAndMetadataDisabled($samples, $isDisabled, $isMetadataFieldDisabled)
     {
         $orderData = $this->getOrderData();
@@ -165,7 +163,8 @@ class NphOrderTest extends NphTestCase
     /**
      * @dataProvider getOrderStatusDataProvider
      */
-    public function testGetOrderStatus($samples, $expectedStatus) {
+    public function testGetOrderStatus($samples, $expectedStatus)
+    {
         $orderData = $this->getOrderData();
         $nphOrder = $this->createNphOrder($orderData);
         foreach ($samples as $sample) {
@@ -173,10 +172,10 @@ class NphOrderTest extends NphTestCase
             $this->createNphSample($sample);
         }
         $this->assertSame($expectedStatus, $nphOrder->getStatus());
-        $nphOrder->getStatus();
     }
 
-    public function getOrderStatusDataProvider(): array {
+    public function getOrderStatusDataProvider(): array
+    {
         $finalizedTs = new \DateTime('2023-01-01 08:00:00');
         $collectedTs = new \DateTime('2023-01-01 08:00:00');
         return [
@@ -186,6 +185,22 @@ class NphOrderTest extends NphTestCase
                         'sampleId' => '1000000000',
                         'sampleCode' => 'ST1',
                         'finalizedTs' => $finalizedTs
+                    ],
+                    [
+                        'sampleId' => '2000000000',
+                        'sampleCode' => 'ST2',
+                        'finalizedTs' => $finalizedTs
+                    ],
+                ],
+                'Finalized'
+            ],
+            [
+                [
+                    [
+                        'sampleId' => '1000000000',
+                        'sampleCode' => 'ST1',
+                        'finalizedTs' => $finalizedTs,
+                        'biobankFinalized' => true
                     ],
                     [
                         'sampleId' => '2000000000',
@@ -244,7 +259,6 @@ class NphOrderTest extends NphTestCase
     /**
      * @dataProvider collectedTimeProvider
      */
-
     public function testGetCollectedTs(array $samples, ?\DateTime $expectedCollectedTs): void
     {
         $orderData = $this->getOrderData();
@@ -309,7 +323,6 @@ class NphOrderTest extends NphTestCase
     /**
      * @dataProvider stoolTypeProvider
      */
-
     public function testIsStoolCollectedTsDisabled(string $orderType, array $samples, bool $expectedResult): void
     {
         $orderData = $this->getOrderData();

--- a/web/assets/css/nph.css
+++ b/web/assets/css/nph.css
@@ -137,3 +137,6 @@ div.order-row {
 .sample-disabled-colored {
     color: #A59D9B;
 }
+.warning-text {
+    color: #df4633;
+}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ✅ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1419 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

Biobank view shows the same aliquot page as any other user, allows finalizing of only stool samples. All other samples are disabled and read only.

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->

![image](https://github.com/all-of-us/healthpro/assets/666617/6baa24a2-d8b3-471a-b4df-6f1c81027595)
![image](https://github.com/all-of-us/healthpro/assets/666617/f04660e6-05dc-4e57-bab8-d7260ea666f8)
![image](https://github.com/all-of-us/healthpro/assets/666617/203ea155-4f10-4615-a13d-203747ac1942)
![image](https://github.com/all-of-us/healthpro/assets/666617/5a13007b-a573-4dda-a5c7-ce10531309f0)


