### PR TITLE
[HPRO-1696] Don't allow amended measurements in safety check.

### DIFF
--- a/src/Repository/MeasurementRepository.php
+++ b/src/Repository/MeasurementRepository.php
@@ -148,9 +148,18 @@ class MeasurementRepository extends ServiceEntityRepository
 
     public function getMostRecentFinalizedNonNullWeight($participantId): Measurement|null
     {
+        $parentIds = $this->createQueryBuilder('m')
+            ->select('m.parentId')
+            ->where('m.parentId is not null')
+            ->andWhere('m.participantId = :participantId')
+            ->setParameter('participantId', $participantId)
+            ->getQuery()
+            ->getResult();
         $query = $this->createQueryBuilder('m')
             ->where('m.participantId = :participantId')
             ->andWhere('m.finalizedTs is not null')
+            ->andWhere('m.id not in (:parentIds)')
+            ->setParameter('parentIds', $parentIds)
             ->orderBy('m.finalizedTs', 'DESC')
             ->leftJoin('m.history', 'mh')
             ->setParameter('participantId', $participantId);


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1696 <!-- Tag which ticket(s) this PR relates to -->

### Summary
Fixes an issue where safety check would load amended physical measurements parent's whenever the child physical measurement was unfinalized..
<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
