### PR TITLE
[HPRO-1655] Temporarily removed 2ED04 sample, updated test to better test weight breakpoints.

### DIFF
--- a/src/Order/versions/3.1-ped-16.4.json
+++ b/src/Order/versions/3.1-ped-16.4.json
@@ -9,13 +9,6 @@
             "color": "Lavender",
             "specimen": "2mL EDTA"
         },
-        "2ED04": {
-            "number": 2,
-            "label": "4 ml EDTA",
-            "temperature": "Refrigerated",
-            "color": "Lavender",
-            "specimen": "4 mL EDTA"
-        },
         "1UR10": {
             "number": 3,
             "label": "Urine 10 mL",
@@ -24,9 +17,6 @@
             "specimen": "Urine 10 mL",
             "labelCount": 2
         }
-    },
-    "urineSamplesInformation": {
-
     },
     "salivaSamplesInformation": {
         "1SAL2": {

--- a/src/Order/versions/3.1-ped-2.5.json
+++ b/src/Order/versions/3.1-ped-2.5.json
@@ -11,9 +11,6 @@
             "labelCount": 2
         }
     },
-    "urineSamplesInformation": {
-
-    },
     "salivaSamplesInformation": {
         "1SAL2": {
             "label": "Saliva [1SAL2]",

--- a/src/Order/versions/3.1-ped-5.json
+++ b/src/Order/versions/3.1-ped-5.json
@@ -17,9 +17,6 @@
             "labelCount": 2
         }
     },
-    "urineSamplesInformation": {
-
-    },
     "salivaSamplesInformation": {
         "1SAL2": {
             "label": "Saliva [1SAL2]",

--- a/src/Order/versions/3.1-ped-9999.json
+++ b/src/Order/versions/3.1-ped-9999.json
@@ -32,9 +32,6 @@
             "labelCount": 2
         }
     },
-    "urineSamplesInformation": {
-
-    },
     "salivaSamplesInformation": {
         "1SAL2": {
             "label": "Saliva [1SAL2]",

--- a/tests/Helper/ParticipantTest.php
+++ b/tests/Helper/ParticipantTest.php
@@ -9,13 +9,13 @@ class ParticipantTest extends TestCase
 {
     public function testMayolinkDob()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'dateOfBirth' => '1999-05-20',
         ]);
         $this->assertSame('1999-05-20', $participant->dob->format('Y-m-d'));
         $this->assertSame('1933-03-03', $participant->getMayolinkDob()->format('Y-m-d'));
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'dateOfBirth' => '1996-02-29',
         ]);
         $this->assertSame('1996-02-29', $participant->dob->format('Y-m-d'));
@@ -24,7 +24,7 @@ class ParticipantTest extends TestCase
 
     public function testDeceasedParticipantPendingAccessStatus()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'deceasedStatus' => 'PENDING'
         ]);
@@ -35,7 +35,7 @@ class ParticipantTest extends TestCase
 
     public function testDeceasedParticipantApprovedAccessStatus()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'deceasedStatus' => 'APPROVED'
         ]);
@@ -52,7 +52,7 @@ class ParticipantTest extends TestCase
             'cohortOneLaunchTime' => ''
         ];
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'hpoId' => 'TEST',
             'questionnaireOnTheBasics' => 'SUBMITTED',
@@ -65,7 +65,7 @@ class ParticipantTest extends TestCase
 
     public function testParticipantBasicsStatus()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'questionnaireOnTheBasics' => 'UNSET',
             'consentForStudyEnrollment' => 'SUBMITTED'
         ]);
@@ -76,7 +76,7 @@ class ParticipantTest extends TestCase
 
     public function testParticipantConsentStatus()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'questionnaireOnTheBasics' => 'SUBMITTED',
             'consentForStudyEnrollment' => 'UNSET'
         ]);
@@ -84,7 +84,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('consent', $participant->statusReason);
         $this->assertSame(false, $participant->isWithdrawn);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'questionnaireOnTheBasics' => 'SUBMITTED',
             'consentForStudyEnrollment' => 'UNSET',
             'withdrawalStatus' => 'NO_USE'
