### PR TITLE
[HPRO-1566] Add links to participant name and order id in aliquot page

### DIFF
--- a/templates/program/nph/order/partials/sample-finalize-participant-details.html.twig
+++ b/templates/program/nph/order/partials/sample-finalize-participant-details.html.twig
@@ -1,7 +1,9 @@
 <div class="panel-heading clearfix">
     <div class="col-sm-5">
-        <strong>Name</strong> {{ participant.lastName }}, {{ participant.firstName }} {{ participant
-        .middleName }} <br>
+        <strong>Name</strong>
+        <a href="{{ path('nph_participant_summary', { participantId: participant.id }) }}">
+            {{ participant.lastName }}, {{ participant.firstName }} {{ participant.middleName }} <br>
+        </a>
         <strong>Participant ID</strong> {{ participant.id }} <br>
         <strong>Biobank ID</strong> {{ participant.biobankId }} <br>
         <strong>Site</strong> {{ participant.nphPairedSite ? siteInfo.getNphSiteDisplayName(participant.nphPairedSiteSuffix) : '(not paired)' }} <br>
@@ -12,7 +14,10 @@
             Module {{ order.module }} | Visit {{ order.visitType }} | {{ timePoints[order.timepoint] }}
             | {{ samples[sampleCode]}}
         </strong><br>
-        <strong>Order ID</strong> {{ sample.nphOrder.orderId }}<br>
+        <strong>Order ID</strong>
+        <a href="{{ path('nph_order_collect', {'participantId': participant.id, 'orderId': sample.nphOrder.id }) }}">
+            {{ sample.nphOrder.orderId }} <br>
+        </a>
         <strong>Collection Sample ID</strong> {{ sample.sampleId }}
     </div>
 </div>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 3.13.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ✅ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1566<!-- Tag which ticket(s) this PR relates to -->


### Screenshots <!-- if applicable -->
<img width="1181" alt="image" src="https://github.com/all-of-us/healthpro/assets/6041980/33a1a1d5-931b-4ec6-89e7-73f882f31a80">
