### PR TITLE
[HPRO-2000] Migrate app engine to php82 runtime

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
 
     docker:
-    - image: cimg/php:8.1.17-node
+    - image: cimg/php:8.2.21-node
     - image: mysql:5.7
       environment:
         MYSQL_ROOT_PASSWORD: passw0rd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1
+FROM php:8.2
 
 # Fix for issue with OpenJDK install
 RUN mkdir -p /usr/share/man/man1

--- a/app.yaml.dist
+++ b/app.yaml.dist
@@ -1,4 +1,4 @@
-runtime: php81
+runtime: php82
 
 # default is `public/index.php` or `index.php`
 entrypoint: serve web/index.php


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 4.3.19 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-2000 <!-- Tag which ticket(s) this PR relates to -->