### PR TITLE
[HPRO-1686][HPRO-1683]Change sample identifiers according to new request.

### DIFF
--- a/src/Order/versions/3.1-ped-16.4.json
+++ b/src/Order/versions/3.1-ped-16.4.json
@@ -2,9 +2,16 @@
     "version": "4",
     "notes": "Pediatric Launch samples, 5 < 16.4 Kg",
     "samplesInformation": {
-        "2ED02": {
-            "number": 1,
+        "1ED02": {
+            "number": 2,
             "label": "2mL EDTA",
+            "temperature": "Refrigerated",
+            "color": "Lavender",
+            "specimen": "2mL EDTA"
+        },
+        "2ED04": {
+            "number": 2,
+            "label": "4mL EDTA",
             "temperature": "Refrigerated",
             "color": "Lavender",
             "specimen": "2mL EDTA"
@@ -15,7 +22,7 @@
             "color": "Yellow",
             "temperature": "Refrigerated",
             "specimen": "Urine 10 mL",
-            "labelCount": 2
+            "labelCount": 1
         }
     },
     "salivaSamplesInformation": {

--- a/src/Order/versions/3.1-ped-16.4.json
+++ b/src/Order/versions/3.1-ped-16.4.json
@@ -3,7 +3,7 @@
     "notes": "Pediatric Launch samples, 5 < 16.4 Kg",
     "samplesInformation": {
         "1ED02": {
-            "number": 2,
+            "number": 1,
             "label": "2mL EDTA",
             "temperature": "Refrigerated",
             "color": "Lavender",

--- a/src/Order/versions/3.1-ped-2.5.json
+++ b/src/Order/versions/3.1-ped-2.5.json
@@ -8,7 +8,7 @@
             "color": "Yellow",
             "temperature": "Refrigerated",
             "specimen": "PMI Urine Cup",
-            "labelCount": 2
+            "labelCount": 1
         }
     },
     "salivaSamplesInformation": {

--- a/src/Order/versions/3.1-ped-5.json
+++ b/src/Order/versions/3.1-ped-5.json
@@ -14,7 +14,7 @@
             "color": "Yellow",
             "temperature": "Refrigerated",
             "specimen": "PMI Urine Cup",
-            "labelCount": 2
+            "labelCount": 1
         }
     },
     "salivaSamplesInformation": {

--- a/src/Order/versions/3.1-ped-9999.json
+++ b/src/Order/versions/3.1-ped-9999.json
@@ -2,7 +2,7 @@
     "version": "4",
     "notes": "Pediatric Launch samples, 6 < 9999 Kg",
     "samplesInformation": {
-        "2ED04": {
+        "1ED04": {
             "number": 1,
             "label": "4 ml EDTA",
             "temperature": "Refrigerated",
@@ -29,7 +29,7 @@
             "color": "Yellow",
             "temperature": "Refrigerated",
             "specimen": "PMI Urine Cup",
-            "labelCount": 2
+            "labelCount": 1
         }
     },
     "salivaSamplesInformation": {


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 0.0.0/Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1686, HPRO-1683 <!-- Tag which ticket(s) this PR relates to -->

### Summary
Updates sample identifiers according to new ticket (HPRO-1686). Also resolves issue of Urine samples requesting two labels.
<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
