### PR TITLE
[HPRO-2197] Allow order generation timezone id to be null

### DIFF
--- a/src/Entity/NphAdminOrderEditLog.php
+++ b/src/Entity/NphAdminOrderEditLog.php
@@ -108,7 +108,7 @@ class NphAdminOrderEditLog
         return $this->originalOrderGenerationTimezoneId;
     }
 
-    public function setOriginalOrderGenerationTimezoneId(int $originalOrderGenerationTimezoneId): static
+    public function setOriginalOrderGenerationTimezoneId(?int $originalOrderGenerationTimezoneId): static
     {
         $this->originalOrderGenerationTimezoneId = $originalOrderGenerationTimezoneId;
 


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 4.4.9.1 <!-- which milestone is this for? -->
| Bug fix?            | ✅ <!-- fixes an issue -->
| New feature?        | ❌ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-2197 <!-- Tag which ticket(s) this PR relates to -->
