### PR TITLE
[HPRO-1654] Move errors outside form group, check 0 before null

### DIFF
--- a/src/Form/Nph/NphOrderForm.php
+++ b/src/Form/Nph/NphOrderForm.php
@@ -161,9 +161,9 @@ class NphOrderForm extends AbstractType
             'constraints' => [
                 new Constraints\Callback(function ($value, $context) {
                     if ($value === 0.0) {
-                        $context->buildViolation('Total collection volume is required')->addViolation();
-                    } elseif (empty($value)) {
                         $context->buildViolation('Total collection volume must be greater than 0')->addViolation();
+                    } elseif (empty($value)) {
+                        $context->buildViolation('Total collection volume is required')->addViolation();
                     }
                 })
             ],

--- a/src/Form/Nph/NphOrderForm.php
+++ b/src/Form/Nph/NphOrderForm.php
@@ -160,9 +160,9 @@ class NphOrderForm extends AbstractType
             'disabled' => $disabled,
             'constraints' => [
                 new Constraints\Callback(function ($value, $context) {
-                    if (empty($value)) {
+                    if ($value === 0.0) {
                         $context->buildViolation('Total collection volume is required')->addViolation();
-                    } elseif ($value == 0) {
+                    } elseif (empty($value)) {
                         $context->buildViolation('Total collection volume must be greater than 0')->addViolation();
                     }
                 })

--- a/templates/program/nph/order/partials/order-collect-urine24.html.twig
+++ b/templates/program/nph/order/partials/order-collect-urine24.html.twig
@@ -25,12 +25,14 @@
         has-error{% endif %} totalCollectionVolumeField">
         <div class="input-group">
             {{ form_widget(orderCollectForm['totalCollectionVolume']) }}
-            {{ form_errors(orderCollectForm['totalCollectionVolume']) }}
             <span class="input-group-addon">mL</span>
         </div>
+        <div>
+            {{ form_errors(orderCollectForm['totalCollectionVolume']) }}
         <span class="text-warning aliquot-volume-warning" id="totalCollectionVolumeWarning" style="display: none;">
             Please verify unit of measure is correct.  (Expected volume is measured mL, for reference 1L = 1000mL)
         </span>
+        </div>
     </td>
     <td {% if not orderCollectForm[nphSample.sampleCode ~ 'Notes'].vars.valid %}
         class="has-error"{% endif %}>

--- a/templates/program/nph/order/sample-finalize.html.twig
+++ b/templates/program/nph/order/sample-finalize.html.twig
@@ -235,9 +235,6 @@
                                     <span class="input-group-addon">mL</span>
                                 </div>
                                 {{ form_errors(sampleFinalizeForm['totalCollectionVolume']) }}
-                                <span class="text-warning aliquot-volume-warning" id="totalCollectionVolumeWarning" style="display: none;">
-                                Please verify unit of measure is correct.  (Expected volume is measured mL, for reference 1L = 1000mL)
-                                </span>
                             </div>
 
                         </div>


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     |Next available <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1654 <!-- Tag which ticket(s) this PR relates to -->

### Summary

<!-- Provide notes for the development team that might be needed to review the PR. Some examples:

- Do they need to add a particular `gaBypassGroups` configuration entry?
- What Participant IDs in the test environment have relevant data/settings?
-->

### Instructions for testing  <!-- if applicable -->


### Screenshots <!-- if applicable -->
