### PR TITLE
[HPRO-2323] Harden PHP session ID generation

### DIFF
--- a/php.ini.dist
+++ b/php.ini.dist
@@ -1,6 +1,10 @@
 date.timezone = UTC
 display_errors = 0
 error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
+session.use_strict_mode = 1
+session.sid_length = 48
+session.sid_bits_per_character = 6
+session.use_only_cookies = 1
 session.cookie_httponly = 1
 session.cookie_secure = 1
 session.cookie_samesite= "Lax"

--- a/tests/Service/SessionAuthenticationStrategyTest.php
+++ b/tests/Service/SessionAuthenticationStrategyTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Tests\Service;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategyInterface;
+
+class SessionAuthenticationStrategyTest extends KernelTestCase
+{
+    private const MINIMUM_SESSION_ENTROPY_BITS = 128;
+
+    public function testSessionIdIsRegeneratedOnAuthentication()
+    {
+        self::bootKernel();
+
+        $session = static::getContainer()->get('session.factory')->createSession();
+        $session->start();
+        $session->set('testKey', 'testValue');
+
+        $initialSessionId = $session->getId();
+
+        $request = new Request();
+        $request->setSession($session);
+
+        /** @var RequestStack $requestStack */
+        $requestStack = static::getContainer()->get(RequestStack::class);
+        $requestStack->push($request);
+
+        /** @var SessionAuthenticationStrategyInterface $strategy */
+        $strategy = static::getContainer()->get('security.authentication.session_strategy.main');
+
+        /** @var TokenInterface&MockObject $token */
+        $token = $this->createMock(TokenInterface::class);
+
+        $strategy->onAuthentication($request, $token);
+
+        $this->assertNotSame($initialSessionId, $session->getId(), 'Session ID should change after authentication.');
+        $this->assertSame('testValue', $session->get('testKey'), 'Session data should be preserved with migrate strategy.');
+    }
+
+    public function testSessionConfigurationMeetsMinimumEntropyRequirement()
+    {
+        $sidLength = (int) ini_get('session.sid_length');
+        $sidBitsPerCharacter = (int) ini_get('session.sid_bits_per_character');
+        $totalEntropyBits = $sidLength * $sidBitsPerCharacter;
+
+        $this->assertGreaterThanOrEqual(
+            self::MINIMUM_SESSION_ENTROPY_BITS,
+            $totalEntropyBits,
+            sprintf(
+                'Configured session entropy is too low: %d bits (sid_length=%d, sid_bits_per_character=%d).',
+                $totalEntropyBits,
+                $sidLength,
+                $sidBitsPerCharacter
+            )
+        );
+    }
+
+    public function testGeneratedSessionIdMeetsMinimumLengthAndAlphabet()
+    {
+        self::bootKernel();
+
+        $session = static::getContainer()->get('session.factory')->createSession();
+        $session->start();
+        $sessionId = $session->getId();
+
+        $sidBitsPerCharacter = (int) ini_get('session.sid_bits_per_character');
+        $minimumCharacters = (int) ceil(self::MINIMUM_SESSION_ENTROPY_BITS / $sidBitsPerCharacter);
+
+        $this->assertGreaterThanOrEqual(
+            $minimumCharacters,
+            strlen($sessionId),
+            sprintf('Session ID length is too short: %d chars (minimum expected: %d).', strlen($sessionId), $minimumCharacters)
+        );
+
+        $allowedPatterns = [
+            4 => '/^[0-9a-f]+$/',
+            5 => '/^[0-9a-v]+$/',
+            6 => '/^[0-9a-zA-Z,-]+$/',
+        ];
+
+        $this->assertArrayHasKey(
+            $sidBitsPerCharacter,
+            $allowedPatterns,
+            sprintf('Unexpected session.sid_bits_per_character value: %d.', $sidBitsPerCharacter)
+        );
+
+        $this->assertMatchesRegularExpression(
+            $allowedPatterns[$sidBitsPerCharacter],
+            $sessionId,
+            sprintf('Session ID contains invalid characters for sid_bits_per_character=%d.', $sidBitsPerCharacter)
+        );
+    }
+}


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 4.9.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-2323<!-- Tag which ticket(s) this PR relates to -->

### Summary

### Recommendation-to-code mapping

1. **Generate session IDs using a CSRNG with minimum entropy of 128 bits**
   - Implemented via PHP native session handling (no custom session ID generator introduced).
   - Configured in `php.ini` and `php.ini.dist`:
     - `session.sid_length = 48`
     - `session.sid_bits_per_character = 6`
   - Effective entropy budget: `48 * 6 = 288 bits` (>= 128 bits).

2. **Ensure session IDs are at least 128 bits (16 bytes) in length when encoded**
   - Enforced by:
     - `session.sid_length = 48`
     - `session.sid_bits_per_character = 6`
   - This configuration exceeds the minimum encoded-length/entropy requirement.

3. **Use established session management frameworks rather than custom implementations**
   - Session management remains framework-native (Symfony/PHP sessions).
   - No custom session ID generation logic is used.

### Screenshots <!-- if applicable -->

**Example Session Ids:**

**Before:**
<img width="539" height="28" alt="image" src="https://github.com/user-attachments/assets/2e915cd6-8ebb-474e-9f22-599ac3d84ad7" />

**After:**
<img width="657" height="26" alt="image" src="https://github.com/user-attachments/assets/a4e3a6ac-3d2f-4b33-8b08-b6bb6d6c9615" />