@@ -95,7 +95,7 @@ class ParticipantTest extends TestCase
 
     public function testParticipantWithdrawalStatusNoUse()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'questionnaireOnTheBasics' => 'SUBMITTED',
             'consentForStudyEnrollment' => 'SUBMITTED',
             'withdrawalStatus' => 'NO_USE'
@@ -107,7 +107,7 @@ class ParticipantTest extends TestCase
 
     public function testParticipantWithdrawalStatusEarlyOut()
     {
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'questionnaireOnTheBasics' => 'SUBMITTED',
             'consentForStudyEnrollment' => 'SUBMITTED',
             'withdrawalStatus' => 'EARLY_OUT'
@@ -126,7 +126,7 @@ class ParticipantTest extends TestCase
         ];
 
         // Assert genomics status (Criteria 1)
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentCohort' => 'COHORT_3',
             'questionnaireOnTheBasics' => 'SUBMITTED',
@@ -137,7 +137,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('genomics', $participant->statusReason);
 
         // Assert genomics status for cohort 2 (Criteria 2)
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
             'clinicPhysicalMeasurementsStatus' => 'UNSET',
@@ -148,7 +148,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('genomics', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
             'clinicPhysicalMeasurementsStatus' => 'UNSET',
@@ -159,7 +159,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('genomics', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
             'clinicPhysicalMeasurementsStatus' => 'COMPLETED',
@@ -171,7 +171,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('genomics', $participant->statusReason);
 
         // Assert genomics status for cohort 1 (Criteria 3)
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_1',
             'clinicPhysicalMeasurementsStatus' => 'UNSET',
@@ -181,7 +181,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('genomics', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_1',
             'clinicPhysicalMeasurementsStatus' => 'UNSET',
@@ -191,7 +191,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('genomics', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_1',
             'clinicPhysicalMeasurementsStatus' => 'COMPLETED',
@@ -212,7 +212,7 @@ class ParticipantTest extends TestCase
 
         // For HPO
         // Assert not submitted ehr consent (UNSET)
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentCohort' => 'COHORT_3',
             'questionnaireOnTheBasics' => 'SUBMITTED',
@@ -224,7 +224,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('ehr-consent', $participant->statusReason);
 
         // Assert not submitted ehr consent (SUBMITTED_NOT_SURE)
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentCohort' => 'COHORT_3',
             'questionnaireOnTheBasics' => 'SUBMITTED',
@@ -236,7 +236,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('ehr-consent', $participant->statusReason);
 
         // Assert UNSET gRoR and Ehr consent
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentCohort' => 'COHORT_3',
             'questionnaireOnTheBasics' => 'SUBMITTED',
@@ -251,43 +251,43 @@ class ParticipantTest extends TestCase
     public function testParticipantConsentCohort()
     {
         // Assert cohort 1
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_1'
         ]);
         $this->assertSame('Cohort 1', $participant->consentCohortText);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_1',
             'cohort2PilotFlag' => 'COHORT_2_PILOT'
         ]);
         $this->assertSame('Cohort 1', $participant->consentCohortText);
 
         // Assert cohort 2
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_2'
         ]);
         $this->assertSame('Cohort 2', $participant->consentCohortText);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_2',
             'cohort2PilotFlag' => 'UNSET'
         ]);
         $this->assertSame('Cohort 2', $participant->consentCohortText);
 
         // Assert cohort 2 pilot
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_2',
             'cohort2PilotFlag' => 'COHORT_2_PILOT'
         ]);
         $this->assertSame('Cohort 2 Pilot', $participant->consentCohortText);
 
         // Assert cohort 3
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_3'
         ]);
         $this->assertSame('Cohort 3', $participant->consentCohortText);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentCohort' => 'COHORT_3',
             'cohort2PilotFlag' => 'COHORT_2_PILOT'
         ]);
