### PR TITLE
[HPRO-1592] Fix for date time not populating.

### DIFF
--- a/web/assets/js/views/NphSampleFinalize.js
+++ b/web/assets/js/views/NphSampleFinalize.js
@@ -83,6 +83,7 @@ $(document).ready(function () {
         if (regex.test(barcode)) {
             let aliquotTsSelector = $(this).closest("tr").find(".order-ts");
             aliquotTsSelector.focus();
+            aliquotTsSelector.data("DateTimePicker").date(new Date());
             aliquotTsSelector.blur();
             $(this).closest("tr").find(".aliquot-volume").focus();
         }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1592 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Adds a fix for aliquot time not populating after using the eraser icon.
<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
