### PR TITLE
[HPRO-2339] Auto focus date picker input when calendar opens

### DIFF
--- a/web/assets/js/bs5.js
+++ b/web/assets/js/bs5.js
@@ -78,6 +78,14 @@ $(document).ready(function () {
             }
         });
         const instance = new tempusDominus.TempusDominus(element, options);
+        if (!element.readOnly) {
+            element.addEventListener("show.td", () => {
+                // Ensure input field stays focused after calendar opens
+                setTimeout(() => {
+                    element.focus();
+                }, 50);
+            });
+        }
         element._bs5dtp = instance;
         return instance;
     };


### PR DESCRIPTION
| Q                   | A
| ------------------- | --------------
| Target Release?     | 4.10.0 <!-- which milestone is this for? -->
| Bug fix?            | ❌ <!-- fixes an issue -->
| New feature?        | ✅ <!-- adds a new feature/behavior change -->
| Database migration? | ❌ <!-- lets us know to look for migrations -->
| New configuration?  | ❌ <!-- lets us know if we need new config items -->
| Composer updates?   | ❌ <!-- lets us know to run `composer install` -->
| NPM updates?        | ❌ <!-- lets us know to run `npm install` -->
| Jira Ticket(s)      | HPRO-2339<!-- Tag which ticket(s) this PR relates to -->

### Summary
The new datepicker tool is not auto-focusing the date field when selecting the date, which is preventing the users from using Ctrl+A to select the date. They need to click a second time in order to use Ctrl+A to select the date. This PR fixes it by auto-focusing the input field when the datepicker is selected.