### PR TITLE
[HPRO-1754] Add head circumference growth percentiles to summary view

### DIFF
--- a/templates/partials/participant-measurement-summary.html.twig
+++ b/templates/partials/participant-measurement-summary.html.twig
@@ -139,6 +139,23 @@
                     </td>
                 </tr>
                 <tr>
+                    <th>Growth Percentile Head Circumference for Age</th>
+                    <td colspan="2">
+                        {% if summary['growth-percentile-head-circumference-for-age'] is defined and summary['growth-percentile-head-circumference-for-age'] is not empty %}
+                            {{ summary['growth-percentile-head-circumference-for-age'] }}th percentile
+                        {% elseif summary['growth-percentile-head-circumference-for-age-male'] is defined or summary['growth-percentile-head-circumference-for-age-female'] is defined %}
+                            {% if summary['growth-percentile-head-circumference-for-age-male'] is defined %}
+                                {{ summary['growth-percentile-head-circumference-for-age-male'] }}th percentile (M) <br>
+                            {% endif %}
+                            {% if summary['growth-percentile-head-circumference-for-age-female'] is defined %}
+                                {{ summary['growth-percentile-head-circumference-for-age-female'] }}th percentile (F)
+                            {% endif %}
+                        {% else %}
+                            --
+                        {% endif %}
+                    </td>
+                </tr>
+                <tr>
                     <th>Growth Percentile BMI for Age</th>
                     <td colspan="2">
                         {% if summary['growth-percentile-bmi-for-age'] is defined and summary['growth-percentile-bmi-for-age'] is not empty %}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 4.2.0 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-1754 <!-- Tag which ticket(s) this PR relates to -->