@@ -297,7 +297,7 @@ class ParticipantTest extends TestCase
     public function testParticipantProgramUpdateStatus()
     {
         // Assert program update status
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
             'clinicPhysicalMeasurementsStatus' => 'UNSET',
@@ -307,7 +307,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('program-update', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
             'clinicPhysicalMeasurementsStatus' => 'UNSET',
@@ -317,7 +317,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('program-update', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
             'clinicPhysicalMeasurementsStatus' => 'COMPLETED',
@@ -328,7 +328,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('program-update', $participant->statusReason);
 
         // Assert participant status to true
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'consentForStudyEnrollment' => 'SUBMITTED',
             'questionnaireOnTheBasics' => 'SUBMITTED',
             'consentCohort' => 'COHORT_2',
@@ -348,7 +348,7 @@ class ParticipantTest extends TestCase
             'cohortOneLaunchTime' => '2020-03-24T12:44:33'
         ];
         // Assert program update status
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_1',
@@ -360,7 +360,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('primary-consent-update', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_1',
@@ -372,7 +372,7 @@ class ParticipantTest extends TestCase
         $this->assertSame(false, $participant->status);
         $this->assertSame('primary-consent-update', $participant->statusReason);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentForStudyEnrollment' => 'SUBMITTED',
             'consentCohort' => 'COHORT_1',
@@ -385,7 +385,7 @@ class ParticipantTest extends TestCase
         $this->assertSame('primary-consent-update', $participant->statusReason);
 
         // Assert participant status to true
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'options' => $options,
             'consentForStudyEnrollment' => 'SUBMITTED',
             'questionnaireOnTheBasics' => 'SUBMITTED',
@@ -401,42 +401,42 @@ class ParticipantTest extends TestCase
     public function testActivityStatus()
     {
         // Withdrawn
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'NO_USE'
         ]);
         $this->assertSame('withdrawn', $participant->activityStatus);
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'EARLY_OUT'
         ]);
         $this->assertSame('withdrawn', $participant->activityStatus);
 
         // Deactivated
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'NOT_WITHDRAWN',
             'suspensionStatus' => 'NO_CONTACT'
         ]);
         $this->assertSame('deactivated', $participant->activityStatus);
 
         // Deceased
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'NOT_WITHDRAWN',
             'deceasedStatus' => 'PENDING'
         ]);
         $this->assertSame('deceased', $participant->activityStatus);
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'NOT_WITHDRAWN',
             'deceasedStatus' => 'APPROVED'
         ]);
         $this->assertSame('deceased', $participant->activityStatus);
 
         // Priority
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'NO_USE',
             'deceasedStatus' => 'APPROVED'
         ]);
         $this->assertSame('withdrawn', $participant->activityStatus);
 
-        $participant = new Participant((object)[
+        $participant = new Participant((object) [
             'withdrawalStatus' => 'NOT_WITHDRAWN',
             'suspensionStatus' => 'NO_CONTACT',
             'deceasedStatus' => 'APPROVED'
@@ -444,15 +444,32 @@ class ParticipantTest extends TestCase
         $this->assertSame('deactivated', $participant->activityStatus);
     }
 
-    public function testGetPediatricWeightBreakpoint()
+    public function getPediatricWeightBreakpointProvider()
     {
-        $participant = new Participant((object)[
+        return
+            [
+                [2.5, 2.3],
+                [2.5, 2.4],
+                [5.0, 2.5],
+                [5.0, 4.8],
+                [5.0, 4.9],
+                [16.4, 5],
+                [16.4, 16.2],
+                [16.4, 16.3],
+                [9999.0, 16.4],
+                [9999.0, 16.5],
+                [9999.0, 9998.9]
+            ];
+    }
+
+    /**
+     * @dataProvider getPediatricWeightBreakpointProvider
+     */
+    public function testGetPediatricWeightBreakpoint($expectedResult, $weight)
+    {
+        $participant = new Participant((object) [
             'dateOfBirth' => '2010-01-01',
         ]);
-        $this->assertSame(16.4, $participant->getPediatricWeightBreakpoint(8));
-        $this->assertSame(9999.0, $participant->getPediatricWeightBreakpoint(38));
-        $this->assertSame(2.5, $participant->getPediatricWeightBreakpoint(1.4));
-        $this->assertSame(5.0, $participant->getPediatricWeightBreakpoint(3.1));
-        $this->assertSame(9999.0, $participant->getPediatricWeightBreakpoint(29));
+        $this->assertSame($expectedResult, $participant->getPediatricWeightBreakpoint($weight));
     }
 }


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1655 <!-- Tag which ticket(s) this PR relates to -->

### Summary

Temporarily removing 2ED04 sample until biobank resolves an issue with multiple 2ED samples on order generation.

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
